### PR TITLE
Fix endpoint error handling and support for implicit foreign key reference for mssql

### DIFF
--- a/packages/dbml-core/__tests__/parser/mssql-parse/input/inline_referential_actions.in.sql
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/input/inline_referential_actions.in.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [orders] (
   [id] int PRIMARY KEY IDENTITY(1, 1),
   [user_id] int UNIQUE NOT NULL 
-    CONSTRAINT fk_order_user FOREIGN KEY REFERENCES [users] ([id]) 
+    CONSTRAINT fk_order_user FOREIGN KEY REFERENCES [users] 
     ON DELETE NO ACTION,
   [status] orders_status_enum,
   [created_at] varchar(255)
@@ -17,7 +17,7 @@ CREATE TABLE [order_items] (
 GO
 
 CREATE TABLE [users] (
-  [id] int PRIMARY KEY IDENTITY(1, 1),
+  [user_id] int PRIMARY KEY IDENTITY(1, 1),
   [name] varchar(255),
   [email] varchar(255) UNIQUE,
   [date_of_birth] datetime,

--- a/packages/dbml-core/__tests__/parser/mssql-parse/input/table_constraints_indexes.in.sql
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/input/table_constraints_indexes.in.sql
@@ -6,7 +6,7 @@ CREATE TABLE [products] (
 );
 
 CREATE TABLE [countries] (
-  [code] int PRIMARY KEY,
+  [country_code] int PRIMARY KEY,
   [name] varchar(255),
   [continent_name] varchar(255),
   INDEX [unique_continent] UNIQUE NONCLUSTERED ([continent_name])
@@ -19,7 +19,7 @@ CREATE TABLE [users] (
   [date_of_birth] datetime,
   [created_at] datetime DEFAULT (now()),
   [country_code] int NOT NULL,
-  FOREIGN KEY ([country_code]) REFERENCES [countries] ([code]) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  FOREIGN KEY ([country_code]) REFERENCES [countries] ON DELETE NO ACTION ON UPDATE NO ACTION,
   INDEX [unique_email_name] UNIQUE CLUSTERED ([email],[name])
 );
 

--- a/packages/dbml-core/__tests__/parser/mssql-parse/output/inline_referential_actions.out.json
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/output/inline_referential_actions.out.json
@@ -22,7 +22,7 @@
               "endpoint": {
                 "tableName": "users",
                 "fieldNames": [
-                  "id"
+                  "user_id"
                 ],
                 "relation": "1"
               },
@@ -113,7 +113,7 @@
           },
           "pk": true,
           "increment": true,
-          "name": "id"
+          "name": "user_id"
         },
         {
           "type": {
@@ -221,7 +221,7 @@
         {
           "tableName": "users",
           "fieldNames": [
-            "id"
+            "user_id"
           ],
           "relation": "1"
         }

--- a/packages/dbml-core/__tests__/parser/mssql-parse/output/table_constraints_indexes.out.json
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/output/table_constraints_indexes.out.json
@@ -45,7 +45,7 @@
             "type_name": "int"
           },
           "pk": true,
-          "name": "code"
+          "name": "country_code"
         },
         {
           "type": {
@@ -226,7 +226,7 @@
         },
         {
           "fieldNames": [
-            "code"
+            "country_code"
           ],
           "relation": "1",
           "tableName": "countries"

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-core/src/model_structure/endpoint.js
+++ b/packages/dbml-core/src/model_structure/endpoint.js
@@ -74,9 +74,10 @@ class Endpoint extends Element {
       if (!field) {
         this.error(`Can't find field ${shouldPrintSchema(table.schema)
           ? `"${table.schema.name}".` : ''}"${fieldName}" in table "${this.tableName}"`);
+      } else {
+        this.fields.push(field);
+        field.pushEndpoint(this);
       }
-      this.fields.push(field);
-      field.pushEndpoint(this);
     });
   }
 

--- a/packages/dbml-core/src/model_structure/endpoint.js
+++ b/packages/dbml-core/src/model_structure/endpoint.js
@@ -74,10 +74,9 @@ class Endpoint extends Element {
       if (!field) {
         this.error(`Can't find field ${shouldPrintSchema(table.schema)
           ? `"${table.schema.name}".` : ''}"${fieldName}" in table "${this.tableName}"`);
-      } else {
-        this.fields.push(field);
-        field.pushEndpoint(this);
       }
+      this.fields.push(field);
+      field.pushEndpoint(this);
     });
   }
 

