### PR TITLE
Support many to many relationship

### DIFF
--- a/dbml-homepage/docs/docs/README.md
+++ b/dbml-homepage/docs/docs/README.md
@@ -210,11 +210,12 @@ Relationships are used to define foreign key constraints between tables across s
 
     // The space after '<' is optional
     
-There are 3 types of relationships: one-to-one, one-to-many, and many-to-one
+There are 4 types of relationships: one-to-one, one-to-many, many-to-one and many-to-many
 
 - `<`: one-to-many. E.g: `users.id < posts.user_id`
 - `>`: many-to-one. E.g: `posts.user_id > users.id`
 - `-`: one-to-one. E.g: `users.id - user_infos.user_id`
+- `<>`: many-to-many. E.g: `authors.id <> books.id`
 
 In DBML, there are 3 syntaxes to define relationships:
 

--- a/packages/dbml-cli/yarn.lock
+++ b/packages/dbml-cli/yarn.lock
@@ -703,10 +703,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@dbml/core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@dbml/core/-/core-2.4.0.tgz#227eb357e8aa6642c336d8a4a88ad26c52e5f729"
-  integrity sha512-tAkvqBBA8s6rblYN4NdZ9KVvoRhsdda/vzxrM945TBwsgQb47FQgKcVBO2XO6dIH4AN5IAAQib1defYh6BLl6A==
+"@dbml/core@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@dbml/core/-/core-2.4.1.tgz#9dc3f59978e2bb5bc5e073ee08194c1c7264ac06"
+  integrity sha512-+xZ37nIJW3zxDpcyPZ5B1rbhKU9NxtrkJvNe9ksjX4Til4jMBOYYaUIoZ3u5uLc4KIutVocfh3PjtpH7mChBfg==
   dependencies:
     lodash "^4.17.15"
     parsimmon "^1.13.0"

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
@@ -1,0 +1,14 @@
+Table "schemaA"."authors" {
+  "id" int [pk]
+  "name" varchar
+  "dob" date [pk]
+  "gender" varchar
+}
+
+Table "schemaB"."books" {
+  "id" int [pk]
+  "release_date" date [pk]
+  "title" varchar
+}
+
+ref:  "schemaA"."authors".("id","dob") <>  "schemaB"."books".("id","release_date")

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
@@ -1,14 +1,36 @@
-Table "schemaA"."authors" {
-  "id" int [pk]
-  "name" varchar
-  "dob" date [pk]
-  "gender" varchar
+table "A"."a" {
+  "AB" integer [pk]
+  "BA" integer [pk]
 }
 
-Table "schemaB"."books" {
-  "id" int [pk]
-  "release_date" date [pk]
-  "title" varchar
+table "B"."b" {
+  "BC" integer [pk]
+  "CB" integer [pk]
 }
 
-ref:  "schemaA"."authors".("id","dob") <>  "schemaB"."books".("id","release_date")
+table "C"."c" {
+  "CD" integer [pk, ref: <> "D"."d"."DE"]
+  "DC" integer
+}
+
+table "D"."d" {
+  "DE" integer [pk]
+  "ED" integer
+}
+
+table "E"."e" {
+  "EF" integer [pk]
+  "FE" integer [pk]
+  "DE" integer 
+  "ED" integer 
+}
+
+table "G"."g" {
+  "GH" integer [pk]
+  "HG" integer [pk]
+  "EH" integer 
+  "HE" integer 
+}
+
+ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
+ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
@@ -34,3 +34,21 @@ table "G"."g" {
 
 ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
 ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
+
+
+table t1 {
+  a int
+  b int
+}
+
+table t2 {
+  a int
+  b int
+}
+
+table t1_t2 {
+  a int
+}
+
+ref: t1.a <> t2.a
+ref: t1.b <> t2.b

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
@@ -60,6 +60,23 @@ CREATE TABLE [G].[g] (
 )
 GO
 
+CREATE TABLE [t1] (
+  [a] int,
+  [b] int
+)
+GO
+
+CREATE TABLE [t2] (
+  [a] int,
+  [b] int
+)
+GO
+
+CREATE TABLE [t1_t2] (
+  [a] int
+)
+GO
+
 CREATE TABLE [a_b] (
   [a_AB] integer NOT NULL,
   [a_BA] integer NOT NULL,
@@ -115,5 +132,33 @@ ALTER TABLE [e_g] ADD FOREIGN KEY ([e_EF], [e_FE]) REFERENCES [E].[e] ([EF], [FE
 GO
 
 ALTER TABLE [e_g] ADD FOREIGN KEY ([g_GH], [g_HG]) REFERENCES [G].[g] ([GH], [HG]);
+GO
+
+
+CREATE TABLE [t1_t2(1)] (
+  [t1_a] int NOT NULL,
+  [t2_a] int NOT NULL,
+  PRIMARY KEY ([t1_a], [t2_a])
+);
+GO
+
+ALTER TABLE [t1_t2(1)] ADD FOREIGN KEY ([t1_a]) REFERENCES [t1] ([a]);
+GO
+
+ALTER TABLE [t1_t2(1)] ADD FOREIGN KEY ([t2_a]) REFERENCES [t2] ([a]);
+GO
+
+
+CREATE TABLE [t1_t2(2)] (
+  [t1_b] int NOT NULL,
+  [t2_b] int NOT NULL,
+  PRIMARY KEY ([t1_b], [t2_b])
+);
+GO
+
+ALTER TABLE [t1_t2(2)] ADD FOREIGN KEY ([t1_b]) REFERENCES [t1] ([b]);
+GO
+
+ALTER TABLE [t1_t2(2)] ADD FOREIGN KEY ([t2_b]) REFERENCES [t2] ([b]);
 GO
 

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
@@ -1,44 +1,119 @@
-CREATE SCHEMA [schemaA]
+CREATE SCHEMA [A]
 GO
 
-CREATE SCHEMA [schemaB]
+CREATE SCHEMA [B]
 GO
 
-CREATE TABLE [schemaA].[authors] (
-  [id] int,
-  [name] nvarchar(255),
-  [dob] date,
-  [gender] nvarchar(255),
-  PRIMARY KEY ([id], [dob])
+CREATE SCHEMA [C]
+GO
+
+CREATE SCHEMA [D]
+GO
+
+CREATE SCHEMA [E]
+GO
+
+CREATE SCHEMA [G]
+GO
+
+CREATE TABLE [A].[a] (
+  [AB] integer,
+  [BA] integer,
+  PRIMARY KEY ([AB], [BA])
 )
 GO
 
-CREATE TABLE [schemaB].[books] (
-  [id] int,
-  [release_date] date,
-  [title] nvarchar(255),
-  PRIMARY KEY ([id], [release_date])
+CREATE TABLE [B].[b] (
+  [BC] integer,
+  [CB] integer,
+  PRIMARY KEY ([BC], [CB])
 )
 GO
 
-CREATE TABLE [authors_books] (
-  [authors_id] int NOT NULL,
-  [authors_dob] date NOT NULL,
-  [books_id] int NOT NULL,
-  [books_release_date] date NOT NULL,
-  CONSTRAINT PK_authors_books PRIMARY KEY ([authors_id], [authors_dob], [books_id], [books_release_date])
+CREATE TABLE [C].[c] (
+  [CD] integer PRIMARY KEY,
+  [DC] integer
+)
+GO
+
+CREATE TABLE [D].[d] (
+  [DE] integer PRIMARY KEY,
+  [ED] integer
+)
+GO
+
+CREATE TABLE [E].[e] (
+  [EF] integer,
+  [FE] integer,
+  [DE] integer,
+  [ED] integer,
+  PRIMARY KEY ([EF], [FE])
+)
+GO
+
+CREATE TABLE [G].[g] (
+  [GH] integer,
+  [HG] integer,
+  [EH] integer,
+  [HE] integer,
+  PRIMARY KEY ([GH], [HG])
+)
+GO
+
+CREATE TABLE [a_b] (
+  [a_AB] integer NOT NULL,
+  [a_BA] integer NOT NULL,
+  [b_BC] integer NOT NULL,
+  [b_CB] integer NOT NULL,
+  PRIMARY KEY ([a_AB], [a_BA], [b_BC], [b_CB])
 );
 GO
 
-CREATE INDEX idx_authors_books_authors ON [authors_books] ("authors_id", "authors_dob");
+CREATE INDEX [idx_a_b_a] ON [a_b] ("a_AB", "a_BA");
 GO
 
-CREATE INDEX idx_authors_books_books ON [authors_books] ("books_id", "books_release_date");
+CREATE INDEX [idx_a_b_b] ON [a_b] ("b_BC", "b_CB");
 GO
 
-ALTER TABLE [authors_books] ADD FOREIGN KEY ([authors_id], [authors_dob]) REFERENCES [schemaA].[authors] ([id], [dob]);
+ALTER TABLE [a_b] ADD FOREIGN KEY ([a_AB], [a_BA]) REFERENCES [A].[a] ([AB], [BA]);
 GO
 
-ALTER TABLE [authors_books] ADD FOREIGN KEY ([books_id], [books_release_date]) REFERENCES [schemaB].[books] ([id], [release_date]);
+ALTER TABLE [a_b] ADD FOREIGN KEY ([b_BC], [b_CB]) REFERENCES [B].[b] ([BC], [CB]);
+GO
+
+
+CREATE TABLE [d_c] (
+  [d_DE] integer NOT NULL,
+  [c_CD] integer NOT NULL,
+  PRIMARY KEY ([d_DE], [c_CD])
+);
+GO
+
+ALTER TABLE [d_c] ADD FOREIGN KEY ([d_DE]) REFERENCES [D].[d] ([DE]);
+GO
+
+ALTER TABLE [d_c] ADD FOREIGN KEY ([c_CD]) REFERENCES [C].[c] ([CD]);
+GO
+
+
+CREATE TABLE [e_g] (
+  [e_EF] integer NOT NULL,
+  [e_FE] integer NOT NULL,
+  [g_GH] integer NOT NULL,
+  [g_HG] integer NOT NULL,
+  PRIMARY KEY ([e_EF], [e_FE], [g_GH], [g_HG])
+);
+GO
+
+CREATE INDEX [idx_e_g_e] ON [e_g] ("e_EF", "e_FE");
+GO
+
+CREATE INDEX [idx_e_g_g] ON [e_g] ("g_GH", "g_HG");
+GO
+
+ALTER TABLE [e_g] ADD FOREIGN KEY ([e_EF], [e_FE]) REFERENCES [E].[e] ([EF], [FE]);
+GO
+
+ALTER TABLE [e_g] ADD FOREIGN KEY ([g_GH], [g_HG]) REFERENCES [G].[g] ([GH], [HG]);
 GO
 

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
@@ -1,0 +1,44 @@
+CREATE SCHEMA [schemaA]
+GO
+
+CREATE SCHEMA [schemaB]
+GO
+
+CREATE TABLE [schemaA].[authors] (
+  [id] int,
+  [name] nvarchar(255),
+  [dob] date,
+  [gender] nvarchar(255),
+  PRIMARY KEY ([id], [dob])
+)
+GO
+
+CREATE TABLE [schemaB].[books] (
+  [id] int,
+  [release_date] date,
+  [title] nvarchar(255),
+  PRIMARY KEY ([id], [release_date])
+)
+GO
+
+CREATE TABLE [authors_books] (
+  [authors_id] int NOT NULL,
+  [authors_dob] date NOT NULL,
+  [books_id] int NOT NULL,
+  [books_release_date] date NOT NULL,
+  CONSTRAINT PK_authors_books PRIMARY KEY ([authors_id], [authors_dob], [books_id], [books_release_date])
+);
+GO
+
+CREATE INDEX idx_authors_books_authors ON [authors_books] ("authors_id", "authors_dob");
+GO
+
+CREATE INDEX idx_authors_books_books ON [authors_books] ("books_id", "books_release_date");
+GO
+
+ALTER TABLE [authors_books] ADD FOREIGN KEY ([authors_id], [authors_dob]) REFERENCES [schemaA].[authors] ([id], [dob]);
+GO
+
+ALTER TABLE [authors_books] ADD FOREIGN KEY ([books_id], [books_release_date]) REFERENCES [schemaB].[books] ([id], [release_date]);
+GO
+

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
@@ -1,14 +1,36 @@
-Table "authors" {
-  "id" int [pk]
-  "name" varchar
-  "dob" date
-  "gender" varchar
+table "A"."a" {
+  "AB" integer [pk]
+  "BA" integer [pk]
 }
 
-Table "books" {
-  "id" int [pk]
-  "release_date" date
-  "title" varchar
+table "B"."b" {
+  "BC" integer [pk]
+  "CB" integer [pk]
 }
 
-ref:  "authors"."id" <> "books"."id"
+table "C"."c" {
+  "CD" integer [pk, ref: <> "D"."d"."DE"]
+  "DC" integer
+}
+
+table "D"."d" {
+  "DE" integer [pk]
+  "ED" integer
+}
+
+table "E"."e" {
+  "EF" integer [pk]
+  "FE" integer [pk]
+  "DE" integer 
+  "ED" integer 
+}
+
+table "G"."g" {
+  "GH" integer [pk]
+  "HG" integer [pk]
+  "EH" integer 
+  "HE" integer 
+}
+
+ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
+ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
@@ -1,0 +1,14 @@
+Table "authors" {
+  "id" int [pk]
+  "name" varchar
+  "dob" date
+  "gender" varchar
+}
+
+Table "books" {
+  "id" int [pk]
+  "release_date" date
+  "title" varchar
+}
+
+ref:  "authors"."id" <> "books"."id"

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
@@ -34,3 +34,21 @@ table "G"."g" {
 
 ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
 ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
+
+
+table t1 {
+  a int
+  b int
+}
+
+table t2 {
+  a int
+  b int
+}
+
+table t1_t2 {
+  a int
+}
+
+ref: t1.a <> t2.a
+ref: t1.b <> t2.b

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
@@ -48,6 +48,20 @@ CREATE TABLE `G`.`g` (
   PRIMARY KEY (`GH`, `HG`)
 );
 
+CREATE TABLE `t1` (
+  `a` int,
+  `b` int
+);
+
+CREATE TABLE `t2` (
+  `a` int,
+  `b` int
+);
+
+CREATE TABLE `t1_t2` (
+  `a` int
+);
+
 CREATE TABLE `a_b` (
   `a_AB` integer NOT NULL,
   `a_BA` integer NOT NULL,
@@ -91,4 +105,26 @@ CREATE INDEX `idx_e_g_g` ON `e_g` (`g_GH`, `g_HG`);
 ALTER TABLE `e_g` ADD FOREIGN KEY (`e_EF`, `e_FE`) REFERENCES `E`.`e` (`EF`, `FE`);
 
 ALTER TABLE `e_g` ADD FOREIGN KEY (`g_GH`, `g_HG`) REFERENCES `G`.`g` (`GH`, `HG`);
+
+
+CREATE TABLE `t1_t2(1)` (
+  `t1_a` int NOT NULL,
+  `t2_a` int NOT NULL,
+  PRIMARY KEY (`t1_a`, `t2_a`)
+);
+
+ALTER TABLE `t1_t2(1)` ADD FOREIGN KEY (`t1_a`) REFERENCES `t1` (`a`);
+
+ALTER TABLE `t1_t2(1)` ADD FOREIGN KEY (`t2_a`) REFERENCES `t2` (`a`);
+
+
+CREATE TABLE `t1_t2(2)` (
+  `t1_b` int NOT NULL,
+  `t2_b` int NOT NULL,
+  PRIMARY KEY (`t1_b`, `t2_b`)
+);
+
+ALTER TABLE `t1_t2(2)` ADD FOREIGN KEY (`t1_b`) REFERENCES `t1` (`b`);
+
+ALTER TABLE `t1_t2(2)` ADD FOREIGN KEY (`t2_b`) REFERENCES `t2` (`b`);
 

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
@@ -1,23 +1,94 @@
-CREATE TABLE `authors` (
-  `id` int PRIMARY KEY,
-  `name` varchar(255),
-  `dob` date,
-  `gender` varchar(255)
+CREATE SCHEMA `A`;
+
+CREATE SCHEMA `B`;
+
+CREATE SCHEMA `C`;
+
+CREATE SCHEMA `D`;
+
+CREATE SCHEMA `E`;
+
+CREATE SCHEMA `G`;
+
+CREATE TABLE `A`.`a` (
+  `AB` integer,
+  `BA` integer,
+  PRIMARY KEY (`AB`, `BA`)
 );
 
-CREATE TABLE `books` (
-  `id` int PRIMARY KEY,
-  `release_date` date,
-  `title` varchar(255)
+CREATE TABLE `B`.`b` (
+  `BC` integer,
+  `CB` integer,
+  PRIMARY KEY (`BC`, `CB`)
 );
 
-CREATE TABLE `authors_books` (
-  `authors_id` int NOT NULL,
-  `books_id` int NOT NULL,
-  CONSTRAINT PK_authors_books PRIMARY KEY (`authors_id`, `books_id`)
+CREATE TABLE `C`.`c` (
+  `CD` integer PRIMARY KEY,
+  `DC` integer
 );
 
-ALTER TABLE `authors_books` ADD FOREIGN KEY (`authors_id`) REFERENCES `authors` (`id`);
+CREATE TABLE `D`.`d` (
+  `DE` integer PRIMARY KEY,
+  `ED` integer
+);
 
-ALTER TABLE `authors_books` ADD FOREIGN KEY (`books_id`) REFERENCES `books` (`id`);
+CREATE TABLE `E`.`e` (
+  `EF` integer,
+  `FE` integer,
+  `DE` integer,
+  `ED` integer,
+  PRIMARY KEY (`EF`, `FE`)
+);
+
+CREATE TABLE `G`.`g` (
+  `GH` integer,
+  `HG` integer,
+  `EH` integer,
+  `HE` integer,
+  PRIMARY KEY (`GH`, `HG`)
+);
+
+CREATE TABLE `a_b` (
+  `a_AB` integer NOT NULL,
+  `a_BA` integer NOT NULL,
+  `b_BC` integer NOT NULL,
+  `b_CB` integer NOT NULL,
+  PRIMARY KEY (`a_AB`, `a_BA`, `b_BC`, `b_CB`)
+);
+
+CREATE INDEX `idx_a_b_a` ON `a_b` (`a_AB`, `a_BA`);
+
+CREATE INDEX `idx_a_b_b` ON `a_b` (`b_BC`, `b_CB`);
+
+ALTER TABLE `a_b` ADD FOREIGN KEY (`a_AB`, `a_BA`) REFERENCES `A`.`a` (`AB`, `BA`);
+
+ALTER TABLE `a_b` ADD FOREIGN KEY (`b_BC`, `b_CB`) REFERENCES `B`.`b` (`BC`, `CB`);
+
+
+CREATE TABLE `d_c` (
+  `d_DE` integer NOT NULL,
+  `c_CD` integer NOT NULL,
+  PRIMARY KEY (`d_DE`, `c_CD`)
+);
+
+ALTER TABLE `d_c` ADD FOREIGN KEY (`d_DE`) REFERENCES `D`.`d` (`DE`);
+
+ALTER TABLE `d_c` ADD FOREIGN KEY (`c_CD`) REFERENCES `C`.`c` (`CD`);
+
+
+CREATE TABLE `e_g` (
+  `e_EF` integer NOT NULL,
+  `e_FE` integer NOT NULL,
+  `g_GH` integer NOT NULL,
+  `g_HG` integer NOT NULL,
+  PRIMARY KEY (`e_EF`, `e_FE`, `g_GH`, `g_HG`)
+);
+
+CREATE INDEX `idx_e_g_e` ON `e_g` (`e_EF`, `e_FE`);
+
+CREATE INDEX `idx_e_g_g` ON `e_g` (`g_GH`, `g_HG`);
+
+ALTER TABLE `e_g` ADD FOREIGN KEY (`e_EF`, `e_FE`) REFERENCES `E`.`e` (`EF`, `FE`);
+
+ALTER TABLE `e_g` ADD FOREIGN KEY (`g_GH`, `g_HG`) REFERENCES `G`.`g` (`GH`, `HG`);
 

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `authors` (
+  `id` int PRIMARY KEY,
+  `name` varchar(255),
+  `dob` date,
+  `gender` varchar(255)
+);
+
+CREATE TABLE `books` (
+  `id` int PRIMARY KEY,
+  `release_date` date,
+  `title` varchar(255)
+);
+
+CREATE TABLE `authors_books` (
+  `authors_id` int NOT NULL,
+  `books_id` int NOT NULL,
+  CONSTRAINT PK_authors_books PRIMARY KEY (`authors_id`, `books_id`)
+);
+
+ALTER TABLE `authors_books` ADD FOREIGN KEY (`authors_id`) REFERENCES `authors` (`id`);
+
+ALTER TABLE `authors_books` ADD FOREIGN KEY (`books_id`) REFERENCES `books` (`id`);
+

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
@@ -1,14 +1,36 @@
-Table "authors" {
-  "id" int [pk]
-  "name" varchar
-  "dob" date
-  "gender" varchar
+table "A"."a" {
+  "AB" integer [pk]
+  "BA" integer [pk]
 }
 
-Table "books" {
-  "id" int [pk]
-  "release_date" date
-  "title" varchar
+table "B"."b" {
+  "BC" integer [pk]
+  "CB" integer [pk]
 }
 
-ref:  "authors"."id" <> "books"."id"
+table "C"."c" {
+  "CD" integer [pk, ref: <> "D"."d"."DE"]
+  "DC" integer
+}
+
+table "D"."d" {
+  "DE" integer [pk]
+  "ED" integer
+}
+
+table "E"."e" {
+  "EF" integer [pk]
+  "FE" integer [pk]
+  "DE" integer 
+  "ED" integer 
+}
+
+table "G"."g" {
+  "GH" integer [pk]
+  "HG" integer [pk]
+  "EH" integer 
+  "HE" integer 
+}
+
+ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
+ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
@@ -1,0 +1,14 @@
+Table "authors" {
+  "id" int [pk]
+  "name" varchar
+  "dob" date
+  "gender" varchar
+}
+
+Table "books" {
+  "id" int [pk]
+  "release_date" date
+  "title" varchar
+}
+
+ref:  "authors"."id" <> "books"."id"

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
@@ -34,3 +34,21 @@ table "G"."g" {
 
 ref:  "A"."a".("AB","BA") <>  "B"."b".("BC","CB")
 ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
+
+
+table t1 {
+  a int
+  b int
+}
+
+table t2 {
+  a int
+  b int
+}
+
+table t1_t2 {
+  a int
+}
+
+ref: t1.a <> t2.a
+ref: t1.b <> t2.b

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
@@ -1,23 +1,94 @@
-CREATE TABLE "authors" (
-  "id" int PRIMARY KEY,
-  "name" varchar,
-  "dob" date,
-  "gender" varchar
+CREATE SCHEMA "A";
+
+CREATE SCHEMA "B";
+
+CREATE SCHEMA "C";
+
+CREATE SCHEMA "D";
+
+CREATE SCHEMA "E";
+
+CREATE SCHEMA "G";
+
+CREATE TABLE "A"."a" (
+  "AB" integer,
+  "BA" integer,
+  PRIMARY KEY ("AB", "BA")
 );
 
-CREATE TABLE "books" (
-  "id" int PRIMARY KEY,
-  "release_date" date,
-  "title" varchar
+CREATE TABLE "B"."b" (
+  "BC" integer,
+  "CB" integer,
+  PRIMARY KEY ("BC", "CB")
 );
 
-CREATE TABLE "authors_books" (
-  "authors_id" int NOT NULL,
-  "books_id" int NOT NULL,
-  CONSTRAINT PK_authors_books PRIMARY KEY ("authors_id", "books_id")
+CREATE TABLE "C"."c" (
+  "CD" integer PRIMARY KEY,
+  "DC" integer
 );
 
-ALTER TABLE "authors_books" ADD FOREIGN KEY ("authors_id") REFERENCES "authors" ("id");
+CREATE TABLE "D"."d" (
+  "DE" integer PRIMARY KEY,
+  "ED" integer
+);
 
-ALTER TABLE "authors_books" ADD FOREIGN KEY ("books_id") REFERENCES "books" ("id");
+CREATE TABLE "E"."e" (
+  "EF" integer,
+  "FE" integer,
+  "DE" integer,
+  "ED" integer,
+  PRIMARY KEY ("EF", "FE")
+);
+
+CREATE TABLE "G"."g" (
+  "GH" integer,
+  "HG" integer,
+  "EH" integer,
+  "HE" integer,
+  PRIMARY KEY ("GH", "HG")
+);
+
+CREATE TABLE "a_b" (
+  "a_AB" integer NOT NULL,
+  "a_BA" integer NOT NULL,
+  "b_BC" integer NOT NULL,
+  "b_CB" integer NOT NULL,
+  PRIMARY KEY ("a_AB", "a_BA", "b_BC", "b_CB")
+);
+
+CREATE INDEX "idx_a_b_a" ON "a_b" ("a_AB", "a_BA");
+
+CREATE INDEX "idx_a_b_b" ON "a_b" ("b_BC", "b_CB");
+
+ALTER TABLE "a_b" ADD FOREIGN KEY ("a_AB", "a_BA") REFERENCES "A"."a" ("AB", "BA");
+
+ALTER TABLE "a_b" ADD FOREIGN KEY ("b_BC", "b_CB") REFERENCES "B"."b" ("BC", "CB");
+
+
+CREATE TABLE "d_c" (
+  "d_DE" integer NOT NULL,
+  "c_CD" integer NOT NULL,
+  PRIMARY KEY ("d_DE", "c_CD")
+);
+
+ALTER TABLE "d_c" ADD FOREIGN KEY ("d_DE") REFERENCES "D"."d" ("DE");
+
+ALTER TABLE "d_c" ADD FOREIGN KEY ("c_CD") REFERENCES "C"."c" ("CD");
+
+
+CREATE TABLE "e_g" (
+  "e_EF" integer NOT NULL,
+  "e_FE" integer NOT NULL,
+  "g_GH" integer NOT NULL,
+  "g_HG" integer NOT NULL,
+  PRIMARY KEY ("e_EF", "e_FE", "g_GH", "g_HG")
+);
+
+CREATE INDEX "idx_e_g_e" ON "e_g" ("e_EF", "e_FE");
+
+CREATE INDEX "idx_e_g_g" ON "e_g" ("g_GH", "g_HG");
+
+ALTER TABLE "e_g" ADD FOREIGN KEY ("e_EF", "e_FE") REFERENCES "E"."e" ("EF", "FE");
+
+ALTER TABLE "e_g" ADD FOREIGN KEY ("g_GH", "g_HG") REFERENCES "G"."g" ("GH", "HG");
 

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
@@ -48,6 +48,20 @@ CREATE TABLE "G"."g" (
   PRIMARY KEY ("GH", "HG")
 );
 
+CREATE TABLE "t1" (
+  "a" int,
+  "b" int
+);
+
+CREATE TABLE "t2" (
+  "a" int,
+  "b" int
+);
+
+CREATE TABLE "t1_t2" (
+  "a" int
+);
+
 CREATE TABLE "a_b" (
   "a_AB" integer NOT NULL,
   "a_BA" integer NOT NULL,
@@ -91,4 +105,26 @@ CREATE INDEX "idx_e_g_g" ON "e_g" ("g_GH", "g_HG");
 ALTER TABLE "e_g" ADD FOREIGN KEY ("e_EF", "e_FE") REFERENCES "E"."e" ("EF", "FE");
 
 ALTER TABLE "e_g" ADD FOREIGN KEY ("g_GH", "g_HG") REFERENCES "G"."g" ("GH", "HG");
+
+
+CREATE TABLE "t1_t2(1)" (
+  "t1_a" int NOT NULL,
+  "t2_a" int NOT NULL,
+  PRIMARY KEY ("t1_a", "t2_a")
+);
+
+ALTER TABLE "t1_t2(1)" ADD FOREIGN KEY ("t1_a") REFERENCES "t1" ("a");
+
+ALTER TABLE "t1_t2(1)" ADD FOREIGN KEY ("t2_a") REFERENCES "t2" ("a");
+
+
+CREATE TABLE "t1_t2(2)" (
+  "t1_b" int NOT NULL,
+  "t2_b" int NOT NULL,
+  PRIMARY KEY ("t1_b", "t2_b")
+);
+
+ALTER TABLE "t1_t2(2)" ADD FOREIGN KEY ("t1_b") REFERENCES "t1" ("b");
+
+ALTER TABLE "t1_t2(2)" ADD FOREIGN KEY ("t2_b") REFERENCES "t2" ("b");
 

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "authors" (
+  "id" int PRIMARY KEY,
+  "name" varchar,
+  "dob" date,
+  "gender" varchar
+);
+
+CREATE TABLE "books" (
+  "id" int PRIMARY KEY,
+  "release_date" date,
+  "title" varchar
+);
+
+CREATE TABLE "authors_books" (
+  "authors_id" int NOT NULL,
+  "books_id" int NOT NULL,
+  CONSTRAINT PK_authors_books PRIMARY KEY ("authors_id", "books_id")
+);
+
+ALTER TABLE "authors_books" ADD FOREIGN KEY ("authors_id") REFERENCES "authors" ("id");
+
+ALTER TABLE "authors_books" ADD FOREIGN KEY ("books_id") REFERENCES "books" ("id");
+

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -124,13 +124,13 @@ class MySQLExporter {
   static buildJunctionFields2 (fieldIds, model, firstTableKey) {
     const mapFieldKeys = new Map();
     fieldIds.map((fieldId) => {
-      let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
+      let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
       let count = 1;
-      while (firstTableKey.has(key)) {
-        key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
+      while (firstTableKey.has(fieldName)) {
+        fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
         count += 1;
       }
-      mapFieldKeys.set(key, model.fields[fieldId].type.type_name);
+      mapFieldKeys.set(fieldName, model.fields[fieldId].type.type_name);
     });
     return mapFieldKeys;
   }

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -115,59 +115,64 @@ class MySQLExporter {
     return `(${fieldNames})`;
   }
 
-  static buildFieldKeyTableFirst (fieldIds, model) {
-    const keyFields = new Map();
-    fieldIds.map(fieldId => keyFields.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
-    return keyFields;
+  static buildJunctionFields1 (fieldIds, model) {
+    const mapFieldKeys = new Map();
+    fieldIds.map(fieldId => mapFieldKeys.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
+    return mapFieldKeys;
   }
 
-  static buildFieldKeyTableSecond (fieldIds, model, keyTableFirst) {
-    const keyFields = new Map();
+  static buildJunctionFields2 (fieldIds, model, firstTableKey) {
+    const mapFieldKeys = new Map();
     fieldIds.map((fieldId) => {
       let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
       let count = 1;
-      while (true) {
-        if (!keyTableFirst.has(key)) {
-          break;
-        }
+      while (firstTableKey.has(key)) {
         key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
         count += 1;
       }
-      keyFields.set(key, model.fields[fieldId].type.type_name);
+      mapFieldKeys.set(key, model.fields[fieldId].type.type_name);
     });
-    return keyFields;
+    return mapFieldKeys;
   }
 
-  static buildTableManyToMany (keyTableFirst, keyTableSecond, tableName) {
+  static buildTableManyToMany (firstTableKey, secondTableKey, tableName) {
     let line = `CREATE TABLE \`${tableName}\` (\n`;
-    const key1s = [...keyTableFirst.keys()].join('`, `');
-    const key2s = [...keyTableSecond.keys()].join('`, `');
-    keyTableFirst.forEach((value, key) => {
+    const key1s = [...firstTableKey.keys()].join('`, `');
+    const key2s = [...secondTableKey.keys()].join('`, `');
+    firstTableKey.forEach((value, key) => {
       line += `  \`${key}\` ${value} NOT NULL,\n`;
     });
-    keyTableSecond.forEach((value, key) => {
+    secondTableKey.forEach((value, key) => {
       line += `  \`${key}\` ${value} NOT NULL,\n`;
     });
-    line += `  CONSTRAINT PK_${tableName} PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
+    line += `  PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
     line += ');\n\n';
     return line;
   }
 
-  static buildForeignKeyManyToMany (keyTable, keyForeign, nameTable, nameForeign, schema, model) {
-    const key = [...keyTable.keys()].join('`, `');
-    const line = `ALTER TABLE \`${nameTable}\` ADD FOREIGN KEY (\`${key}\`) REFERENCES ${shouldPrintSchema(schema, model)
-      ? `\`${schema.name}\`.` : ''}\`${nameForeign}\` ${keyForeign};\n\n`;
+  static buildForeignKeyManyToMany (mapFieldKeys, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+    const refEndpointFields = [...mapFieldKeys.keys()].join('`, `');
+    const line = `ALTER TABLE \`${refEndpointTableName}\` ADD FOREIGN KEY (\`${refEndpointFields}\`) REFERENCES ${shouldPrintSchema(schema, model)
+      ? `\`${schema.name}\`.` : ''}\`${foreignEndpointTableName}\` ${foreignEndpointFields};\n\n`;
     return line;
   }
 
-  static buildIndexManytoMany (keyTable, nameNewTable, nameTableRef) {
-    const key = [...keyTable.keys()].join('`, `');
-    let line = `CREATE INDEX idx_${nameNewTable}_${nameTableRef} ON \`${nameNewTable}\` (`;
-    line += `\`${key}\`);\n\n`;
+  static buildIndexManytoMany (keyTable, newTableName, nameTableRef, indexes, setIndexNewTableName) {
+    let indexNewTableName = `${newTableName}_${nameTableRef}`;
+    let count = 1;
+    while ((Object.values(indexes).findIndex((index) => index.name === indexNewTableName) !== -1) || setIndexNewTableName.has(indexNewTableName)) {
+      indexNewTableName = `${newTableName}_${nameTableRef}(${count})`;
+      count += 1;
+    }
+    const indexFields = [...keyTable.keys()].join('`, `');
+    let line = `CREATE INDEX \`idx_${indexNewTableName}\` ON \`${newTableName}\` (`;
+    line += `\`${indexFields}\`);\n\n`;
     return line;
   }
 
   static exportRefs (refIds, model) {
+    let setNewTableName = new Set();
+    let setIndexNewTableName = new Set();
     const strArr = refIds.map((refId) => {
       let line = '';
       const ref = model.refs[refId];
@@ -189,21 +194,21 @@ class MySQLExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mysql');
 
       if (refOneIndex === -1) {
-        const keyTableFirst = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'mysql');
-        const keyTableSecond = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTableFirst);
+        const firstTableKey = this.buildJunctionFields1(refEndpoint.fieldIds, model, 'mysql');
+        const secondTableKey = this.buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableKey);
 
-        const nameNewTable = this.buildNameNewTable(refEndpointTable.name, foreignEndpointTable.name, model.tables);
-        line += this.buildTableManyToMany(keyTableFirst, keyTableSecond, nameNewTable);
+        const nameNewTable = this.buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, setNewTableName);
+        line += this.buildTableManyToMany(firstTableKey, secondTableKey, nameNewTable);
 
-        if (keyTableFirst.size > 1) {
-          line += this.buildIndexManytoMany(keyTableFirst, nameNewTable, refEndpointTable.name);
+        if (firstTableKey.size > 1) {
+          line += this.buildIndexManytoMany(firstTableKey, nameNewTable, refEndpointTable.name, model.tables, setIndexNewTableName);
         }
 
-        if (keyTableSecond.size > 1) {
-          line += this.buildIndexManytoMany(keyTableSecond, nameNewTable, foreignEndpointTable.name);
+        if (secondTableKey.size > 1) {
+          line += this.buildIndexManytoMany(secondTableKey, nameNewTable, foreignEndpointTable.name, model.tables, setIndexNewTableName);
         }
-        line += this.buildForeignKeyManyToMany(keyTableFirst, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(keyTableSecond, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableKey, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableKey, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `\`${foreignEndpointSchema.name}\`.` : ''}\`${foreignEndpointTable.name}\` ADD `;
@@ -220,23 +225,20 @@ class MySQLExporter {
         }
         line += ';\n';
       }
-
       return line;
     });
 
     return strArr;
   }
 
-  static buildNameNewTable (tableFirst, tableSecond, tables) {
-    let nameNewTable = `${tableFirst}_${tableSecond}`;
+  static buildNewTableName (firstTable, secondTable, tables, setNewTableName) {
+    let nameNewTable = `${firstTable}_${secondTable}`;
     let count = 1;
-    while (true) {
-      if (Object.values(tables).findIndex((table) => table.name === nameNewTable) === -1) {
-        break;
-      }
-      nameNewTable = `${tableFirst}_${tableSecond}(${count})`;
+    while ((Object.values(tables).findIndex((table) => table.name === nameNewTable) !== -1) || setNewTableName.has(nameNewTable)) {
+      nameNewTable = `${firstTable}_${secondTable}(${count})`;
       count += 1;
     }
+    setNewTableName.add(nameNewTable);
     return nameNewTable;
   }
 

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -138,14 +138,14 @@ class MySQLExporter {
     return keyFields;
   }
 
-  static buildTableManyToMany (keyTable1, keyTable2, tableName) {
+  static buildTableManyToMany (keyTableFirst, keyTableSecond, tableName) {
     let line = `CREATE TABLE \`${tableName}\` (\n`;
-    const key1s = [...keyTable1.keys()].join('`, `');
-    const key2s = [...keyTable2.keys()].join('`, `');
-    keyTable1.forEach((value, key) => {
+    const key1s = [...keyTableFirst.keys()].join('`, `');
+    const key2s = [...keyTableSecond.keys()].join('`, `');
+    keyTableFirst.forEach((value, key) => {
       line += `  \`${key}\` ${value} NOT NULL,\n`;
     });
-    keyTable2.forEach((value, key) => {
+    keyTableSecond.forEach((value, key) => {
       line += `  \`${key}\` ${value} NOT NULL,\n`;
     });
     line += `  CONSTRAINT PK_${tableName} PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
@@ -189,21 +189,21 @@ class MySQLExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mysql');
 
       if (refOneIndex === -1) {
-        const keyTable1 = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'postgres');
-        const keyTable2 = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTable1);
+        const keyTableFirst = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'mysql');
+        const keyTableSecond = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTableFirst);
 
         const nameNewTable = this.buildNameNewTable(refEndpointTable.name, foreignEndpointTable.name, model.tables);
-        line += this.buildTableManyToMany(keyTable1, keyTable2, nameNewTable);
+        line += this.buildTableManyToMany(keyTableFirst, keyTableSecond, nameNewTable);
 
-        if (keyTable1.size > 1) {
-          line += this.buildIndexManytoMany(keyTable1, nameNewTable, refEndpointTable.name);
+        if (keyTableFirst.size > 1) {
+          line += this.buildIndexManytoMany(keyTableFirst, nameNewTable, refEndpointTable.name);
         }
 
-        if (keyTable2.size > 1) {
-          line += this.buildIndexManytoMany(keyTable2, nameNewTable, foreignEndpointTable.name);
+        if (keyTableSecond.size > 1) {
+          line += this.buildIndexManytoMany(keyTableSecond, nameNewTable, foreignEndpointTable.name);
         }
-        line += this.buildForeignKeyManyToMany(keyTable1, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(keyTable2, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(keyTableFirst, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(keyTableSecond, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `\`${foreignEndpointSchema.name}\`.` : ''}\`${foreignEndpointTable.name}\` ADD `;

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -182,7 +182,7 @@ class MySQLExporter {
         const firstTableFieldsMap = buildJunctionFields1(refEndpoint.fieldIds, model);
         const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
-        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, usedTableNames);
+        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
         line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
         if (firstTableFieldsMap.size > 1) {

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -115,10 +115,64 @@ class MySQLExporter {
     return `(${fieldNames})`;
   }
 
+  static buildFieldKeyTableFirst (fieldIds, model) {
+    const keyFields = new Map();
+    fieldIds.map(fieldId => keyFields.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
+    return keyFields;
+  }
+
+  static buildFieldKeyTableSecond (fieldIds, model, keyTableFirst) {
+    const keyFields = new Map();
+    fieldIds.map((fieldId) => {
+      let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
+      let count = 1;
+      while (true) {
+        if (!keyTableFirst.has(key)) {
+          break;
+        }
+        key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
+        count += 1;
+      }
+      keyFields.set(key, model.fields[fieldId].type.type_name);
+    });
+    return keyFields;
+  }
+
+  static buildTableManyToMany (keyTable1, keyTable2, tableName) {
+    let line = `CREATE TABLE \`${tableName}\` (\n`;
+    const key1s = [...keyTable1.keys()].join('`, `');
+    const key2s = [...keyTable2.keys()].join('`, `');
+    keyTable1.forEach((value, key) => {
+      line += `  \`${key}\` ${value} NOT NULL,\n`;
+    });
+    keyTable2.forEach((value, key) => {
+      line += `  \`${key}\` ${value} NOT NULL,\n`;
+    });
+    line += `  CONSTRAINT PK_${tableName} PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
+    line += ');\n\n';
+    return line;
+  }
+
+  static buildForeignKeyManyToMany (keyTable, keyForeign, nameTable, nameForeign, schema, model) {
+    const key = [...keyTable.keys()].join('`, `');
+    const line = `ALTER TABLE \`${nameTable}\` ADD FOREIGN KEY (\`${key}\`) REFERENCES ${shouldPrintSchema(schema, model)
+      ? `\`${schema.name}\`.` : ''}\`${nameForeign}\` ${keyForeign};\n\n`;
+    return line;
+  }
+
+  static buildIndexManytoMany (keyTable, nameNewTable, nameTableRef) {
+    const key = [...keyTable.keys()].join('`, `');
+    let line = `CREATE INDEX idx_${nameNewTable}_${nameTableRef} ON \`${nameNewTable}\` (`;
+    line += `\`${key}\`);\n\n`;
+    return line;
+  }
+
   static exportRefs (refIds, model) {
     const strArr = refIds.map((refId) => {
+      let line = '';
       const ref = model.refs[refId];
-      const refEndpointIndex = ref.endpointIds.findIndex(endpointId => model.endpoints[endpointId].relation === '1');
+      const refOneIndex = ref.endpointIds.findIndex(endpointId => model.endpoints[endpointId].relation === '1');
+      const refEndpointIndex = refOneIndex === -1 ? 0 : refOneIndex;
       const foreignEndpointId = ref.endpointIds[1 - refEndpointIndex];
       const refEndpointId = ref.endpointIds[refEndpointIndex];
       const foreignEndpoint = model.endpoints[foreignEndpointId];
@@ -134,27 +188,56 @@ class MySQLExporter {
       const foreignEndpointSchema = model.schemas[foreignEndpointTable.schemaId];
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mysql');
 
-      let line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
-        ? `\`${foreignEndpointSchema.name}\`.` : ''}\`${foreignEndpointTable.name}\` ADD `;
+      if (refOneIndex === -1) {
+        const keyTable1 = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'postgres');
+        const keyTable2 = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTable1);
 
-      if (ref.name) {
-        line += `CONSTRAINT \`${ref.name}\` `;
-      }
+        const nameNewTable = this.buildNameNewTable(refEndpointTable.name, foreignEndpointTable.name, model.tables);
+        line += this.buildTableManyToMany(keyTable1, keyTable2, nameNewTable);
 
-      line += `FOREIGN KEY ${foreignEndpointFieldName} REFERENCES ${shouldPrintSchema(refEndpointSchema, model)
-        ? `\`${refEndpointSchema.name}\`.` : ''}\`${refEndpointTable.name}\` ${refEndpointFieldName}`;
-      if (ref.onDelete) {
-        line += ` ON DELETE ${ref.onDelete.toUpperCase()}`;
+        if (keyTable1.size > 1) {
+          line += this.buildIndexManytoMany(keyTable1, nameNewTable, refEndpointTable.name);
+        }
+
+        if (keyTable2.size > 1) {
+          line += this.buildIndexManytoMany(keyTable2, nameNewTable, foreignEndpointTable.name);
+        }
+        line += this.buildForeignKeyManyToMany(keyTable1, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(keyTable2, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+      } else {
+        line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
+          ? `\`${foreignEndpointSchema.name}\`.` : ''}\`${foreignEndpointTable.name}\` ADD `;
+        if (ref.name) {
+          line += `CONSTRAINT \`${ref.name}\` `;
+        }
+        line += `FOREIGN KEY ${foreignEndpointFieldName} REFERENCES ${shouldPrintSchema(refEndpointSchema, model)
+          ? `\`${refEndpointSchema.name}\`.` : ''}\`${refEndpointTable.name}\` ${refEndpointFieldName}`;
+        if (ref.onDelete) {
+          line += ` ON DELETE ${ref.onDelete.toUpperCase()}`;
+        }
+        if (ref.onUpdate) {
+          line += ` ON UPDATE ${ref.onUpdate.toUpperCase()}`;
+        }
+        line += ';\n';
       }
-      if (ref.onUpdate) {
-        line += ` ON UPDATE ${ref.onUpdate.toUpperCase()}`;
-      }
-      line += ';\n';
 
       return line;
     });
 
     return strArr;
+  }
+
+  static buildNameNewTable (tableFirst, tableSecond, tables) {
+    let nameNewTable = `${tableFirst}_${tableSecond}`;
+    let count = 1;
+    while (true) {
+      if (Object.values(tables).findIndex((table) => table.name === nameNewTable) === -1) {
+        break;
+      }
+      nameNewTable = `${tableFirst}_${tableSecond}(${count})`;
+      count += 1;
+    }
+    return nameNewTable;
   }
 
   static exportIndexes (indexIds, model) {

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -1,5 +1,10 @@
 import _ from 'lodash';
-import { shouldPrintSchema } from './utils';
+import {
+  shouldPrintSchema,
+  buildJunctionFields1,
+  buildJunctionFields2,
+  buildNewTableName,
+} from './utils';
 
 class MySQLExporter {
   static getFieldLines (tableId, model) {
@@ -115,64 +120,44 @@ class MySQLExporter {
     return `(${fieldNames})`;
   }
 
-  static buildJunctionFields1 (fieldIds, model) {
-    const mapFieldKeys = new Map();
-    fieldIds.map(fieldId => mapFieldKeys.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
-    return mapFieldKeys;
-  }
-
-  static buildJunctionFields2 (fieldIds, model, firstTableKey) {
-    const mapFieldKeys = new Map();
-    fieldIds.map((fieldId) => {
-      let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
-      let count = 1;
-      while (firstTableKey.has(fieldName)) {
-        fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
-        count += 1;
-      }
-      mapFieldKeys.set(fieldName, model.fields[fieldId].type.type_name);
-    });
-    return mapFieldKeys;
-  }
-
-  static buildTableManyToMany (firstTableKey, secondTableKey, tableName) {
+  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName) {
     let line = `CREATE TABLE \`${tableName}\` (\n`;
-    const key1s = [...firstTableKey.keys()].join('`, `');
-    const key2s = [...secondTableKey.keys()].join('`, `');
-    firstTableKey.forEach((value, key) => {
-      line += `  \`${key}\` ${value} NOT NULL,\n`;
+    const key1s = [...firstTableFieldsMap.keys()].join('`, `');
+    const key2s = [...secondTableFieldsMap.keys()].join('`, `');
+    firstTableFieldsMap.forEach((fieldType, fieldName) => {
+      line += `  \`${fieldName}\` ${fieldType} NOT NULL,\n`;
     });
-    secondTableKey.forEach((value, key) => {
-      line += `  \`${key}\` ${value} NOT NULL,\n`;
+    secondTableFieldsMap.forEach((fieldType, fieldName) => {
+      line += `  \`${fieldName}\` ${fieldType} NOT NULL,\n`;
     });
     line += `  PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
     line += ');\n\n';
     return line;
   }
 
-  static buildForeignKeyManyToMany (mapFieldKeys, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
-    const refEndpointFields = [...mapFieldKeys.keys()].join('`, `');
+  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+    const refEndpointFields = [...fieldsMap.keys()].join('`, `');
     const line = `ALTER TABLE \`${refEndpointTableName}\` ADD FOREIGN KEY (\`${refEndpointFields}\`) REFERENCES ${shouldPrintSchema(schema, model)
       ? `\`${schema.name}\`.` : ''}\`${foreignEndpointTableName}\` ${foreignEndpointFields};\n\n`;
     return line;
   }
 
-  static buildIndexManytoMany (keyTable, newTableName, nameTableRef, indexes, setIndexNewTableName) {
-    let indexNewTableName = `${newTableName}_${nameTableRef}`;
+  static buildIndexManytoMany (fieldsMap, newTableName, tableRefName, usedIndexNames) {
+    let newIndexName = `${newTableName}_${tableRefName}`;
     let count = 1;
-    while ((Object.values(indexes).findIndex((index) => index.name === indexNewTableName) !== -1) || setIndexNewTableName.has(indexNewTableName)) {
-      indexNewTableName = `${newTableName}_${nameTableRef}(${count})`;
+    while (usedIndexNames.has(newIndexName)) {
+      newIndexName = `${newTableName}_${tableRefName}(${count})`;
       count += 1;
     }
-    const indexFields = [...keyTable.keys()].join('`, `');
-    let line = `CREATE INDEX \`idx_${indexNewTableName}\` ON \`${newTableName}\` (`;
+    usedIndexNames.add(newIndexName);
+    const indexFields = [...fieldsMap.keys()].join('`, `');
+    let line = `CREATE INDEX \`idx_${newIndexName}\` ON \`${newTableName}\` (`;
     line += `\`${indexFields}\`);\n\n`;
     return line;
   }
 
-  static exportRefs (refIds, model) {
-    let setNewTableName = new Set();
-    let setIndexNewTableName = new Set();
+
+  static exportRefs (refIds, model, usedTableNames, usedIndexNames) {
     const strArr = refIds.map((refId) => {
       let line = '';
       const ref = model.refs[refId];
@@ -194,21 +179,21 @@ class MySQLExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mysql');
 
       if (refOneIndex === -1) {
-        const firstTableKey = this.buildJunctionFields1(refEndpoint.fieldIds, model, 'mysql');
-        const secondTableKey = this.buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableKey);
+        const firstTableFieldsMap = buildJunctionFields1(refEndpoint.fieldIds, model);
+        const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
-        const nameNewTable = this.buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, setNewTableName);
-        line += this.buildTableManyToMany(firstTableKey, secondTableKey, nameNewTable);
+        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, usedTableNames);
+        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
-        if (firstTableKey.size > 1) {
-          line += this.buildIndexManytoMany(firstTableKey, nameNewTable, refEndpointTable.name, model.tables, setIndexNewTableName);
+        if (firstTableFieldsMap.size > 1) {
+          line += this.buildIndexManytoMany(firstTableFieldsMap, newTableName, refEndpointTable.name, usedIndexNames);
         }
 
-        if (secondTableKey.size > 1) {
-          line += this.buildIndexManytoMany(secondTableKey, nameNewTable, foreignEndpointTable.name, model.tables, setIndexNewTableName);
+        if (secondTableFieldsMap.size > 1) {
+          line += this.buildIndexManytoMany(secondTableFieldsMap, newTableName, foreignEndpointTable.name, usedIndexNames);
         }
-        line += this.buildForeignKeyManyToMany(firstTableKey, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(secondTableKey, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `\`${foreignEndpointSchema.name}\`.` : ''}\`${foreignEndpointTable.name}\` ADD `;
@@ -229,17 +214,6 @@ class MySQLExporter {
     });
 
     return strArr;
-  }
-
-  static buildNewTableName (firstTable, secondTable, tables, setNewTableName) {
-    let nameNewTable = `${firstTable}_${secondTable}`;
-    let count = 1;
-    while ((Object.values(tables).findIndex((table) => table.name === nameNewTable) !== -1) || setNewTableName.has(nameNewTable)) {
-      nameNewTable = `${firstTable}_${secondTable}(${count})`;
-      count += 1;
-    }
-    setNewTableName.add(nameNewTable);
-    return nameNewTable;
   }
 
   static exportIndexes (indexIds, model) {
@@ -298,6 +272,9 @@ class MySQLExporter {
   static export (model) {
     const database = model.database['1'];
 
+    const usedTableNames = new Set(Object.values(model.tables).map(table => table.name));
+    const usedIndexNames = new Set(Object.values(model.indexes).map(index => index.name));
+
     const statements = database.schemaIds.reduce((prevStatements, schemaId) => {
       const schema = model.schemas[schemaId];
       const { tableIds, refIds } = schema;
@@ -324,7 +301,7 @@ class MySQLExporter {
       }
 
       if (!_.isEmpty(refIds)) {
-        prevStatements.refs.push(...MySQLExporter.exportRefs(refIds, model));
+        prevStatements.refs.push(...MySQLExporter.exportRefs(refIds, model, usedTableNames, usedIndexNames));
       }
 
       return prevStatements;
@@ -345,7 +322,6 @@ class MySQLExporter {
       statements.comments,
       statements.refs,
     ).join('\n');
-
     return res;
   }
 }

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -139,13 +139,13 @@ class PostgresExporter {
   static buildJunctionFields2 (fieldIds, model, firstTableKey) {
     const mapFieldKeys = new Map();
     fieldIds.map((fieldId) => {
-      let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
+      let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
       let count = 1;
-      while (firstTableKey.has(key)) {
-        key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
+      while (firstTableKey.has(fieldName)) {
+        fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
         count += 1;
       }
-      mapFieldKeys.set(key, model.fields[fieldId].type.type_name);
+      mapFieldKeys.set(fieldName, model.fields[fieldId].type.type_name);
     });
     return mapFieldKeys;
   }

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -306,13 +306,13 @@ class PostgresExporter {
       switch (comment.type) {
         case 'table': {
           line += ` TABLE ${shouldPrintSchema(schema, model)
-            ? `"${schema.name}".` : ''}"${table.name}" IS '${table.note.replace(/'/g, '\"')}'`;
+            ? `"${schema.name}".` : ''}"${table.name}" IS '${table.note.replace(/'/g, "\"")}'`;
           break;
         }
         case 'column': {
           const field = model.fields[comment.fieldId];
           line += ` COLUMN ${shouldPrintSchema(schema, model)
-            ? `"${schema.name}".` : ''}"${table.name}"."${field.name}" IS '${field.note.replace(/'/g, '\"')}'`;
+            ? `"${schema.name}".` : ''}"${table.name}"."${field.name}" IS '${field.note.replace(/'/g, "\"")}'`;
           break;
         }
         default:

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -153,14 +153,14 @@ class PostgresExporter {
     return keyFields;
   }
 
-  static buildTableManyToMany (keyTable1, keyTable2, tableName) {
+  static buildTableManyToMany (keyTableFirst, keyTableSecond, tableName) {
     let line = `CREATE TABLE "${tableName}" (\n`;
-    const key1s = [...keyTable1.keys()].join('", "');
-    const key2s = [...keyTable2.keys()].join('", "');
-    keyTable1.forEach((value, key) => {
+    const key1s = [...keyTableFirst.keys()].join('", "');
+    const key2s = [...keyTableSecond.keys()].join('", "');
+    keyTableFirst.forEach((value, key) => {
       line += `  "${key}" ${value} NOT NULL,\n`;
     });
-    keyTable2.forEach((value, key) => {
+    keyTableSecond.forEach((value, key) => {
       line += `  "${key}" ${value} NOT NULL,\n`;
     });
     line += `  CONSTRAINT PK_${tableName} PRIMARY KEY ("${key1s}", "${key2s}")\n`;
@@ -222,21 +222,21 @@ class PostgresExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'postgres');
 
       if (refOneIndex === -1) { // many to many relationship
-        const keyTable1 = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'postgres');
-        const keyTable2 = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTable1);
+        const keyTableFirst = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'postgres');
+        const keyTableSecond = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTableFirst);
 
         const nameNewTable = this.buildNameNewTable(refEndpointTable.name, foreignEndpointTable.name, model.tables);
-        line += this.buildTableManyToMany(keyTable1, keyTable2, nameNewTable);
+        line += this.buildTableManyToMany(keyTableFirst, keyTableSecond, nameNewTable);
 
-        if (keyTable1.size > 1) {
-          line += this.buildIndexManytoMany(keyTable1, nameNewTable, refEndpointTable.name);
+        if (keyTableFirst.size > 1) {
+          line += this.buildIndexManytoMany(keyTableFirst, nameNewTable, refEndpointTable.name);
         }
 
-        if (keyTable2.size > 1) {
-          line += this.buildIndexManytoMany(keyTable2, nameNewTable, foreignEndpointTable.name);
+        if (keyTableSecond.size > 1) {
+          line += this.buildIndexManytoMany(keyTableSecond, nameNewTable, foreignEndpointTable.name);
         }
-        line += this.buildForeignKeyManyToMany(keyTable1, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(keyTable2, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(keyTableFirst, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(keyTableSecond, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `"${foreignEndpointSchema.name}".` : ''}"${foreignEndpointTable.name}" ADD `;

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -221,7 +221,7 @@ class PostgresExporter {
       const foreignEndpointSchema = model.schemas[foreignEndpointTable.schemaId];
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'postgres');
 
-      if (refOneIndex === -1) {
+      if (refOneIndex === -1) { // many to many relationship
         const keyTable1 = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'postgres');
         const keyTable2 = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTable1);
 

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -306,13 +306,13 @@ class PostgresExporter {
       switch (comment.type) {
         case 'table': {
           line += ` TABLE ${shouldPrintSchema(schema, model)
-            ? `"${schema.name}".` : ''}"${table.name}" IS '${table.note.replace(/'/g, '"')}'`;
+            ? `"${schema.name}".` : ''}"${table.name}" IS '${table.note.replace(/'/g, '\"')}'`;
           break;
         }
         case 'column': {
           const field = model.fields[comment.fieldId];
           line += ` COLUMN ${shouldPrintSchema(schema, model)
-            ? `"${schema.name}".` : ''}"${table.name}"."${field.name}" IS '${field.note.replace(/'/g, '"')}'`;
+            ? `"${schema.name}".` : ''}"${table.name}"."${field.name}" IS '${field.note.replace(/'/g, '\"')}'`;
           break;
         }
         default:

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -197,7 +197,7 @@ class PostgresExporter {
         const firstTableFieldsMap = buildJunctionFields1(refEndpoint.fieldIds, model);
         const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
-        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, usedTableNames);
+        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
         line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
         if (firstTableFieldsMap.size > 1) {

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -178,7 +178,7 @@ class SqlServerExporter {
         const firstTableFieldsMap = buildJunctionFields1(refEndpoint.fieldIds, model);
         const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
-        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, usedTableNames);
+        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
         line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
         if (firstTableFieldsMap.size > 1) {

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -107,55 +107,59 @@ class SqlServerExporter {
     return tableStrs;
   }
 
-  static buildFieldKeyTableFirst (fieldIds, model) {
-    const keyFields = new Map();
-    fieldIds.map(fieldId => keyFields.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
-    return keyFields;
+  static buildJunctionFields1 (fieldIds, model) {
+    const mapFieldKeys = new Map();
+    fieldIds.map(fieldId => mapFieldKeys.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
+    return mapFieldKeys;
   }
 
-  static buildFieldKeyTableSecond (fieldIds, model, keyTableFirst) {
-    const keyFields = new Map();
+  static buildJunctionFields2 (fieldIds, model, firstTableKey) {
+    const mapFieldKeys = new Map();
     fieldIds.map((fieldId) => {
       let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
       let count = 1;
-      while (true) {
-        if (!keyTableFirst.has(key)) {
-          break;
-        }
+      while (firstTableKey.has(key)) {
         key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
         count += 1;
       }
-      keyFields.set(key, model.fields[fieldId].type.type_name);
+      mapFieldKeys.set(key, model.fields[fieldId].type.type_name);
     });
-    return keyFields;
+    return mapFieldKeys;
   }
 
-  static buildTableManyToMany (keyTableFirst, keyTableSecond, tableName) {
+  static buildTableManyToMany (firstTableKey, secondTableKey, tableName) {
     let line = `CREATE TABLE [${tableName}] (\n`;
-    const key1s = [...keyTableFirst.keys()].join('], [');
-    const key2s = [...keyTableSecond.keys()].join('], [');
-    keyTableFirst.forEach((value, key) => {
+    const key1s = [...firstTableKey.keys()].join('], [');
+    const key2s = [...secondTableKey.keys()].join('], [');
+    firstTableKey.forEach((value, key) => {
       line += `  [${key}] ${value} NOT NULL,\n`;
     });
-    keyTableSecond.forEach((value, key) => {
+    secondTableKey.forEach((value, key) => {
       line += `  [${key}] ${value} NOT NULL,\n`;
     });
-    line += `  CONSTRAINT PK_${tableName} PRIMARY KEY ([${key1s}], [${key2s}])\n`;
+    line += `  PRIMARY KEY ([${key1s}], [${key2s}])\n`;
     line += ');\nGO\n\n';
     return line;
   }
 
-  static buildForeignKeyManyToMany (keyTable, keyForeign, nameTable, nameForeign, schema, model) {
-    const key = [...keyTable.keys()].join('], [');
-    const line = `ALTER TABLE [${nameTable}] ADD FOREIGN KEY ([${key}]) REFERENCES ${shouldPrintSchema(schema, model)
-      ? `[${schema.name}].` : ''}[${nameForeign}] ${keyForeign};\nGO\n\n`;
+
+  static buildForeignKeyManyToMany (mapFieldKeys, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+    const refEndpointFields = [...mapFieldKeys.keys()].join('], [');
+    const line = `ALTER TABLE [${refEndpointTableName}] ADD FOREIGN KEY ([${refEndpointFields}]) REFERENCES ${shouldPrintSchema(schema, model)
+      ? `[${schema.name}].` : ''}[${foreignEndpointTableName}] ${foreignEndpointFields};\nGO\n\n`;
     return line;
   }
 
-  static buildIndexManytoMany (keyTable, nameNewTable, nameTableRef) {
-    const key = [...keyTable.keys()].join('", "');
-    let line = `CREATE INDEX idx_${nameNewTable}_${nameTableRef} ON [${nameNewTable}] (`;
-    line += `"${key}");\nGO\n\n`;
+  static buildIndexManytoMany (keyTable, newTableName, nameTableRef, indexes, setIndexNewTableName) {
+    let indexNewTableName = `${newTableName}_${nameTableRef}`;
+    let count = 1;
+    while ((Object.values(indexes).findIndex((index) => index.name === indexNewTableName) !== -1) || setIndexNewTableName.has(indexNewTableName)) {
+      indexNewTableName = `${newTableName}_${nameTableRef}(${count})`;
+      count += 1;
+    }
+    const indexFields = [...keyTable.keys()].join('", "');
+    let line = `CREATE INDEX [idx_${indexNewTableName}] ON [${newTableName}] (`;
+    line += `"${indexFields}");\nGO\n\n`;
     return line;
   }
 
@@ -164,20 +168,20 @@ class SqlServerExporter {
     return `(${fieldNames})`;
   }
 
-  static buildNameNewTable (tableFirst, tableSecond, tables) {
-    let nameNewTable = `${tableFirst}_${tableSecond}`;
+  static buildNewTableName (firstTable, secondTable, tables, setNewTableName) {
+    let nameNewTable = `${firstTable}_${secondTable}`;
     let count = 1;
-    while (true) {
-      if (Object.values(tables).findIndex((table) => table.name === nameNewTable) === -1) {
-        break;
-      }
-      nameNewTable = `${tableFirst}_${tableSecond}(${count})`;
+    while ((Object.values(tables).findIndex((table) => table.name === nameNewTable) !== -1) || setNewTableName.has(nameNewTable)) {
+      nameNewTable = `${firstTable}_${secondTable}(${count})`;
       count += 1;
     }
+    setNewTableName.add(nameNewTable);
     return nameNewTable;
   }
 
   static exportRefs (refIds, model) {
+    let setNewTableName = new Set();
+    let setIndexNewTableName = new Set();
     const strArr = refIds.map((refId) => {
       let line = '';
       const ref = model.refs[refId];
@@ -199,21 +203,21 @@ class SqlServerExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mssql');
 
       if (refOneIndex === -1) { // many to many relationship
-        const keyTableFirst = this.buildFieldKeyTableFirst(refEndpoint.fieldIds, model, 'mssql');
-        const keyTableSecond = this.buildFieldKeyTableSecond(foreignEndpoint.fieldIds, model, keyTableFirst);
+        const firstTableKey = this.buildJunctionFields1(refEndpoint.fieldIds, model, 'postgres');
+        const secondTableKey = this.buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableKey);
 
-        const nameNewTable = this.buildNameNewTable(refEndpointTable.name, foreignEndpointTable.name, model.tables);
-        line += this.buildTableManyToMany(keyTableFirst, keyTableSecond, nameNewTable);
+        const nameNewTable = this.buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, setNewTableName);
+        line += this.buildTableManyToMany(firstTableKey, secondTableKey, nameNewTable);
 
-        if (keyTableFirst.size > 1) {
-          line += this.buildIndexManytoMany(keyTableFirst, nameNewTable, refEndpointTable.name);
+        if (firstTableKey.size > 1) {
+          line += this.buildIndexManytoMany(firstTableKey, nameNewTable, refEndpointTable.name, model.tables, setIndexNewTableName);
         }
 
-        if (keyTableSecond.size > 1) {
-          line += this.buildIndexManytoMany(keyTableSecond, nameNewTable, foreignEndpointTable.name);
+        if (secondTableKey.size > 1) {
+          line += this.buildIndexManytoMany(secondTableKey, nameNewTable, foreignEndpointTable.name, model.tables, setIndexNewTableName);
         }
-        line += this.buildForeignKeyManyToMany(keyTableFirst, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(keyTableSecond, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableKey, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableKey, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `[${foreignEndpointSchema.name}].` : ''}[${foreignEndpointTable.name}] ADD `;

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -1,5 +1,10 @@
 import _ from 'lodash';
-import { shouldPrintSchema } from './utils';
+import {
+  shouldPrintSchema,
+  buildJunctionFields1,
+  buildJunctionFields2,
+  buildNewTableName,
+} from './utils';
 
 class SqlServerExporter {
   static getFieldLines (tableId, model) {
@@ -107,58 +112,38 @@ class SqlServerExporter {
     return tableStrs;
   }
 
-  static buildJunctionFields1 (fieldIds, model) {
-    const mapFieldKeys = new Map();
-    fieldIds.map(fieldId => mapFieldKeys.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
-    return mapFieldKeys;
-  }
-
-  static buildJunctionFields2 (fieldIds, model, firstTableKey) {
-    const mapFieldKeys = new Map();
-    fieldIds.map((fieldId) => {
-      let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
-      let count = 1;
-      while (firstTableKey.has(fieldName)) {
-        fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
-        count += 1;
-      }
-      mapFieldKeys.set(fieldName, model.fields[fieldId].type.type_name);
-    });
-    return mapFieldKeys;
-  }
-
-  static buildTableManyToMany (firstTableKey, secondTableKey, tableName) {
+  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName) {
     let line = `CREATE TABLE [${tableName}] (\n`;
-    const key1s = [...firstTableKey.keys()].join('], [');
-    const key2s = [...secondTableKey.keys()].join('], [');
-    firstTableKey.forEach((value, key) => {
-      line += `  [${key}] ${value} NOT NULL,\n`;
+    const key1s = [...firstTableFieldsMap.keys()].join('], [');
+    const key2s = [...secondTableFieldsMap.keys()].join('], [');
+    firstTableFieldsMap.forEach((fieldType, fieldName) => {
+      line += `  [${fieldName}] ${fieldType} NOT NULL,\n`;
     });
-    secondTableKey.forEach((value, key) => {
-      line += `  [${key}] ${value} NOT NULL,\n`;
+    secondTableFieldsMap.forEach((fieldType, fieldName) => {
+      line += `  [${fieldName}] ${fieldType} NOT NULL,\n`;
     });
     line += `  PRIMARY KEY ([${key1s}], [${key2s}])\n`;
     line += ');\nGO\n\n';
     return line;
   }
 
-
-  static buildForeignKeyManyToMany (mapFieldKeys, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
-    const refEndpointFields = [...mapFieldKeys.keys()].join('], [');
+  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+    const refEndpointFields = [...fieldsMap.keys()].join('], [');
     const line = `ALTER TABLE [${refEndpointTableName}] ADD FOREIGN KEY ([${refEndpointFields}]) REFERENCES ${shouldPrintSchema(schema, model)
       ? `[${schema.name}].` : ''}[${foreignEndpointTableName}] ${foreignEndpointFields};\nGO\n\n`;
     return line;
   }
 
-  static buildIndexManytoMany (keyTable, newTableName, nameTableRef, indexes, setIndexNewTableName) {
-    let indexNewTableName = `${newTableName}_${nameTableRef}`;
+  static buildIndexManytoMany (fieldsMap, newTableName, tableRefName, usedIndexNames) {
+    let newIndexName = `${newTableName}_${tableRefName}`;
     let count = 1;
-    while ((Object.values(indexes).findIndex((index) => index.name === indexNewTableName) !== -1) || setIndexNewTableName.has(indexNewTableName)) {
-      indexNewTableName = `${newTableName}_${nameTableRef}(${count})`;
+    while (usedIndexNames.has(newIndexName)) {
+      newIndexName = `${newTableName}_${tableRefName}(${count})`;
       count += 1;
     }
-    const indexFields = [...keyTable.keys()].join('", "');
-    let line = `CREATE INDEX [idx_${indexNewTableName}] ON [${newTableName}] (`;
+    usedIndexNames.add(newIndexName);
+    const indexFields = [...fieldsMap.keys()].join('", "');
+    let line = `CREATE INDEX [idx_${newIndexName}] ON [${newTableName}] (`;
     line += `"${indexFields}");\nGO\n\n`;
     return line;
   }
@@ -168,20 +153,7 @@ class SqlServerExporter {
     return `(${fieldNames})`;
   }
 
-  static buildNewTableName (firstTable, secondTable, tables, setNewTableName) {
-    let nameNewTable = `${firstTable}_${secondTable}`;
-    let count = 1;
-    while ((Object.values(tables).findIndex((table) => table.name === nameNewTable) !== -1) || setNewTableName.has(nameNewTable)) {
-      nameNewTable = `${firstTable}_${secondTable}(${count})`;
-      count += 1;
-    }
-    setNewTableName.add(nameNewTable);
-    return nameNewTable;
-  }
-
-  static exportRefs (refIds, model) {
-    let setNewTableName = new Set();
-    let setIndexNewTableName = new Set();
+  static exportRefs (refIds, model, usedTableNames, usedIndexNames) {
     const strArr = refIds.map((refId) => {
       let line = '';
       const ref = model.refs[refId];
@@ -203,21 +175,21 @@ class SqlServerExporter {
       const foreignEndpointFieldName = this.buildFieldName(foreignEndpoint.fieldIds, model, 'mssql');
 
       if (refOneIndex === -1) { // many to many relationship
-        const firstTableKey = this.buildJunctionFields1(refEndpoint.fieldIds, model, 'postgres');
-        const secondTableKey = this.buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableKey);
+        const firstTableFieldsMap = buildJunctionFields1(refEndpoint.fieldIds, model);
+        const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
-        const nameNewTable = this.buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, setNewTableName);
-        line += this.buildTableManyToMany(firstTableKey, secondTableKey, nameNewTable);
+        const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, model.tables, usedTableNames);
+        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
-        if (firstTableKey.size > 1) {
-          line += this.buildIndexManytoMany(firstTableKey, nameNewTable, refEndpointTable.name, model.tables, setIndexNewTableName);
+        if (firstTableFieldsMap.size > 1) {
+          line += this.buildIndexManytoMany(firstTableFieldsMap, newTableName, refEndpointTable.name, usedIndexNames);
         }
 
-        if (secondTableKey.size > 1) {
-          line += this.buildIndexManytoMany(secondTableKey, nameNewTable, foreignEndpointTable.name, model.tables, setIndexNewTableName);
+        if (secondTableFieldsMap.size > 1) {
+          line += this.buildIndexManytoMany(secondTableFieldsMap, newTableName, foreignEndpointTable.name, usedIndexNames);
         }
-        line += this.buildForeignKeyManyToMany(firstTableKey, refEndpointFieldName, nameNewTable, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(secondTableKey, foreignEndpointFieldName, nameNewTable, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `[${foreignEndpointSchema.name}].` : ''}[${foreignEndpointTable.name}] ADD `;
@@ -317,6 +289,9 @@ class SqlServerExporter {
   static export (model) {
     const database = model.database['1'];
 
+    const usedTableNames = new Set(Object.values(model.tables).map(table => table.name));
+    const usedIndexNames = new Set(Object.values(model.indexes).map(index => index.name));
+
     const statements = database.schemaIds.reduce((prevStatements, schemaId) => {
       const schema = model.schemas[schemaId];
       const { tableIds, refIds } = schema;
@@ -346,7 +321,7 @@ class SqlServerExporter {
       }
 
       if (!_.isEmpty(refIds)) {
-        prevStatements.refs.push(...SqlServerExporter.exportRefs(refIds, model));
+        prevStatements.refs.push(...SqlServerExporter.exportRefs(refIds, model, usedTableNames, usedIndexNames));
       }
 
       return prevStatements;

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -116,13 +116,13 @@ class SqlServerExporter {
   static buildJunctionFields2 (fieldIds, model, firstTableKey) {
     const mapFieldKeys = new Map();
     fieldIds.map((fieldId) => {
-      let key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
+      let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
       let count = 1;
-      while (firstTableKey.has(key)) {
-        key = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
+      while (firstTableKey.has(fieldName)) {
+        fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
         count += 1;
       }
-      mapFieldKeys.set(key, model.fields[fieldId].type.type_name);
+      mapFieldKeys.set(fieldName, model.fields[fieldId].type.type_name);
     });
     return mapFieldKeys;
   }

--- a/packages/dbml-core/src/export/utils.js
+++ b/packages/dbml-core/src/export/utils.js
@@ -7,3 +7,35 @@ export function hasWhiteSpace (s) {
 export function shouldPrintSchema (schema, model) {
   return schema.name !== DEFAULT_SCHEMA_NAME || (schema.name === DEFAULT_SCHEMA_NAME && model.database['1'].hasDefaultSchema);
 }
+
+
+export function buildJunctionFields1 (fieldIds, model) {
+  const fieldsMap = new Map();
+  fieldIds.map(fieldId => fieldsMap.set(`${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`, model.fields[fieldId].type.type_name));
+  return fieldsMap;
+}
+
+export function buildJunctionFields2 (fieldIds, model, firstTableFieldsMap) {
+  const fieldsMap = new Map();
+  fieldIds.map((fieldId) => {
+    let fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}`;
+    let count = 1;
+    while (firstTableFieldsMap.has(fieldName)) {
+      fieldName = `${model.tables[model.fields[fieldId].tableId].name}_${model.fields[fieldId].name}(${count})`;
+      count += 1;
+    }
+    fieldsMap.set(fieldName, model.fields[fieldId].type.type_name);
+  });
+  return fieldsMap;
+}
+
+export function buildNewTableName (firstTable, secondTable, tables, usedTableNames) {
+  let newTableName = `${firstTable}_${secondTable}`;
+  let count = 1;
+  while (usedTableNames.has(newTableName)) {
+    newTableName = `${firstTable}_${secondTable}(${count})`;
+    count += 1;
+  }
+  usedTableNames.add(newTableName);
+  return newTableName;
+}

--- a/packages/dbml-core/src/export/utils.js
+++ b/packages/dbml-core/src/export/utils.js
@@ -29,7 +29,7 @@ export function buildJunctionFields2 (fieldIds, model, firstTableFieldsMap) {
   return fieldsMap;
 }
 
-export function buildNewTableName (firstTable, secondTable, tables, usedTableNames) {
+export function buildNewTableName (firstTable, secondTable, usedTableNames) {
   let newTableName = `${firstTable}_${secondTable}`;
   let count = 1;
   while (usedTableNames.has(newTableName)) {

--- a/packages/dbml-core/src/parse/dbml/parser.pegjs
+++ b/packages/dbml-core/src/parse/dbml/parser.pegjs
@@ -619,7 +619,7 @@ set_null "set null" = "set null"i
 set_default "set default" = "set default"i
 
 // Commonly used tokens
-relation ">, - or <" = '<>' / '>' / '<' / '-'
+relation "<>, >, - or <" = '<>' / '>' / '<' / '-'
 name "valid name"
   = c:(character+) { return c.join("") }
   / quote c:[^\"\n]+ quote { return c.join("") }

--- a/packages/dbml-core/src/parse/dbml/parser.pegjs
+++ b/packages/dbml-core/src/parse/dbml/parser.pegjs
@@ -9,6 +9,12 @@
     project: {},
   };
   let projectCnt = 0;
+  function getRelations(operator) {
+    if(operator === '<>') return ['*','*'];
+    if(operator === '>') return ['*','1'];
+    if(operator === '<') return ['1','*'];
+    if(operator === '-') return ['1','1'];
+  }
 }
 
 rules
@@ -173,19 +179,20 @@ ref_short
 
 ref_body
   = field1:field_identifier sp+ relation:relation sp+ field2:field_identifier sp* ref_settings:RefSettings? {
+    const rel = getRelations(relation);
     const endpoints = [
       {
         schemaName: field1.schemaName,
         tableName: field1.tableName,
         fieldNames: field1.fieldNames,
-        relation: relation === ">" ? "*" : "1",
+        relation: rel[0],
         token: location()
       },
       {
         schemaName: field2.schemaName,
         tableName: field2.tableName,
         fieldNames: field2.fieldNames,
-        relation: relation === "<" ? "*" : "1",
+        relation: rel[1],
         token: location()
       }
     ];
@@ -243,19 +250,20 @@ TableSyntax
 
       fields.forEach((field) => {
         (field.inline_refs || []).forEach((iref) => {
+          const rel = getRelations(iref.relation);
           const endpoints = [
           {
             schemaName: iref.schemaName,
             tableName: iref.tableName,
             fieldNames: iref.fieldNames,
-            relation: iref.relation === "<" ? "*" : "1",
+            relation: rel[1],
             token: iref.token
           },
           {
             schemaName: schemaName,
             tableName: name,
             fieldNames: [field.name],
-            relation: iref.relation === ">" ? "*" : "1",
+            relation: rel[0],
             token: iref.token
           }];
 
@@ -611,7 +619,7 @@ set_null "set null" = "set null"i
 set_default "set default" = "set default"i
 
 // Commonly used tokens
-relation ">, - or <" = [>\-<]
+relation ">, - or <" = '<>' / '>' / '<' / '-'
 name "valid name"
   = c:(character+) { return c.join("") }
   / quote c:[^\"\n]+ quote { return c.join("") }

--- a/packages/dbml-core/src/parse/dbmlParser.js
+++ b/packages/dbml-core/src/parse/dbmlParser.js
@@ -279,19 +279,20 @@ function peg$parse(input, options) {
             return ref;
           },
       peg$c25 = function(field1, relation, field2, ref_settings) {
+          const rel = getRelations(relation);
           const endpoints = [
             {
               schemaName: field1.schemaName,
               tableName: field1.tableName,
               fieldNames: field1.fieldNames,
-              relation: relation === ">" ? "*" : "1",
+              relation: rel[0],
               token: location()
             },
             {
               schemaName: field2.schemaName,
               tableName: field2.tableName,
               fieldNames: field2.fieldNames,
-              relation: relation === "<" ? "*" : "1",
+              relation: rel[1],
               token: location()
             }
           ];
@@ -345,19 +346,20 @@ function peg$parse(input, options) {
 
             fields.forEach((field) => {
               (field.inline_refs || []).forEach((iref) => {
+                const rel = getRelations(iref.relation);
                 const endpoints = [
                 {
                   schemaName: iref.schemaName,
                   tableName: iref.tableName,
                   fieldNames: iref.fieldNames,
-                  relation: iref.relation === "<" ? "*" : "1",
+                  relation: rel[1],
                   token: iref.token
                 },
                 {
                   schemaName: schemaName,
                   tableName: name,
                   fieldNames: [field.name],
-                  relation: iref.relation === ">" ? "*" : "1",
+                  relation: rel[0],
                   token: iref.token
                 }];
 
@@ -680,22 +682,28 @@ function peg$parse(input, options) {
       peg$c152 = "set default",
       peg$c153 = peg$literalExpectation("set default", true),
       peg$c154 = peg$otherExpectation(">, - or <"),
-      peg$c155 = /^[>\-<]/,
-      peg$c156 = peg$classExpectation([">", "-", "<"], false, false),
-      peg$c157 = peg$otherExpectation("valid name"),
-      peg$c158 = function(c) { return c.join("") },
-      peg$c159 = /^[^"\n]/,
-      peg$c160 = peg$classExpectation(["\"", "\n"], true, false),
-      peg$c161 = peg$otherExpectation("schema name"),
-      peg$c162 = ".",
-      peg$c163 = peg$literalExpectation(".", false),
-      peg$c164 = function(name) { return name },
-      peg$c165 = function(schemaName, tableName, fieldNames) { return { schemaName, tableName, fieldNames } },
-      peg$c166 = function(tableName, fieldNames) { return { schemaName: null, tableName, fieldNames } },
-      peg$c167 = function(schemaName, tableName, fieldName) { return { schemaName, tableName, fieldName } },
-      peg$c168 = function(tableName, fieldName) { return { schemaName: null, tableName, fieldName } },
-      peg$c169 = peg$otherExpectation("type"),
-      peg$c170 = function(type_name, args) {
+      peg$c155 = "<>",
+      peg$c156 = peg$literalExpectation("<>", false),
+      peg$c157 = ">",
+      peg$c158 = peg$literalExpectation(">", false),
+      peg$c159 = "<",
+      peg$c160 = peg$literalExpectation("<", false),
+      peg$c161 = "-",
+      peg$c162 = peg$literalExpectation("-", false),
+      peg$c163 = peg$otherExpectation("valid name"),
+      peg$c164 = function(c) { return c.join("") },
+      peg$c165 = /^[^"\n]/,
+      peg$c166 = peg$classExpectation(["\"", "\n"], true, false),
+      peg$c167 = peg$otherExpectation("schema name"),
+      peg$c168 = ".",
+      peg$c169 = peg$literalExpectation(".", false),
+      peg$c170 = function(name) { return name },
+      peg$c171 = function(schemaName, tableName, fieldNames) { return { schemaName, tableName, fieldNames } },
+      peg$c172 = function(tableName, fieldNames) { return { schemaName: null, tableName, fieldNames } },
+      peg$c173 = function(schemaName, tableName, fieldName) { return { schemaName, tableName, fieldName } },
+      peg$c174 = function(tableName, fieldName) { return { schemaName: null, tableName, fieldName } },
+      peg$c175 = peg$otherExpectation("type"),
+      peg$c176 = function(type_name, args) {
         args = args ? args[3] : null;
 
       	if (type_name.toLowerCase() !== 'enum') {
@@ -707,67 +715,67 @@ function peg$parse(input, options) {
       		args
       	}
       },
-      peg$c171 = peg$otherExpectation("expression"),
-      peg$c172 = function(factors) {
+      peg$c177 = peg$otherExpectation("expression"),
+      peg$c178 = function(factors) {
       	return _.flattenDeep(factors).join("");
       },
-      peg$c173 = ",",
-      peg$c174 = peg$literalExpectation(",", false),
-      peg$c175 = ");",
-      peg$c176 = peg$literalExpectation(");", false),
-      peg$c177 = peg$anyExpectation(),
-      peg$c178 = function(factors) {
+      peg$c179 = ",",
+      peg$c180 = peg$literalExpectation(",", false),
+      peg$c181 = ");",
+      peg$c182 = peg$literalExpectation(");", false),
+      peg$c183 = peg$anyExpectation(),
+      peg$c184 = function(factors) {
           	return _.flattenDeep(factors).join("");
           },
-      peg$c179 = /^[',.a-z0-9_+-`]/i,
-      peg$c180 = peg$classExpectation(["'", ",", ".", ["a", "z"], ["0", "9"], "_", ["+", "`"]], false, true),
-      peg$c181 = /^['.a-z0-9_+\-]/i,
-      peg$c182 = peg$classExpectation(["'", ".", ["a", "z"], ["0", "9"], "_", "+", "-"], false, true),
-      peg$c183 = function() {return text()},
-      peg$c184 = /^[[\]]/,
-      peg$c185 = peg$classExpectation(["[", "]"], false, false),
-      peg$c186 = peg$otherExpectation("letter, number or underscore"),
-      peg$c187 = /^[a-z0-9_]/i,
-      peg$c188 = peg$classExpectation([["a", "z"], ["0", "9"], "_"], false, true),
-      peg$c189 = /^[0-9a-fA-F]/,
-      peg$c190 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c191 = function(c) {return c.toLowerCase()},
-      peg$c192 = "\"",
-      peg$c193 = peg$literalExpectation("\"", false),
-      peg$c194 = peg$otherExpectation("endline"),
-      peg$c195 = "\t",
-      peg$c196 = peg$literalExpectation("\t", false),
-      peg$c197 = "//",
-      peg$c198 = peg$literalExpectation("//", false),
-      peg$c199 = /^[^\n]/,
-      peg$c200 = peg$classExpectation(["\n"], true, false),
-      peg$c201 = "/*",
-      peg$c202 = peg$literalExpectation("/*", false),
-      peg$c203 = "*/",
-      peg$c204 = peg$literalExpectation("*/", false),
-      peg$c205 = peg$otherExpectation("comment"),
-      peg$c206 = peg$otherExpectation("newline"),
-      peg$c207 = "\r\n",
-      peg$c208 = peg$literalExpectation("\r\n", false),
-      peg$c209 = "\n",
-      peg$c210 = peg$literalExpectation("\n", false),
-      peg$c211 = peg$otherExpectation("whitespace"),
-      peg$c212 = /^[ \t\r\n\r]/,
-      peg$c213 = peg$classExpectation([" ", "\t", "\r", "\n", "\r"], false, false),
-      peg$c214 = /^[ \t\r\n\r"]/,
-      peg$c215 = peg$classExpectation([" ", "\t", "\r", "\n", "\r", "\""], false, false),
-      peg$c216 = " ",
-      peg$c217 = peg$literalExpectation(" ", false),
-      peg$c218 = "#",
-      peg$c219 = peg$literalExpectation("#", false),
-      peg$c220 = function() {return "#"},
-      peg$c221 = peg$otherExpectation("string"),
-      peg$c222 = function(chars) {
+      peg$c185 = /^[',.a-z0-9_+-`]/i,
+      peg$c186 = peg$classExpectation(["'", ",", ".", ["a", "z"], ["0", "9"], "_", ["+", "`"]], false, true),
+      peg$c187 = /^['.a-z0-9_+\-]/i,
+      peg$c188 = peg$classExpectation(["'", ".", ["a", "z"], ["0", "9"], "_", "+", "-"], false, true),
+      peg$c189 = function() {return text()},
+      peg$c190 = /^[[\]]/,
+      peg$c191 = peg$classExpectation(["[", "]"], false, false),
+      peg$c192 = peg$otherExpectation("letter, number or underscore"),
+      peg$c193 = /^[a-z0-9_]/i,
+      peg$c194 = peg$classExpectation([["a", "z"], ["0", "9"], "_"], false, true),
+      peg$c195 = /^[0-9a-fA-F]/,
+      peg$c196 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c197 = function(c) {return c.toLowerCase()},
+      peg$c198 = "\"",
+      peg$c199 = peg$literalExpectation("\"", false),
+      peg$c200 = peg$otherExpectation("endline"),
+      peg$c201 = "\t",
+      peg$c202 = peg$literalExpectation("\t", false),
+      peg$c203 = "//",
+      peg$c204 = peg$literalExpectation("//", false),
+      peg$c205 = /^[^\n]/,
+      peg$c206 = peg$classExpectation(["\n"], true, false),
+      peg$c207 = "/*",
+      peg$c208 = peg$literalExpectation("/*", false),
+      peg$c209 = "*/",
+      peg$c210 = peg$literalExpectation("*/", false),
+      peg$c211 = peg$otherExpectation("comment"),
+      peg$c212 = peg$otherExpectation("newline"),
+      peg$c213 = "\r\n",
+      peg$c214 = peg$literalExpectation("\r\n", false),
+      peg$c215 = "\n",
+      peg$c216 = peg$literalExpectation("\n", false),
+      peg$c217 = peg$otherExpectation("whitespace"),
+      peg$c218 = /^[ \t\r\n\r]/,
+      peg$c219 = peg$classExpectation([" ", "\t", "\r", "\n", "\r"], false, false),
+      peg$c220 = /^[ \t\r\n\r"]/,
+      peg$c221 = peg$classExpectation([" ", "\t", "\r", "\n", "\r", "\""], false, false),
+      peg$c222 = " ",
+      peg$c223 = peg$literalExpectation(" ", false),
+      peg$c224 = "#",
+      peg$c225 = peg$literalExpectation("#", false),
+      peg$c226 = function() {return "#"},
+      peg$c227 = peg$otherExpectation("string"),
+      peg$c228 = function(chars) {
             return { value: chars.join(''), type: 'string' } ;
           },
-      peg$c223 = "'''",
-      peg$c224 = peg$literalExpectation("'''", false),
-      peg$c225 = function(chars) {
+      peg$c229 = "'''",
+      peg$c230 = peg$literalExpectation("'''", false),
+      peg$c231 = function(chars) {
               let str = chars.join('');
               // // replace line continuation using look around, but this is not compatible with firefox, safari.
               // str = str.replace(/(?<!\\)\\(?!\\)(?:\n|\r\n)?/g, ''); 
@@ -800,45 +808,43 @@ function peg$parse(input, options) {
               const finalStr = lines.join('\n');
               return { value: finalStr, type: 'string' } ;
           },
-      peg$c226 = "'",
-      peg$c227 = peg$literalExpectation("'", false),
-      peg$c228 = "\\",
-      peg$c229 = peg$literalExpectation("\\", false),
-      peg$c230 = function() { return '"'; },
-      peg$c231 = function() { return text(); },
-      peg$c232 = "\\'",
-      peg$c233 = peg$literalExpectation("\\'", false),
-      peg$c234 = function() { return "'"; },
-      peg$c235 = function(bl) { // escape character \. \\n => \n. Remove one backslash in the result string.
+      peg$c232 = "'",
+      peg$c233 = peg$literalExpectation("'", false),
+      peg$c234 = "\\",
+      peg$c235 = peg$literalExpectation("\\", false),
+      peg$c236 = function() { return '"'; },
+      peg$c237 = function() { return text(); },
+      peg$c238 = "\\'",
+      peg$c239 = peg$literalExpectation("\\'", false),
+      peg$c240 = function() { return "'"; },
+      peg$c241 = function(bl) { // escape character \. \\n => \n. Remove one backslash in the result string.
          return bl.join('');
        },
-      peg$c236 = function() { // replace line continuation
+      peg$c242 = function() { // replace line continuation
          return ''
        },
-      peg$c237 = /^[0-9]/,
-      peg$c238 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c239 = "=",
-      peg$c240 = peg$literalExpectation("=", false),
-      peg$c241 = "true",
-      peg$c242 = peg$literalExpectation("true", true),
-      peg$c243 = "false",
-      peg$c244 = peg$literalExpectation("false", true),
-      peg$c245 = function(boolean) {
+      peg$c243 = /^[0-9]/,
+      peg$c244 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c245 = "=",
+      peg$c246 = peg$literalExpectation("=", false),
+      peg$c247 = "true",
+      peg$c248 = peg$literalExpectation("true", true),
+      peg$c249 = "false",
+      peg$c250 = peg$literalExpectation("false", true),
+      peg$c251 = function(boolean) {
         return {
           type: 'boolean',
           value: boolean
         };
       },
-      peg$c246 = "-",
-      peg$c247 = peg$literalExpectation("-", false),
-      peg$c248 = function(minus, number) {
+      peg$c252 = function(minus, number) {
         return {
           type: 'number',
           value: minus ? -number : number
         };
       },
-      peg$c249 = function(left, right) { return parseFloat(left.join("") + "." +   right.join("")); },
-      peg$c250 = function(digits) { return parseInt(digits.join(""), 10); },
+      peg$c253 = function(left, right) { return parseFloat(left.join("") + "." +   right.join("")); },
+      peg$c254 = function(digits) { return parseInt(digits.join(""), 10); },
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -4819,12 +4825,39 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    if (peg$c155.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
+    if (input.substr(peg$currPos, 2) === peg$c155) {
+      s0 = peg$c155;
+      peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c156); }
+    }
+    if (s0 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 62) {
+        s0 = peg$c157;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c158); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 60) {
+          s0 = peg$c159;
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+        }
+        if (s0 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 45) {
+            s0 = peg$c161;
+            peg$currPos++;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c162); }
+          }
+        }
+      }
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
@@ -4852,7 +4885,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c158(s1);
+      s1 = peg$c164(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4860,22 +4893,22 @@ function peg$parse(input, options) {
       s1 = peg$parsequote();
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c159.test(input.charAt(peg$currPos))) {
+        if (peg$c165.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c159.test(input.charAt(peg$currPos))) {
+            if (peg$c165.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c166); }
             }
           }
         } else {
@@ -4885,7 +4918,7 @@ function peg$parse(input, options) {
           s3 = peg$parsequote();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c158(s2);
+            s1 = peg$c164(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4903,7 +4936,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
 
     return s0;
@@ -4917,15 +4950,15 @@ function peg$parse(input, options) {
     s1 = peg$parsename();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c162;
+        s2 = peg$c168;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c164(s1);
+        s1 = peg$c170(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4938,7 +4971,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
 
     return s0;
@@ -4951,27 +4984,27 @@ function peg$parse(input, options) {
     s1 = peg$parsename();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c162;
+        s2 = peg$c168;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parsename();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c162;
+            s4 = peg$c168;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c163); }
+            if (peg$silentFails === 0) { peg$fail(peg$c169); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseRefField();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c165(s1, s3, s5);
+              s1 = peg$c171(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4998,17 +5031,17 @@ function peg$parse(input, options) {
       s1 = peg$parsename();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c162;
+          s2 = peg$c168;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseRefField();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c166(s1, s3);
+            s1 = peg$c172(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5034,27 +5067,27 @@ function peg$parse(input, options) {
     s1 = peg$parsename();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c162;
+        s2 = peg$c168;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parsename();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c162;
+            s4 = peg$c168;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c163); }
+            if (peg$silentFails === 0) { peg$fail(peg$c169); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsename();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c167(s1, s3, s5);
+              s1 = peg$c173(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5081,17 +5114,17 @@ function peg$parse(input, options) {
       s1 = peg$parsename();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c162;
+          s2 = peg$c168;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsename();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c168(s1, s3);
+            s1 = peg$c174(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5127,7 +5160,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c158(s1);
+      s1 = peg$c164(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5135,22 +5168,22 @@ function peg$parse(input, options) {
       s1 = peg$parsequote();
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c159.test(input.charAt(peg$currPos))) {
+        if (peg$c165.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c159.test(input.charAt(peg$currPos))) {
+            if (peg$c165.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c166); }
             }
           }
         } else {
@@ -5160,7 +5193,7 @@ function peg$parse(input, options) {
           s3 = peg$parsequote();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c158(s2);
+            s1 = peg$c164(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5178,7 +5211,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
 
     return s0;
@@ -5262,7 +5295,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c176(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5275,7 +5308,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
 
     return s0;
@@ -5294,13 +5327,13 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c172(s1);
+      s1 = peg$c178(s1);
     }
     s0 = s1;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c171); }
+      if (peg$silentFails === 0) { peg$fail(peg$c177); }
     }
 
     return s0;
@@ -5426,30 +5459,30 @@ function peg$parse(input, options) {
           }
           if (s4 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c173;
+              s4 = peg$c179;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c174); }
+              if (peg$silentFails === 0) { peg$fail(peg$c180); }
             }
             if (s4 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c175) {
-                s4 = peg$c175;
+              if (input.substr(peg$currPos, 2) === peg$c181) {
+                s4 = peg$c181;
                 peg$currPos += 2;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c176); }
+                if (peg$silentFails === 0) { peg$fail(peg$c182); }
               }
               if (s4 === peg$FAILED) {
                 s4 = peg$currPos;
                 s5 = peg$parseendline();
                 if (s5 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c175) {
-                    s6 = peg$c175;
+                  if (input.substr(peg$currPos, 2) === peg$c181) {
+                    s6 = peg$c181;
                     peg$currPos += 2;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c176); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c182); }
                   }
                   if (s6 !== peg$FAILED) {
                     s5 = [s5, s6];
@@ -5503,7 +5536,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c177); }
+              if (peg$silentFails === 0) { peg$fail(peg$c183); }
             }
             peg$silentFails--;
             if (s4 !== peg$FAILED) {
@@ -5528,7 +5561,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c178(s1);
+      s1 = peg$c184(s1);
     }
     s0 = s1;
 
@@ -5538,12 +5571,12 @@ function peg$parse(input, options) {
   function peg$parseexprChar() {
     var s0;
 
-    if (peg$c179.test(input.charAt(peg$currPos))) {
+    if (peg$c185.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c180); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$parsesp();
@@ -5561,12 +5594,12 @@ function peg$parse(input, options) {
   function peg$parseexprCharNoCommaSpace() {
     var s0;
 
-    if (peg$c181.test(input.charAt(peg$currPos))) {
+    if (peg$c187.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c182); }
+      if (peg$silentFails === 0) { peg$fail(peg$c188); }
     }
 
     return s0;
@@ -5610,11 +5643,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c183();
+        s1 = peg$c189();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5633,12 +5666,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parsecharacter();
     if (s0 === peg$FAILED) {
-      if (peg$c184.test(input.charAt(peg$currPos))) {
+      if (peg$c190.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
     }
 
@@ -5649,17 +5682,17 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    if (peg$c187.test(input.charAt(peg$currPos))) {
+    if (peg$c193.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c186); }
+      if (peg$silentFails === 0) { peg$fail(peg$c192); }
     }
 
     return s0;
@@ -5669,16 +5702,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c189.test(input.charAt(peg$currPos))) {
+    if (peg$c195.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c190); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c191(s1);
+      s1 = peg$c197(s1);
     }
     s0 = s1;
 
@@ -5689,11 +5722,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 34) {
-      s0 = peg$c192;
+      s0 = peg$c198;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
 
     return s0;
@@ -5768,7 +5801,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
 
     return s0;
@@ -5778,11 +5811,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c195;
+      s0 = peg$c201;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c202); }
     }
 
     return s0;
@@ -5792,30 +5825,30 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c197) {
-      s1 = peg$c197;
+    if (input.substr(peg$currPos, 2) === peg$c203) {
+      s1 = peg$c203;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c199.test(input.charAt(peg$currPos))) {
+      if (peg$c205.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c200); }
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        if (peg$c199.test(input.charAt(peg$currPos))) {
+        if (peg$c205.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -5837,24 +5870,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c201) {
-      s1 = peg$c201;
+    if (input.substr(peg$currPos, 2) === peg$c207) {
+      s1 = peg$c207;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c203) {
-        s5 = peg$c203;
+      if (input.substr(peg$currPos, 2) === peg$c209) {
+        s5 = peg$c209;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c204); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -5869,7 +5902,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c177); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -5887,12 +5920,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c203) {
-          s5 = peg$c203;
+        if (input.substr(peg$currPos, 2) === peg$c209) {
+          s5 = peg$c209;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -5907,7 +5940,7 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c177); }
+            if (peg$silentFails === 0) { peg$fail(peg$c183); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -5922,12 +5955,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c203) {
-          s3 = peg$c203;
+        if (input.substr(peg$currPos, 2) === peg$c209) {
+          s3 = peg$c209;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -5959,7 +5992,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c211); }
     }
 
     return s0;
@@ -5969,26 +6002,26 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    if (input.substr(peg$currPos, 2) === peg$c207) {
-      s0 = peg$c207;
+    if (input.substr(peg$currPos, 2) === peg$c213) {
+      s0 = peg$c213;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 10) {
-        s0 = peg$c209;
+        s0 = peg$c215;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c210); }
+        if (peg$silentFails === 0) { peg$fail(peg$c216); }
       }
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c212); }
     }
 
     return s0;
@@ -5998,17 +6031,17 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    if (peg$c212.test(input.charAt(peg$currPos))) {
+    if (peg$c218.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c213); }
+      if (peg$silentFails === 0) { peg$fail(peg$c219); }
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c211); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
 
     return s0;
@@ -6018,17 +6051,17 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    if (peg$c214.test(input.charAt(peg$currPos))) {
+    if (peg$c220.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c221); }
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c211); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
 
     return s0;
@@ -6038,11 +6071,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 32) {
-      s0 = peg$c216;
+      s0 = peg$c222;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c217); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
 
     return s0;
@@ -6052,11 +6085,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 44) {
-      s0 = peg$c173;
+      s0 = peg$c179;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
 
     return s0;
@@ -6067,15 +6100,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 35) {
-      s1 = peg$c218;
+      s1 = peg$c224;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c219); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c220();
+      s1 = peg$c226();
     }
     s0 = s1;
 
@@ -6088,11 +6121,11 @@ function peg$parse(input, options) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c192;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -6103,15 +6136,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c192;
+          s3 = peg$c198;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c222(s2);
+          s1 = peg$c228(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6127,12 +6160,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c223) {
-        s1 = peg$c223;
+      if (input.substr(peg$currPos, 3) === peg$c229) {
+        s1 = peg$c229;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c224); }
+        if (peg$silentFails === 0) { peg$fail(peg$c230); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6142,16 +6175,16 @@ function peg$parse(input, options) {
           s3 = peg$parseMultiLineStringCharacter();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c223) {
-            s3 = peg$c223;
+          if (input.substr(peg$currPos, 3) === peg$c229) {
+            s3 = peg$c229;
             peg$currPos += 3;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c224); }
+            if (peg$silentFails === 0) { peg$fail(peg$c230); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c225(s2);
+            s1 = peg$c231(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6168,11 +6201,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 39) {
-          s1 = peg$c226;
+          s1 = peg$c232;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c227); }
+          if (peg$silentFails === 0) { peg$fail(peg$c233); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6183,15 +6216,15 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 39) {
-              s3 = peg$c226;
+              s3 = peg$c232;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c227); }
+              if (peg$silentFails === 0) { peg$fail(peg$c233); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c222(s2);
+              s1 = peg$c228(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6210,7 +6243,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c221); }
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
     }
 
     return s0;
@@ -6221,23 +6254,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c228;
+      s1 = peg$c234;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c192;
+        s2 = peg$c198;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c193); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c230();
+        s1 = peg$c236();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6252,11 +6285,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c192;
+        s2 = peg$c198;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c193); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -6269,7 +6302,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSourceCharacter();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c231();
+          s1 = peg$c237();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6288,16 +6321,16 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c232) {
-      s1 = peg$c232;
+    if (input.substr(peg$currPos, 2) === peg$c238) {
+      s1 = peg$c238;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c234();
+      s1 = peg$c240();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6305,11 +6338,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c226;
+        s2 = peg$c232;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c233); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -6322,7 +6355,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSourceCharacter();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c231();
+          s1 = peg$c237();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6341,45 +6374,45 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c232) {
-      s1 = peg$c232;
+    if (input.substr(peg$currPos, 2) === peg$c238) {
+      s1 = peg$c238;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c234();
+      s1 = peg$c240();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c228;
+        s1 = peg$c234;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c228;
+          s3 = peg$c234;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c229); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
             if (input.charCodeAt(peg$currPos) === 92) {
-              s3 = peg$c228;
+              s3 = peg$c234;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c229); }
+              if (peg$silentFails === 0) { peg$fail(peg$c235); }
             }
           }
         } else {
@@ -6387,7 +6420,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c235(s2);
+          s1 = peg$c241(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6400,26 +6433,26 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c228;
+          s1 = peg$c234;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c229); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 10) {
-            s2 = peg$c209;
+            s2 = peg$c215;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c210); }
+            if (peg$silentFails === 0) { peg$fail(peg$c216); }
           }
           if (s2 === peg$FAILED) {
             s2 = null;
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c236();
+            s1 = peg$c242();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6433,12 +6466,12 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c223) {
-            s2 = peg$c223;
+          if (input.substr(peg$currPos, 3) === peg$c229) {
+            s2 = peg$c229;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c224); }
+            if (peg$silentFails === 0) { peg$fail(peg$c230); }
           }
           peg$silentFails--;
           if (s2 === peg$FAILED) {
@@ -6451,7 +6484,7 @@ function peg$parse(input, options) {
             s2 = peg$parseSourceCharacter();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c231();
+              s1 = peg$c237();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6476,7 +6509,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c183); }
     }
 
     return s0;
@@ -6485,12 +6518,12 @@ function peg$parse(input, options) {
   function peg$parsedigit() {
     var s0;
 
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c243.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
 
     return s0;
@@ -6500,11 +6533,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 61) {
-      s0 = peg$c239;
+      s0 = peg$c245;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
 
     return s0;
@@ -6514,11 +6547,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 46) {
-      s0 = peg$c162;
+      s0 = peg$c168;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c169); }
     }
 
     return s0;
@@ -6528,20 +6561,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c247) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c243) {
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c249) {
         s1 = input.substr(peg$currPos, 5);
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c244); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s1 === peg$FAILED) {
         if (input.substr(peg$currPos, 4).toLowerCase() === peg$c60) {
@@ -6555,7 +6588,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c245(s1);
+      s1 = peg$c251(s1);
     }
     s0 = s1;
 
@@ -6567,11 +6600,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c246;
+      s1 = peg$c161;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -6583,7 +6616,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c248(s1, s2);
+        s1 = peg$c252(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6602,22 +6635,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c243.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c237.test(input.charAt(peg$currPos))) {
+        if (peg$c243.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c244); }
         }
       }
     } else {
@@ -6625,30 +6658,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c162;
+        s2 = peg$c168;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c237.test(input.charAt(peg$currPos))) {
+        if (peg$c243.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c244); }
         }
         if (s4 !== peg$FAILED) {
           while (s4 !== peg$FAILED) {
             s3.push(s4);
-            if (peg$c237.test(input.charAt(peg$currPos))) {
+            if (peg$c243.test(input.charAt(peg$currPos))) {
               s4 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c238); }
+              if (peg$silentFails === 0) { peg$fail(peg$c244); }
             }
           }
         } else {
@@ -6656,7 +6689,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c249(s1, s3);
+          s1 = peg$c253(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6679,22 +6712,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c243.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c237.test(input.charAt(peg$currPos))) {
+        if (peg$c243.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c244); }
         }
       }
     } else {
@@ -6702,7 +6735,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c250(s1);
+      s1 = peg$c254(s1);
     }
     s0 = s1;
 
@@ -6721,6 +6754,12 @@ function peg$parse(input, options) {
       project: {},
     };
     let projectCnt = 0;
+    function getRelations(operator) {
+      if(operator === '<>') return ['*','*'];
+      if(operator === '>') return ['*','1'];
+      if(operator === '<') return ['1','*'];
+      if(operator === '-') return ['1','1'];
+    }
 
 
 


### PR DESCRIPTION
## Summary
* Implement parser for many to many relationship
* Implement export for many to many relationship

## Issue
(https://github.com/holistics/dbml/issues/146#issuecomment-739096912)

## Lasting Changes (Technical)
* Add syntax `<>` for ref in parser.pegjs
* Add function `getRelations(operator)` to get relation for every operator relation in parser.pegjs
* Add function `buildJunctionFields1` to get fields that will the primary key of table first in PosgresExporter, MySqlExporter, SQLServerExporter
* Add function `buildJunctionFields2` to get fields that will the primary key of table second, if fields exist, it wils generate new name  in PosgresExporter, MySqlExporter, SQLServerExporter
* Add function `buildNewTableName` to create name for new table in PosgresExporter, MySqlExporter, SQLServerExporter
*  Add function `buildTableManyToMany` to generate SQL create new table in PosgresExporter, MySqlExporter, SQLServerExporter
* Add function `buildIndexManytoMany ` to generate SQL create  index for fields of new table in PosgresExporter, MySqlExporter, SQLServerExporter
*  Add function `buildForeignKeyManyToMany` to generate SQL create  foregin key for new table in PosgresExporter, MySqlExporter, SQLServerExporter
* Replace the logic handle export ref in `exportRefs.js` 
```   const refOneIndex = ref.endpointIds.findIndex(endpointId => model.endpoints[endpointId].relation === '1');
      const refEndpointIndex = refOneIndex === -1 ? 0 : refOneIndex;
      ......
      if(refOneIndex === -1) { // case [*,*] (many to many)
      .......
      } else { // case [1, *] (one to many), [1, 1],  (one to one) [*,1] (many to one)
      ........   
      }
```
## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review