### PR TITLE
Add --mssql option for sql2dbml CLI

### DIFF
--- a/dbml-homepage/docs/cli/README.md
+++ b/dbml-homepage/docs/cli/README.md
@@ -84,6 +84,6 @@ $ sql2dbml --mysql dump.sql -o mydatabase.dbml
 
 ```bash
 $ sql2dbml <path-to-sql-file>
-           [--mysql|--postgres |--mssql]
+           [--mysql|--postgres|--mssql]
            [-o|--out-file <output-filepath>]
 ```

--- a/dbml-homepage/docs/cli/README.md
+++ b/dbml-homepage/docs/cli/README.md
@@ -53,7 +53,7 @@ $ dbml2sql schema.dbml -o schema.sql
 
 ```bash
 $ dbml2sql <path-to-dbml-file>
-           [--mysql|--postgres]
+           [--mysql|--postgres| -mssql]
            [-o|--out-file <output-filepath>]
 ```
 
@@ -84,6 +84,6 @@ $ sql2dbml --mysql dump.sql -o mydatabase.dbml
 
 ```bash
 $ sql2dbml <path-to-sql-file>
-           [--mysql|--postgres]
+           [--mysql|--postgres | -mssql]
            [-o|--out-file <output-filepath>]
 ```

--- a/dbml-homepage/docs/cli/README.md
+++ b/dbml-homepage/docs/cli/README.md
@@ -53,7 +53,7 @@ $ dbml2sql schema.dbml -o schema.sql
 
 ```bash
 $ dbml2sql <path-to-dbml-file>
-           [--mysql|--postgres| -mssql]
+           [--mysql|--postgres|--mssql]
            [-o|--out-file <output-filepath>]
 ```
 
@@ -84,6 +84,6 @@ $ sql2dbml --mysql dump.sql -o mydatabase.dbml
 
 ```bash
 $ sql2dbml <path-to-sql-file>
-           [--mysql|--postgres | -mssql]
+           [--mysql|--postgres |--mssql]
            [-o|--out-file <output-filepath>]
 ```

--- a/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/expect-out-files/schema.dbml
@@ -1,0 +1,25 @@
+Table "UserMaster" {
+  "UserMasterKey" BIGINT [not null, increment]
+}
+
+Table "CodeDef" {
+  "CdKey" BIGINT [not null, increment]
+  "Category" NVARCHAR(50) [not null]
+  "Description" NVARCHAR(100)
+  "Code" NVARCHAR(50) [not null]
+  "ParentCdKey" BIGINT
+  "UserMasterKeyAddedBy" BIGINT [not null]
+  "UserMasterKeyLastEditedBy" BIGINT
+  "AddedDtTm" DATETIMEOFFSET(7) [not null]
+  "LastEditedDtTm" DATETIMEOFFSET(7)
+  "EffectiveFromDtTm" DATETIMEOFFSET(7) [not null]
+  "EffectiveThruDtTm" DATETIMEOFFSET(7)
+
+Indexes {
+  CdKey [pk]
+}
+}
+
+Ref "fk__CodeDef__ParentCdKey__CodeDef__CdKey":"CodeDef"."CdKey" < "CodeDef"."ParentCdKey"
+
+Ref "fk__CodeDef__UserMasterKeyLastEditedBy__UserMaster_UserMasterKey":"UserMaster"."UserMasterKey" < "CodeDef"."UserMasterKeyLastEditedBy"

--- a/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/in-files/schema.sql
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/in-files/schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [UserMaster] (
+	[UserMasterKey] BIGINT IDENTITY (1, 1) NOT NULL
+);
+
+CREATE TABLE [CodeDef] (
+    [CdKey]                     BIGINT             IDENTITY (1, 1) NOT NULL,
+    [Category]                  NVARCHAR (50)      NOT NULL,
+    [Description]               NVARCHAR (100)     NULL,
+    [Code]                      NVARCHAR (50)      NOT NULL,
+    [ParentCdKey]               BIGINT             NULL,
+    [UserMasterKeyAddedBy]      BIGINT             NOT NULL,
+    [UserMasterKeyLastEditedBy] BIGINT             NULL,
+    [AddedDtTm]                 DATETIMEOFFSET (7) NOT NULL,
+    [LastEditedDtTm]            DATETIMEOFFSET (7) NULL,
+    [EffectiveFromDtTm]         DATETIMEOFFSET (7) NOT NULL,
+    [EffectiveThruDtTm]         DATETIMEOFFSET (7) NULL,
+    CONSTRAINT [PK__CodeDef__4922449ECDD244C3] PRIMARY KEY CLUSTERED ([CdKey] ASC),
+    CONSTRAINT [fk__CodeDef__ParentCdKey__CodeDef__CdKey] FOREIGN KEY ([ParentCdKey]) REFERENCES [CodeDef] ([CdKey]),
+    CONSTRAINT [fk__CodeDef__UserMasterKeyLastEditedBy__UserMaster_UserMasterKey] FOREIGN KEY ([UserMasterKeyLastEditedBy]) REFERENCES [UserMaster] ([UserMasterKey])
+);

--- a/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/options.json
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/options.json
@@ -1,0 +1,8 @@
+{
+  "args": [
+    "./in-files/schema.sql",
+    "--mssql",
+    "-o",
+    "./out-files/schema.dbml"
+  ]
+}

--- a/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/stdout.txt
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --mssql --out-file/stdout.txt
@@ -1,0 +1,1 @@
+  ✔ Generated DBML file from SQL file (SQL Server): schema.dbml

--- a/packages/dbml-cli/src/cli/index.js
+++ b/packages/dbml-cli/src/cli/index.js
@@ -26,6 +26,7 @@ function sql2dbml (args) {
     .usage('[options] <files...>')
     .option('--mysql')
     .option('--postgres')
+    .option('--mssql')
     .option('-o, --out-file <pathspec>', 'compile all input files into a single files');
   // .option('-d, --out-dir <pathspec>', 'compile an input directory of sql files into an output directory');
 


### PR DESCRIPTION
## Summary
* Add mssql importer to cli options (usage: sql2dbml --mssql <input_file_path>)

## Issue
* https://github.com/holistics/dbml/issues/208

## Lasting Changes (Technical)


## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review