### PR TITLE
Add links to dbml-renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Example of a database definition of a simple blogging site:
 * [Go parser for DBML by duythinht](https://github.com/duythinht/dbml-go)
 * [DbmlForDjango: Converter between Django models.py and DBML](https://github.com/hamedsj/DbmlForDjango)
 * [parseServerSchema2dbml: Converter between ParseServer MongoDB \_SCHEMA collection and DBML by stepanic](https://github.com/stepanic/parse-server-SCHEMA-to-DBML)
+* [dbml-renderer: A DBML CLI renderer](https://github.com/softwaretechnik-berlin/dbml-renderer)

--- a/dbml-homepage/docs/home/README.md
+++ b/dbml-homepage/docs/home/README.md
@@ -112,3 +112,4 @@ DBML is created and maintained by [Holistics](https://holistics.io?utm_source=db
 * [Go parser for DBML by duythinht](https://github.com/duythinht/dbml-go)
 * [DbmlForDjango: Converter between Django models.py and DBML](https://github.com/hamedsj/DbmlForDjango)
 * [parseServerSchema2dbml: Converter between ParseServer MongoDB \_SCHEMA collection and DBML by stepanic](https://github.com/stepanic/parse-server-SCHEMA-to-DBML)
+* [dbml-renderer: A DBML CLI renderer](https://github.com/softwaretechnik-berlin/dbml-renderer)


### PR DESCRIPTION
## Summary

Hello!

As discussed in https://github.com/holistics/dbml/issues/154, this PR adds a link to [dbml-renderer](https://github.com/softwaretechnik-berlin/dbml-renderer) in both the project's `README.md` and the homepage.

Thank you for your help and support!