### PR TITLE
fixes #85 : PostgreSql export -- bigint autoincrement should give bigserial instead of serial

### DIFF
--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/general_schema.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/general_schema.in.dbml
@@ -12,7 +12,7 @@ Enum "product status" {
 
 Table "orders" {
   "id" int [pk, increment]
-  "user_id" int [unique, not null]
+  "user_id" bigint [unique, not null]
   "status" orders_status
   "created_at" varchar
 }
@@ -31,7 +31,7 @@ Table "products" {
   "status" "product status"
   "created_at" datetime [default: `now()`]
 
-        
+
 Indexes {
   (id, name) [pk]
   (merchant_id, status) [name: "product_status"]
@@ -40,7 +40,7 @@ Indexes {
 }
 
 Table "users" {
-  "id" int [pk]
+  "id" bigint [pk, increment]
   "full_name" varchar
   "email" varchar [unique]
   "gender" varchar

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/general_schema.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/general_schema.out.sql
@@ -12,7 +12,7 @@ CREATE TYPE "product status" AS ENUM (
 
 CREATE TABLE "orders" (
   "id" SERIAL PRIMARY KEY,
-  "user_id" int UNIQUE NOT NULL,
+  "user_id" bigint UNIQUE NOT NULL,
   "status" orders_status,
   "created_at" varchar
 );
@@ -34,7 +34,7 @@ CREATE TABLE "products" (
 );
 
 CREATE TABLE "users" (
-  "id" int PRIMARY KEY,
+  "id" BIGSERIAL PRIMARY KEY,
   "full_name" varchar,
   "email" varchar UNIQUE,
   "gender" varchar,

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -29,8 +29,8 @@ class PostgresExporter {
 
       let line = '';
       if (field.increment) {
-        const type_serial = 'bigint' === field.type.type_name ? 'BIGSERIAL' : 'SERIAL';
-        line = `"${field.name}" ${type_serial}`;
+        const typeSerial = field.type.type_name === 'bigint' ? 'BIGSERIAL' : 'SERIAL';
+        line = `"${field.name}" ${typeSerial}`;
       } else if (hasWhiteSpace(field.type.type_name)) {
         line = `"${field.name}" "${field.type.type_name}"`;
       } else {

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -29,7 +29,8 @@ class PostgresExporter {
 
       let line = '';
       if (field.increment) {
-        line = `"${field.name}" SERIAL`;
+        const type_serial = 'bigint' === field.type.type_name ? 'BIGSERIAL' : 'SERIAL';
+        line = `"${field.name}" ${type_serial}`;
       } else if (hasWhiteSpace(field.type.type_name)) {
         line = `"${field.name}" "${field.type.type_name}"`;
       } else {


### PR DESCRIPTION

## Summary
* if the column is "bigint" with increment, then the exported column will be `BIGSERIAL` instead of `SERIAL` 

## Issue

#85 : PostgreSql export -- bigint autoincrement should give bigserial instead of serial

## Lasting Changes (Technical)

NONE

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review