--- a/packages/dbml-core/src/model_structure/endpoint.js
+++ b/packages/dbml-core/src/model_structure/endpoint.js
@@ -71,17 +71,13 @@ class Endpoint extends Element {
   setFields (fieldNames, table) {
     fieldNames.forEach(fieldName => {
       const field = table.findField(fieldName);
-      this.setField(field, table);
+      if (!field) {
+        this.error(`Can't find field ${shouldPrintSchema(table.schema)
+          ? `"${table.schema.name}".` : ''}"${fieldName}" in table "${this.tableName}"`);
+      }
+      this.fields.push(field);
+      field.pushEndpoint(this);
     });
-  }
-
-  setField (field, table) {
-    if (!field) {
-      this.error(`Can't find field ${shouldPrintSchema(table.schema)
-        ? `"${table.schema.name}".` : ''}"${field.name}" in table "${this.tableName}"`);
-    }
-    this.fields.push(field);
-    field.pushEndpoint(this);
   }
 
   normalize (model) {

--- a/packages/dbml-core/src/parse/mssql/fk_definition/actions.js
+++ b/packages/dbml-core/src/parse/mssql/fk_definition/actions.js
@@ -41,9 +41,19 @@ function makeTableEndpoint (columnNames) {
 function makeTableConstraintFK (_keyword1, endpoint1, _keyword2, tableName, endpoint2, fkOptions) {
   const value = {};
 
+  if (!endpoint2) {
+    // eslint-disable-next-line no-param-reassign
+    endpoint2 = {
+      type: 'endpoint',
+      value: {},
+    };
+    endpoint2.value.fieldNames = endpoint1.value.fieldNames;
+  }
+
   endpoint1.value.relation = '*';
   endpoint2.value.relation = '1';
   endpoint2.value.tableName = _.last(tableName);
+
 
   value.endpoints = [endpoint1.value, endpoint2.value];
   setOption(value, fkOptions);

--- a/packages/dbml-core/src/parse/mssql/fk_definition/index.js
+++ b/packages/dbml-core/src/parse/mssql/fk_definition/index.js
@@ -10,7 +10,7 @@ const Lang = P.createLanguage({
     r.TableEndpoint,
     KP.KeywordReferences,
     pDotDelimitedName,
-    r.TableEndpoint,
+    r.TableEndpoint.fallback(null),
     r.FKOptions.fallback(null),
     A.makeTableConstraintFK,
   ),

--- a/packages/dbml-core/src/parse/mssql/statements/statement_types/create_table/actions.js
+++ b/packages/dbml-core/src/parse/mssql/statements/statement_types/create_table/actions.js
@@ -13,6 +13,9 @@ function createRefFromInlineRef (linesRefs, inlineRefs, fieldName, tableName) {
     fieldNames: [fieldName],
     relation: '*',
   });
+  if (!inlineRef.endpoint.fieldNames) {
+    inlineRef.endpoint.fieldNames = newRef.endpoints[0].fieldNames;
+  }
   newRef.endpoints.push(inlineRef.endpoint);
 
   linesRefs.push(newRef);


### PR DESCRIPTION
## Summary
- Fix error handling when endpoint have fields that are not in endpoint's table.
- Add support for implicit foreign key reference for mssql, only when columns on both sides have the same name, example:
`[user_id] int CONSTRAINT fk_order_user FOREIGN KEY REFERENCES [users]`
## Issue
(issue link here)

## Lasting Changes (Technical)
- Remove  setField in endpoint and move it to setFields, change field.name to fieldName in error message.
## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review