### PR TITLE
Update type smallserial for increment

### DIFF
--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/smallserial_type.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/smallserial_type.in.dbml
@@ -1,0 +1,29 @@
+Table user {
+  id BIGINT [pk, increment]
+  name int 
+  address varcharacter
+}
+
+Table user1 {
+  id SMALLSERIAL [pk, increment]
+  name int 
+  address varcharacter
+}
+
+Table user2 {
+  id BIGINt [pk, increment]
+  name int 
+  address varcharacter
+}
+
+Table user3 {
+  id smallSERIAL [pk, increment]
+  name int 
+  address varcharacter
+}
+
+Table user4 {
+  id serial [pk, increment]
+  name int 
+  address varcharacter
+}

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/smallserial_type.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/smallserial_type.out.sql
@@ -1,23 +1,23 @@
 CREATE TABLE "user" (
-  "id" SERIAL PRIMARY KEY,
+  "id" BIGSERIAL PRIMARY KEY,
   "name" int,
   "address" varcharacter
 );
 
 CREATE TABLE "user1" (
-  "id" BIGSERIAL PRIMARY KEY,
-  "name" int,
-  "address" varcharacter
-);
-
-CREATE TABLE "user2" (
   "id" SMALLSERIAL PRIMARY KEY,
   "name" int,
   "address" varcharacter
 );
 
-CREATE TABLE "user3" (
+CREATE TABLE "user2" (
   "id" BIGSERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);
+
+CREATE TABLE "user3" (
+  "id" SMALLSERIAL PRIMARY KEY,
   "name" int,
   "address" varcharacter
 );

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/smallserial_type.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/smallserial_type.out.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "user" (
+  "id" SERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);
+
+CREATE TABLE "user1" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);
+
+CREATE TABLE "user2" (
+  "id" SMALLSERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);
+
+CREATE TABLE "user3" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);
+
+CREATE TABLE "user4" (
+  "id" SERIAL PRIMARY KEY,
+  "name" int,
+  "address" varcharacter
+);

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -38,7 +38,7 @@ class PostgresExporter {
       if (field.increment) {
         let typeSerial = 'SERIAL';
         if (field.type.type_name.toLowerCase() === 'bigint') typeSerial = 'BIGSERIAL';
-        if (field.type.type_name.toLowerCase() === 'smallserial') typeSerial = 'SMALLSERIAL';
+        else if (field.type.type_name.toLowerCase() === 'smallserial') typeSerial = 'SMALLSERIAL';
         line = `"${field.name}" ${typeSerial}`;
       } else {
         let schemaName = '';

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -36,7 +36,9 @@ class PostgresExporter {
 
       let line = '';
       if (field.increment) {
-        const typeSerial = field.type.type_name === 'bigint' ? 'BIGSERIAL' : 'SERIAL';
+        let typeSerial = 'SERIAL';
+        if (field.type.type_name.toLowerCase() === 'bigint') typeSerial = 'BIGSERIAL';
+        if (field.type.type_name.toLowerCase() === 'smallserial') typeSerial = 'SMALLSERIAL';
         line = `"${field.name}" ${typeSerial}`;
       } else {
         let schemaName = '';


### PR DESCRIPTION
## Summary
* Added SMALLSERIAL type when using increments in settings to export postgress sql

## Issue
[(issue link here)](https://community.dbdiagram.io/t/wrong-postgres-smallserial-export/1450)

## Lasting Changes (Technical)
* Updated `function getFieldLines` to add type for increment
* Added `smallserial_type.in.dbml and smallserial_type.out.sql`  in test/export/postgresql  to test for smallserial type

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review