### PR TITLE
[Enhancement]support symbol for mysql importer

### DIFF
--- a/packages/dbml-core/src/parse/mysql/parser.pegjs
+++ b/packages/dbml-core/src/parse/mysql/parser.pegjs
@@ -491,7 +491,7 @@ factor = factors:(character+ _ "(" expression ")"
     / (exprCharNoCommaSpace+ &(_/","/");"/endline");")) / exprChar+ &.) {
     	return _.flattenDeep(factors).join("");
     }   
-exprChar = [\',.a-z0-9_+-\`]i
+exprChar = [\',.a-z0-9_+-\`%]i
     / sp
     / newline
     / tab

--- a/packages/dbml-core/src/parse/mysqlParser.js
+++ b/packages/dbml-core/src/parse/mysqlParser.js
@@ -649,8 +649,8 @@ function peg$parse(input, options) {
       peg$c283 = function(factors) {
           	return _.flattenDeep(factors).join("");
           },
-      peg$c284 = /^[',.a-z0-9_+-`]/i,
-      peg$c285 = peg$classExpectation(["'", ",", ".", ["a", "z"], ["0", "9"], "_", ["+", "`"]], false, true),
+      peg$c284 = /^[',.a-z0-9_+-`%]/i,
+      peg$c285 = peg$classExpectation(["'", ",", ".", ["a", "z"], ["0", "9"], "_", ["+", "`"], "%"], false, true),
       peg$c286 = /^['.a-z0-9_+\-]/i,
       peg$c287 = peg$classExpectation(["'", ".", ["a", "z"], ["0", "9"], "_", "+", "-"], false, true),
       peg$c288 = peg$otherExpectation("letter, number or underscore"),


### PR DESCRIPTION
## Summary
This is valid in mysql
```sql
create table products (
  id int,
  name varchar(255),
  weight_measurement ENUM('lb', 'kg', '%'),
  primary key(`id`)
) engine=innodb default charset=utf8;
```
From dbdiagram mysql import
![Screen Shot 2020-08-25 at 4 40 28 PM](https://user-images.githubusercontent.com/25905574/91160816-13fd5680-e6f4-11ea-982b-89d25c6c5288.png)

The enhancement
![Screen Shot 2020-08-25 at 4 43 13 PM](https://user-images.githubusercontent.com/25905574/91160877-2d9e9e00-e6f4-11ea-9022-5eab6c64d318.png)

## Lasting Changes (Technical)

* Add supported symbol to 'ExpChar'


## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [x] Integration Tests Passed
- [ ] Code Review