### PR TITLE
Fix relationship description

### DIFF
--- a/packages/dbml-core/src/parse/dbml/parser.pegjs
+++ b/packages/dbml-core/src/parse/dbml/parser.pegjs
@@ -331,7 +331,7 @@ enum "enum" = "enum"i
 header_color = "headercolor"i
 
 // Commonly used tokens
-relation ">,_ or <" = [>\-<]
+relation ">, - or <" = [>\-<]
 name "valid name"
   = c:(character+) { return c.join("") }
   / quote c:[^\"\n]+ quote { return c.join("") }


### PR DESCRIPTION
## Summary
- Community Issue: [Cannot make one-to-one relationship. Underscore isn’t recognized](https://community.dbdiagram.io/t/cannot-make-one-to-one-relationship-underscore-isnt-recognized/275)
- After investigation, it turns out that the `dbml` parser has a mistake in description of relationship.

## Issue
- Community Issue: [Cannot make one-to-one relationship. Underscore isn’t recognized](https://community.dbdiagram.io/t/cannot-make-one-to-one-relationship-underscore-isnt-recognized/275)
- Asana: [Wrong message of relationship between table](https://app.asana.com/0/1125458388096768/1138140611188609/f)

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review