### PR TITLE
Refactor exporter DBML to SQL with case many to many relationship

### DIFF
--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
@@ -78,18 +78,12 @@ CREATE TABLE [t1_t2] (
 GO
 
 CREATE TABLE [a_b] (
-  [a_AB] integer NOT NULL,
-  [a_BA] integer NOT NULL,
-  [b_BC] integer NOT NULL,
-  [b_CB] integer NOT NULL,
+  [a_AB] integer,
+  [a_BA] integer,
+  [b_BC] integer,
+  [b_CB] integer,
   PRIMARY KEY ([a_AB], [a_BA], [b_BC], [b_CB])
 );
-GO
-
-CREATE INDEX [idx_a_b_a] ON [a_b] ("a_AB", "a_BA");
-GO
-
-CREATE INDEX [idx_a_b_b] ON [a_b] ("b_BC", "b_CB");
 GO
 
 ALTER TABLE [a_b] ADD FOREIGN KEY ([a_AB], [a_BA]) REFERENCES [A].[a] ([AB], [BA]);
@@ -100,8 +94,8 @@ GO
 
 
 CREATE TABLE [d_c] (
-  [d_DE] integer NOT NULL,
-  [c_CD] integer NOT NULL,
+  [d_DE] integer,
+  [c_CD] integer,
   PRIMARY KEY ([d_DE], [c_CD])
 );
 GO
@@ -114,18 +108,12 @@ GO
 
 
 CREATE TABLE [e_g] (
-  [e_EF] integer NOT NULL,
-  [e_FE] integer NOT NULL,
-  [g_GH] integer NOT NULL,
-  [g_HG] integer NOT NULL,
+  [e_EF] integer,
+  [e_FE] integer,
+  [g_GH] integer,
+  [g_HG] integer,
   PRIMARY KEY ([e_EF], [e_FE], [g_GH], [g_HG])
 );
-GO
-
-CREATE INDEX [idx_e_g_e] ON [e_g] ("e_EF", "e_FE");
-GO
-
-CREATE INDEX [idx_e_g_g] ON [e_g] ("g_GH", "g_HG");
 GO
 
 ALTER TABLE [e_g] ADD FOREIGN KEY ([e_EF], [e_FE]) REFERENCES [E].[e] ([EF], [FE]);
@@ -136,8 +124,8 @@ GO
 
 
 CREATE TABLE [t1_t2(1)] (
-  [t1_a] int NOT NULL,
-  [t2_a] int NOT NULL,
+  [t1_a] int,
+  [t2_a] int,
   PRIMARY KEY ([t1_a], [t2_a])
 );
 GO
@@ -150,8 +138,8 @@ GO
 
 
 CREATE TABLE [t1_t2(2)] (
-  [t1_b] int NOT NULL,
-  [t2_b] int NOT NULL,
+  [t1_b] int,
+  [t2_b] int,
   PRIMARY KEY ([t1_b], [t2_b])
 );
 GO

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
@@ -63,16 +63,12 @@ CREATE TABLE `t1_t2` (
 );
 
 CREATE TABLE `a_b` (
-  `a_AB` integer NOT NULL,
-  `a_BA` integer NOT NULL,
-  `b_BC` integer NOT NULL,
-  `b_CB` integer NOT NULL,
+  `a_AB` integer,
+  `a_BA` integer,
+  `b_BC` integer,
+  `b_CB` integer,
   PRIMARY KEY (`a_AB`, `a_BA`, `b_BC`, `b_CB`)
 );
-
-CREATE INDEX `idx_a_b_a` ON `a_b` (`a_AB`, `a_BA`);
-
-CREATE INDEX `idx_a_b_b` ON `a_b` (`b_BC`, `b_CB`);
 
 ALTER TABLE `a_b` ADD FOREIGN KEY (`a_AB`, `a_BA`) REFERENCES `A`.`a` (`AB`, `BA`);
 
@@ -80,8 +76,8 @@ ALTER TABLE `a_b` ADD FOREIGN KEY (`b_BC`, `b_CB`) REFERENCES `B`.`b` (`BC`, `CB
 
 
 CREATE TABLE `d_c` (
-  `d_DE` integer NOT NULL,
-  `c_CD` integer NOT NULL,
+  `d_DE` integer,
+  `c_CD` integer,
   PRIMARY KEY (`d_DE`, `c_CD`)
 );
 
@@ -91,16 +87,12 @@ ALTER TABLE `d_c` ADD FOREIGN KEY (`c_CD`) REFERENCES `C`.`c` (`CD`);
 
 
 CREATE TABLE `e_g` (
-  `e_EF` integer NOT NULL,
-  `e_FE` integer NOT NULL,
-  `g_GH` integer NOT NULL,
-  `g_HG` integer NOT NULL,
+  `e_EF` integer,
+  `e_FE` integer,
+  `g_GH` integer,
+  `g_HG` integer,
   PRIMARY KEY (`e_EF`, `e_FE`, `g_GH`, `g_HG`)
 );
-
-CREATE INDEX `idx_e_g_e` ON `e_g` (`e_EF`, `e_FE`);
-
-CREATE INDEX `idx_e_g_g` ON `e_g` (`g_GH`, `g_HG`);
 
 ALTER TABLE `e_g` ADD FOREIGN KEY (`e_EF`, `e_FE`) REFERENCES `E`.`e` (`EF`, `FE`);
 
@@ -108,8 +100,8 @@ ALTER TABLE `e_g` ADD FOREIGN KEY (`g_GH`, `g_HG`) REFERENCES `G`.`g` (`GH`, `HG
 
 
 CREATE TABLE `t1_t2(1)` (
-  `t1_a` int NOT NULL,
-  `t2_a` int NOT NULL,
+  `t1_a` int,
+  `t2_a` int,
   PRIMARY KEY (`t1_a`, `t2_a`)
 );
 
@@ -119,8 +111,8 @@ ALTER TABLE `t1_t2(1)` ADD FOREIGN KEY (`t2_a`) REFERENCES `t2` (`a`);
 
 
 CREATE TABLE `t1_t2(2)` (
-  `t1_b` int NOT NULL,
-  `t2_b` int NOT NULL,
+  `t1_b` int,
+  `t2_b` int,
   PRIMARY KEY (`t1_b`, `t2_b`)
 );
 

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
@@ -63,16 +63,12 @@ CREATE TABLE "t1_t2" (
 );
 
 CREATE TABLE "a_b" (
-  "a_AB" integer NOT NULL,
-  "a_BA" integer NOT NULL,
-  "b_BC" integer NOT NULL,
-  "b_CB" integer NOT NULL,
+  "a_AB" integer,
+  "a_BA" integer,
+  "b_BC" integer,
+  "b_CB" integer,
   PRIMARY KEY ("a_AB", "a_BA", "b_BC", "b_CB")
 );
-
-CREATE INDEX "idx_a_b_a" ON "a_b" ("a_AB", "a_BA");
-
-CREATE INDEX "idx_a_b_b" ON "a_b" ("b_BC", "b_CB");
 
 ALTER TABLE "a_b" ADD FOREIGN KEY ("a_AB", "a_BA") REFERENCES "A"."a" ("AB", "BA");
 
@@ -80,8 +76,8 @@ ALTER TABLE "a_b" ADD FOREIGN KEY ("b_BC", "b_CB") REFERENCES "B"."b" ("BC", "CB
 
 
 CREATE TABLE "d_c" (
-  "d_DE" integer NOT NULL,
-  "c_CD" integer NOT NULL,
+  "d_DE" integer,
+  "c_CD" integer,
   PRIMARY KEY ("d_DE", "c_CD")
 );
 
@@ -91,16 +87,12 @@ ALTER TABLE "d_c" ADD FOREIGN KEY ("c_CD") REFERENCES "C"."c" ("CD");
 
 
 CREATE TABLE "e_g" (
-  "e_EF" integer NOT NULL,
-  "e_FE" integer NOT NULL,
-  "g_GH" integer NOT NULL,
-  "g_HG" integer NOT NULL,
+  "e_EF" integer,
+  "e_FE" integer,
+  "g_GH" integer,
+  "g_HG" integer,
   PRIMARY KEY ("e_EF", "e_FE", "g_GH", "g_HG")
 );
-
-CREATE INDEX "idx_e_g_e" ON "e_g" ("e_EF", "e_FE");
-
-CREATE INDEX "idx_e_g_g" ON "e_g" ("g_GH", "g_HG");
 
 ALTER TABLE "e_g" ADD FOREIGN KEY ("e_EF", "e_FE") REFERENCES "E"."e" ("EF", "FE");
 
@@ -108,8 +100,8 @@ ALTER TABLE "e_g" ADD FOREIGN KEY ("g_GH", "g_HG") REFERENCES "G"."g" ("GH", "HG
 
 
 CREATE TABLE "t1_t2(1)" (
-  "t1_a" int NOT NULL,
-  "t2_a" int NOT NULL,
+  "t1_a" int,
+  "t2_a" int,
   PRIMARY KEY ("t1_a", "t2_a")
 );
 
@@ -119,8 +111,8 @@ ALTER TABLE "t1_t2(1)" ADD FOREIGN KEY ("t2_a") REFERENCES "t2" ("a");
 
 
 CREATE TABLE "t1_t2(2)" (
-  "t1_b" int NOT NULL,
-  "t2_b" int NOT NULL,
+  "t1_b" int,
+  "t2_b" int,
   PRIMARY KEY ("t1_b", "t2_b")
 );
 

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -125,10 +125,10 @@ class MySQLExporter {
     const key1s = [...firstTableFieldsMap.keys()].join('`, `');
     const key2s = [...secondTableFieldsMap.keys()].join('`, `');
     firstTableFieldsMap.forEach((fieldType, fieldName) => {
-      line += `  \`${fieldName}\` ${fieldType} NOT NULL,\n`;
+      line += `  \`${fieldName}\` ${fieldType},\n`;
     });
     secondTableFieldsMap.forEach((fieldType, fieldName) => {
-      line += `  \`${fieldName}\` ${fieldType} NOT NULL,\n`;
+      line += `  \`${fieldName}\` ${fieldType},\n`;
     });
     line += `  PRIMARY KEY (\`${key1s}\`, \`${key2s}\`)\n`;
     line += ');\n\n';
@@ -142,22 +142,8 @@ class MySQLExporter {
     return line;
   }
 
-  static buildIndexManytoMany (fieldsMap, newTableName, tableRefName, usedIndexNames) {
-    let newIndexName = `${newTableName}_${tableRefName}`;
-    let count = 1;
-    while (usedIndexNames.has(newIndexName)) {
-      newIndexName = `${newTableName}_${tableRefName}(${count})`;
-      count += 1;
-    }
-    usedIndexNames.add(newIndexName);
-    const indexFields = [...fieldsMap.keys()].join('`, `');
-    let line = `CREATE INDEX \`idx_${newIndexName}\` ON \`${newTableName}\` (`;
-    line += `\`${indexFields}\`);\n\n`;
-    return line;
-  }
 
-
-  static exportRefs (refIds, model, usedTableNames, usedIndexNames) {
+  static exportRefs (refIds, model, usedTableNames) {
     const strArr = refIds.map((refId) => {
       let line = '';
       const ref = model.refs[refId];
@@ -185,13 +171,6 @@ class MySQLExporter {
         const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
         line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
 
-        if (firstTableFieldsMap.size > 1) {
-          line += this.buildIndexManytoMany(firstTableFieldsMap, newTableName, refEndpointTable.name, usedIndexNames);
-        }
-
-        if (secondTableFieldsMap.size > 1) {
-          line += this.buildIndexManytoMany(secondTableFieldsMap, newTableName, foreignEndpointTable.name, usedIndexNames);
-        }
         line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, model);
         line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, foreignEndpointSchema, model);
       } else {
@@ -273,7 +252,6 @@ class MySQLExporter {
     const database = model.database['1'];
 
     const usedTableNames = new Set(Object.values(model.tables).map(table => table.name));
-    const usedIndexNames = new Set(Object.values(model.indexes).map(index => index.name));
 
     const statements = database.schemaIds.reduce((prevStatements, schemaId) => {
       const schema = model.schemas[schemaId];
@@ -301,7 +279,7 @@ class MySQLExporter {
       }
 
       if (!_.isEmpty(refIds)) {
-        prevStatements.refs.push(...MySQLExporter.exportRefs(refIds, model, usedTableNames, usedIndexNames));
+        prevStatements.refs.push(...MySQLExporter.exportRefs(refIds, model, usedTableNames));
       }
 
       return prevStatements;

--- a/packages/dbml-core/src/parse/dbmlParser.js
+++ b/packages/dbml-core/src/parse/dbmlParser.js
@@ -681,7 +681,7 @@ function peg$parse(input, options) {
       peg$c151 = peg$otherExpectation("set default"),
       peg$c152 = "set default",
       peg$c153 = peg$literalExpectation("set default", true),
-      peg$c154 = peg$otherExpectation(">, - or <"),
+      peg$c154 = peg$otherExpectation("<>, >, - or <"),
       peg$c155 = "<>",
       peg$c156 = peg$literalExpectation("<>", false),
       peg$c157 = ">",


### PR DESCRIPTION
## Summary
* Refactor exporter for MSSQL. MySQL, PostgreSQL
* Update parser for many to many

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* Removed `buildIndexManytoMany` in SQLServerExporter, MySqlExporter, PostgresSQLExporter
* Build new parser for dbml
* Removed `usedIndexNames` in exportRef 
* Removed NOT NULL in `buildTableManyToMany`

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review