### PR TITLE
Add schema name for the junction table of many-to-many relationship

### DIFF
--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/input/many_to_many_relationship.in.dbml
@@ -37,13 +37,13 @@ ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
 
 
 table t1 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t2 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t1_t2 {
@@ -52,3 +52,35 @@ table t1_t2 {
 
 ref: t1.a <> t2.a
 ref: t1.b <> t2.b
+
+Table schema.image {
+  id integer [pk]
+  url varchar
+}
+
+Table schema.content_item {
+  id integer [pk]
+  heading varchar
+  description varchar
+}
+
+Ref: schema.image.id <> schema.content_item.id
+
+Table schema.footer_item {
+  id integer [pk]
+  left varchar
+  centre varchar
+  right varchar
+}
+
+Table "schema1"."customers" {
+  "id" integer [pk]
+  "full_name" varchar
+}
+
+Table "schema2"."orders" {
+  "id" integer [pk]
+  "total_price" integer
+}
+
+Ref: "schema1"."customers"."id" <> "schema2"."orders"."id"

--- a/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mssql_exporter/output/many_to_many_relationship.out.sql
@@ -16,6 +16,15 @@ GO
 CREATE SCHEMA [G]
 GO
 
+CREATE SCHEMA [schema]
+GO
+
+CREATE SCHEMA [schema1]
+GO
+
+CREATE SCHEMA [schema2]
+GO
+
 CREATE TABLE [A].[a] (
   [AB] integer,
   [BA] integer,
@@ -61,14 +70,14 @@ CREATE TABLE [G].[g] (
 GO
 
 CREATE TABLE [t1] (
-  [a] int,
-  [b] int
+  [a] int PRIMARY KEY,
+  [b] int UNIQUE
 )
 GO
 
 CREATE TABLE [t2] (
-  [a] int,
-  [b] int
+  [a] int PRIMARY KEY,
+  [b] int UNIQUE
 )
 GO
 
@@ -77,7 +86,40 @@ CREATE TABLE [t1_t2] (
 )
 GO
 
-CREATE TABLE [a_b] (
+CREATE TABLE [schema].[image] (
+  [id] integer PRIMARY KEY,
+  [url] nvarchar(255)
+)
+GO
+
+CREATE TABLE [schema].[content_item] (
+  [id] integer PRIMARY KEY,
+  [heading] nvarchar(255),
+  [description] nvarchar(255)
+)
+GO
+
+CREATE TABLE [schema].[footer_item] (
+  [id] integer PRIMARY KEY,
+  [left] nvarchar(255),
+  [centre] nvarchar(255),
+  [right] nvarchar(255)
+)
+GO
+
+CREATE TABLE [schema1].[customers] (
+  [id] integer PRIMARY KEY,
+  [full_name] nvarchar(255)
+)
+GO
+
+CREATE TABLE [schema2].[orders] (
+  [id] integer PRIMARY KEY,
+  [total_price] integer
+)
+GO
+
+CREATE TABLE [A].[a_b] (
   [a_AB] integer,
   [a_BA] integer,
   [b_BC] integer,
@@ -86,28 +128,28 @@ CREATE TABLE [a_b] (
 );
 GO
 
-ALTER TABLE [a_b] ADD FOREIGN KEY ([a_AB], [a_BA]) REFERENCES [A].[a] ([AB], [BA]);
+ALTER TABLE [A].[a_b] ADD FOREIGN KEY ([a_AB], [a_BA]) REFERENCES [A].[a] ([AB], [BA]);
 GO
 
-ALTER TABLE [a_b] ADD FOREIGN KEY ([b_BC], [b_CB]) REFERENCES [B].[b] ([BC], [CB]);
+ALTER TABLE [A].[a_b] ADD FOREIGN KEY ([b_BC], [b_CB]) REFERENCES [B].[b] ([BC], [CB]);
 GO
 
 
-CREATE TABLE [d_c] (
+CREATE TABLE [D].[d_c] (
   [d_DE] integer,
   [c_CD] integer,
   PRIMARY KEY ([d_DE], [c_CD])
 );
 GO
 
-ALTER TABLE [d_c] ADD FOREIGN KEY ([d_DE]) REFERENCES [D].[d] ([DE]);
+ALTER TABLE [D].[d_c] ADD FOREIGN KEY ([d_DE]) REFERENCES [D].[d] ([DE]);
 GO
 
-ALTER TABLE [d_c] ADD FOREIGN KEY ([c_CD]) REFERENCES [C].[c] ([CD]);
+ALTER TABLE [D].[d_c] ADD FOREIGN KEY ([c_CD]) REFERENCES [C].[c] ([CD]);
 GO
 
 
-CREATE TABLE [e_g] (
+CREATE TABLE [E].[e_g] (
   [e_EF] integer,
   [e_FE] integer,
   [g_GH] integer,
@@ -116,10 +158,10 @@ CREATE TABLE [e_g] (
 );
 GO
 
-ALTER TABLE [e_g] ADD FOREIGN KEY ([e_EF], [e_FE]) REFERENCES [E].[e] ([EF], [FE]);
+ALTER TABLE [E].[e_g] ADD FOREIGN KEY ([e_EF], [e_FE]) REFERENCES [E].[e] ([EF], [FE]);
 GO
 
-ALTER TABLE [e_g] ADD FOREIGN KEY ([g_GH], [g_HG]) REFERENCES [G].[g] ([GH], [HG]);
+ALTER TABLE [E].[e_g] ADD FOREIGN KEY ([g_GH], [g_HG]) REFERENCES [G].[g] ([GH], [HG]);
 GO
 
 
@@ -148,5 +190,33 @@ ALTER TABLE [t1_t2(2)] ADD FOREIGN KEY ([t1_b]) REFERENCES [t1] ([b]);
 GO
 
 ALTER TABLE [t1_t2(2)] ADD FOREIGN KEY ([t2_b]) REFERENCES [t2] ([b]);
+GO
+
+
+CREATE TABLE [schema].[image_content_item] (
+  [image_id] integer,
+  [content_item_id] integer,
+  PRIMARY KEY ([image_id], [content_item_id])
+);
+GO
+
+ALTER TABLE [schema].[image_content_item] ADD FOREIGN KEY ([image_id]) REFERENCES [schema].[image] ([id]);
+GO
+
+ALTER TABLE [schema].[image_content_item] ADD FOREIGN KEY ([content_item_id]) REFERENCES [schema].[content_item] ([id]);
+GO
+
+
+CREATE TABLE [schema1].[customers_orders] (
+  [customers_id] integer,
+  [orders_id] integer,
+  PRIMARY KEY ([customers_id], [orders_id])
+);
+GO
+
+ALTER TABLE [schema1].[customers_orders] ADD FOREIGN KEY ([customers_id]) REFERENCES [schema1].[customers] ([id]);
+GO
+
+ALTER TABLE [schema1].[customers_orders] ADD FOREIGN KEY ([orders_id]) REFERENCES [schema2].[orders] ([id]);
 GO
 

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/input/many_to_many_relationship.in.dbml
@@ -37,13 +37,13 @@ ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
 
 
 table t1 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t2 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t1_t2 {
@@ -52,3 +52,35 @@ table t1_t2 {
 
 ref: t1.a <> t2.a
 ref: t1.b <> t2.b
+
+Table schema.image {
+    id integer [pk]
+    url varchar
+}
+
+Table schema.content_item {
+    id integer [pk]
+    heading varchar
+    description varchar
+}
+
+Ref: schema.image.id <> schema.content_item.id
+
+Table schema.footer_item {
+    id integer [pk]
+    left varchar
+    centre varchar
+    right varchar
+}
+
+Table "schema1"."customers" {
+  "id" integer [pk]
+  "full_name" varchar
+}
+
+Table "schema2"."orders" {
+  "id" integer [pk]
+  "total_price" integer
+}
+
+Ref: "schema1"."customers"."id" <> "schema2"."orders"."id"

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/many_to_many_relationship.out.sql
@@ -10,6 +10,12 @@ CREATE SCHEMA `E`;
 
 CREATE SCHEMA `G`;
 
+CREATE SCHEMA `schema`;
+
+CREATE SCHEMA `schema1`;
+
+CREATE SCHEMA `schema2`;
+
 CREATE TABLE `A`.`a` (
   `AB` integer,
   `BA` integer,
@@ -49,20 +55,48 @@ CREATE TABLE `G`.`g` (
 );
 
 CREATE TABLE `t1` (
-  `a` int,
-  `b` int
+  `a` int PRIMARY KEY,
+  `b` int UNIQUE
 );
 
 CREATE TABLE `t2` (
-  `a` int,
-  `b` int
+  `a` int PRIMARY KEY,
+  `b` int UNIQUE
 );
 
 CREATE TABLE `t1_t2` (
   `a` int
 );
 
-CREATE TABLE `a_b` (
+CREATE TABLE `schema`.`image` (
+  `id` integer PRIMARY KEY,
+  `url` varchar(255)
+);
+
+CREATE TABLE `schema`.`content_item` (
+  `id` integer PRIMARY KEY,
+  `heading` varchar(255),
+  `description` varchar(255)
+);
+
+CREATE TABLE `schema`.`footer_item` (
+  `id` integer PRIMARY KEY,
+  `left` varchar(255),
+  `centre` varchar(255),
+  `right` varchar(255)
+);
+
+CREATE TABLE `schema1`.`customers` (
+  `id` integer PRIMARY KEY,
+  `full_name` varchar(255)
+);
+
+CREATE TABLE `schema2`.`orders` (
+  `id` integer PRIMARY KEY,
+  `total_price` integer
+);
+
+CREATE TABLE `A`.`a_b` (
   `a_AB` integer,
   `a_BA` integer,
   `b_BC` integer,
@@ -70,23 +104,23 @@ CREATE TABLE `a_b` (
   PRIMARY KEY (`a_AB`, `a_BA`, `b_BC`, `b_CB`)
 );
 
-ALTER TABLE `a_b` ADD FOREIGN KEY (`a_AB`, `a_BA`) REFERENCES `A`.`a` (`AB`, `BA`);
+ALTER TABLE `A`.`a_b` ADD FOREIGN KEY (`a_AB`, `a_BA`) REFERENCES `A`.`a` (`AB`, `BA`);
 
-ALTER TABLE `a_b` ADD FOREIGN KEY (`b_BC`, `b_CB`) REFERENCES `B`.`b` (`BC`, `CB`);
+ALTER TABLE `A`.`a_b` ADD FOREIGN KEY (`b_BC`, `b_CB`) REFERENCES `B`.`b` (`BC`, `CB`);
 
 
-CREATE TABLE `d_c` (
+CREATE TABLE `D`.`d_c` (
   `d_DE` integer,
   `c_CD` integer,
   PRIMARY KEY (`d_DE`, `c_CD`)
 );
 
-ALTER TABLE `d_c` ADD FOREIGN KEY (`d_DE`) REFERENCES `D`.`d` (`DE`);
+ALTER TABLE `D`.`d_c` ADD FOREIGN KEY (`d_DE`) REFERENCES `D`.`d` (`DE`);
 
-ALTER TABLE `d_c` ADD FOREIGN KEY (`c_CD`) REFERENCES `C`.`c` (`CD`);
+ALTER TABLE `D`.`d_c` ADD FOREIGN KEY (`c_CD`) REFERENCES `C`.`c` (`CD`);
 
 
-CREATE TABLE `e_g` (
+CREATE TABLE `E`.`e_g` (
   `e_EF` integer,
   `e_FE` integer,
   `g_GH` integer,
@@ -94,9 +128,9 @@ CREATE TABLE `e_g` (
   PRIMARY KEY (`e_EF`, `e_FE`, `g_GH`, `g_HG`)
 );
 
-ALTER TABLE `e_g` ADD FOREIGN KEY (`e_EF`, `e_FE`) REFERENCES `E`.`e` (`EF`, `FE`);
+ALTER TABLE `E`.`e_g` ADD FOREIGN KEY (`e_EF`, `e_FE`) REFERENCES `E`.`e` (`EF`, `FE`);
 
-ALTER TABLE `e_g` ADD FOREIGN KEY (`g_GH`, `g_HG`) REFERENCES `G`.`g` (`GH`, `HG`);
+ALTER TABLE `E`.`e_g` ADD FOREIGN KEY (`g_GH`, `g_HG`) REFERENCES `G`.`g` (`GH`, `HG`);
 
 
 CREATE TABLE `t1_t2(1)` (
@@ -119,4 +153,26 @@ CREATE TABLE `t1_t2(2)` (
 ALTER TABLE `t1_t2(2)` ADD FOREIGN KEY (`t1_b`) REFERENCES `t1` (`b`);
 
 ALTER TABLE `t1_t2(2)` ADD FOREIGN KEY (`t2_b`) REFERENCES `t2` (`b`);
+
+
+CREATE TABLE `schema`.`image_content_item` (
+  `image_id` integer,
+  `content_item_id` integer,
+  PRIMARY KEY (`image_id`, `content_item_id`)
+);
+
+ALTER TABLE `schema`.`image_content_item` ADD FOREIGN KEY (`image_id`) REFERENCES `schema`.`image` (`id`);
+
+ALTER TABLE `schema`.`image_content_item` ADD FOREIGN KEY (`content_item_id`) REFERENCES `schema`.`content_item` (`id`);
+
+
+CREATE TABLE `schema1`.`customers_orders` (
+  `customers_id` integer,
+  `orders_id` integer,
+  PRIMARY KEY (`customers_id`, `orders_id`)
+);
+
+ALTER TABLE `schema1`.`customers_orders` ADD FOREIGN KEY (`customers_id`) REFERENCES `schema1`.`customers` (`id`);
+
+ALTER TABLE `schema1`.`customers_orders` ADD FOREIGN KEY (`orders_id`) REFERENCES `schema2`.`orders` (`id`);
 

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/input/many_to_many_relationship.in.dbml
@@ -37,13 +37,13 @@ ref:  "E"."e".("EF","FE") <>  "G"."g".("GH","HG")
 
 
 table t1 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t2 {
-  a int
-  b int
+  a int [pk]
+  b int [unique]
 }
 
 table t1_t2 {
@@ -52,3 +52,35 @@ table t1_t2 {
 
 ref: t1.a <> t2.a
 ref: t1.b <> t2.b
+
+Table schema.image {
+    id integer [pk]
+    url varchar
+}
+
+Table schema.content_item {
+    id integer [pk]
+    heading varchar
+    description varchar
+}
+
+Ref: schema.image.id <> schema.content_item.id
+
+Table schema.footer_item {
+    id integer [pk]
+    left varchar
+    centre varchar
+    right varchar
+}
+
+Table "schema1"."customers" {
+  "id" integer [pk]
+  "full_name" varchar
+}
+
+Table "schema2"."orders" {
+  "id" integer [pk]
+  "total_price" integer
+}
+
+Ref: "schema1"."customers"."id" <> "schema2"."orders"."id"

--- a/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
+++ b/packages/dbml-core/__tests__/exporter/postgres_exporter/output/many_to_many_relationship.out.sql
@@ -10,6 +10,12 @@ CREATE SCHEMA "E";
 
 CREATE SCHEMA "G";
 
+CREATE SCHEMA "schema";
+
+CREATE SCHEMA "schema1";
+
+CREATE SCHEMA "schema2";
+
 CREATE TABLE "A"."a" (
   "AB" integer,
   "BA" integer,
@@ -49,20 +55,48 @@ CREATE TABLE "G"."g" (
 );
 
 CREATE TABLE "t1" (
-  "a" int,
-  "b" int
+  "a" int PRIMARY KEY,
+  "b" int UNIQUE
 );
 
 CREATE TABLE "t2" (
-  "a" int,
-  "b" int
+  "a" int PRIMARY KEY,
+  "b" int UNIQUE
 );
 
 CREATE TABLE "t1_t2" (
   "a" int
 );
 
-CREATE TABLE "a_b" (
+CREATE TABLE "schema"."image" (
+  "id" integer PRIMARY KEY,
+  "url" varchar
+);
+
+CREATE TABLE "schema"."content_item" (
+  "id" integer PRIMARY KEY,
+  "heading" varchar,
+  "description" varchar
+);
+
+CREATE TABLE "schema"."footer_item" (
+  "id" integer PRIMARY KEY,
+  "left" varchar,
+  "centre" varchar,
+  "right" varchar
+);
+
+CREATE TABLE "schema1"."customers" (
+  "id" integer PRIMARY KEY,
+  "full_name" varchar
+);
+
+CREATE TABLE "schema2"."orders" (
+  "id" integer PRIMARY KEY,
+  "total_price" integer
+);
+
+CREATE TABLE "A"."a_b" (
   "a_AB" integer,
   "a_BA" integer,
   "b_BC" integer,
@@ -70,23 +104,23 @@ CREATE TABLE "a_b" (
   PRIMARY KEY ("a_AB", "a_BA", "b_BC", "b_CB")
 );
 
-ALTER TABLE "a_b" ADD FOREIGN KEY ("a_AB", "a_BA") REFERENCES "A"."a" ("AB", "BA");
+ALTER TABLE "A"."a_b" ADD FOREIGN KEY ("a_AB", "a_BA") REFERENCES "A"."a" ("AB", "BA");
 
-ALTER TABLE "a_b" ADD FOREIGN KEY ("b_BC", "b_CB") REFERENCES "B"."b" ("BC", "CB");
+ALTER TABLE "A"."a_b" ADD FOREIGN KEY ("b_BC", "b_CB") REFERENCES "B"."b" ("BC", "CB");
 
 
-CREATE TABLE "d_c" (
+CREATE TABLE "D"."d_c" (
   "d_DE" integer,
   "c_CD" integer,
   PRIMARY KEY ("d_DE", "c_CD")
 );
 
-ALTER TABLE "d_c" ADD FOREIGN KEY ("d_DE") REFERENCES "D"."d" ("DE");
+ALTER TABLE "D"."d_c" ADD FOREIGN KEY ("d_DE") REFERENCES "D"."d" ("DE");
 
-ALTER TABLE "d_c" ADD FOREIGN KEY ("c_CD") REFERENCES "C"."c" ("CD");
+ALTER TABLE "D"."d_c" ADD FOREIGN KEY ("c_CD") REFERENCES "C"."c" ("CD");
 
 
-CREATE TABLE "e_g" (
+CREATE TABLE "E"."e_g" (
   "e_EF" integer,
   "e_FE" integer,
   "g_GH" integer,
@@ -94,9 +128,9 @@ CREATE TABLE "e_g" (
   PRIMARY KEY ("e_EF", "e_FE", "g_GH", "g_HG")
 );
 
-ALTER TABLE "e_g" ADD FOREIGN KEY ("e_EF", "e_FE") REFERENCES "E"."e" ("EF", "FE");
+ALTER TABLE "E"."e_g" ADD FOREIGN KEY ("e_EF", "e_FE") REFERENCES "E"."e" ("EF", "FE");
 
-ALTER TABLE "e_g" ADD FOREIGN KEY ("g_GH", "g_HG") REFERENCES "G"."g" ("GH", "HG");
+ALTER TABLE "E"."e_g" ADD FOREIGN KEY ("g_GH", "g_HG") REFERENCES "G"."g" ("GH", "HG");
 
 
 CREATE TABLE "t1_t2(1)" (
@@ -119,4 +153,26 @@ CREATE TABLE "t1_t2(2)" (
 ALTER TABLE "t1_t2(2)" ADD FOREIGN KEY ("t1_b") REFERENCES "t1" ("b");
 
 ALTER TABLE "t1_t2(2)" ADD FOREIGN KEY ("t2_b") REFERENCES "t2" ("b");
+
+
+CREATE TABLE "schema"."image_content_item" (
+  "image_id" integer,
+  "content_item_id" integer,
+  PRIMARY KEY ("image_id", "content_item_id")
+);
+
+ALTER TABLE "schema"."image_content_item" ADD FOREIGN KEY ("image_id") REFERENCES "schema"."image" ("id");
+
+ALTER TABLE "schema"."image_content_item" ADD FOREIGN KEY ("content_item_id") REFERENCES "schema"."content_item" ("id");
+
+
+CREATE TABLE "schema1"."customers_orders" (
+  "customers_id" integer,
+  "orders_id" integer,
+  PRIMARY KEY ("customers_id", "orders_id")
+);
+
+ALTER TABLE "schema1"."customers_orders" ADD FOREIGN KEY ("customers_id") REFERENCES "schema1"."customers" ("id");
+
+ALTER TABLE "schema1"."customers_orders" ADD FOREIGN KEY ("orders_id") REFERENCES "schema2"."orders" ("id");
 

--- a/packages/dbml-core/src/export/PostgresExporter.js
+++ b/packages/dbml-core/src/export/PostgresExporter.js
@@ -136,8 +136,9 @@ class PostgresExporter {
     return `(${fieldNames})`;
   }
 
-  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName) {
-    let line = `CREATE TABLE "${tableName}" (\n`;
+  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName, refEndpointSchema, model) {
+    let line = `CREATE TABLE ${shouldPrintSchema(refEndpointSchema, model)
+      ? `"${refEndpointSchema.name}".` : ''}"${tableName}" (\n`;
     const key1s = [...firstTableFieldsMap.keys()].join('", "');
     const key2s = [...secondTableFieldsMap.keys()].join('", "');
     firstTableFieldsMap.forEach((fieldType, fieldName) => {
@@ -151,10 +152,11 @@ class PostgresExporter {
     return line;
   }
 
-  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, refEndpointSchema, foreignEndpointSchema, model) {
     const refEndpointFields = [...fieldsMap.keys()].join('", "');
-    const line = `ALTER TABLE "${refEndpointTableName}" ADD FOREIGN KEY ("${refEndpointFields}") REFERENCES ${shouldPrintSchema(schema, model)
-      ? `"${schema.name}".` : ''}"${foreignEndpointTableName}" ${foreignEndpointFields};\n\n`;
+    const line = `ALTER TABLE ${shouldPrintSchema(refEndpointSchema, model)
+      ? `"${refEndpointSchema.name}".` : ''}"${refEndpointTableName}" ADD FOREIGN KEY ("${refEndpointFields}") REFERENCES ${shouldPrintSchema(foreignEndpointSchema, model)
+      ? `"${foreignEndpointSchema.name}".` : ''}"${foreignEndpointTableName}" ${foreignEndpointFields};\n\n`;
     return line;
   }
 
@@ -184,10 +186,10 @@ class PostgresExporter {
         const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
         const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
-        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
+        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName, refEndpointSchema, model);
 
-        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name,refEndpointSchema, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `"${foreignEndpointSchema.name}".` : ''}"${foreignEndpointTable.name}" ADD `;

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -112,8 +112,9 @@ class SqlServerExporter {
     return tableStrs;
   }
 
-  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName) {
-    let line = `CREATE TABLE [${tableName}] (\n`;
+  static buildTableManyToMany (firstTableFieldsMap, secondTableFieldsMap, tableName, refEndpointSchema, model) {
+    let line = `CREATE TABLE ${shouldPrintSchema(refEndpointSchema, model)
+      ? `[${refEndpointSchema.name}].` : ''}[${tableName}] (\n`;
     const key1s = [...firstTableFieldsMap.keys()].join('], [');
     const key2s = [...secondTableFieldsMap.keys()].join('], [');
     firstTableFieldsMap.forEach((fieldType, fieldName) => {
@@ -127,10 +128,11 @@ class SqlServerExporter {
     return line;
   }
 
-  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, schema, model) {
+  static buildForeignKeyManyToMany (fieldsMap, foreignEndpointFields, refEndpointTableName, foreignEndpointTableName, refEndpointSchema, foreignEndpointSchema, model) {
     const refEndpointFields = [...fieldsMap.keys()].join('], [');
-    const line = `ALTER TABLE [${refEndpointTableName}] ADD FOREIGN KEY ([${refEndpointFields}]) REFERENCES ${shouldPrintSchema(schema, model)
-      ? `[${schema.name}].` : ''}[${foreignEndpointTableName}] ${foreignEndpointFields};\nGO\n\n`;
+    const line = `ALTER TABLE ${shouldPrintSchema(refEndpointSchema, model)
+      ? `[${refEndpointSchema.name}].` : ''}[${refEndpointTableName}] ADD FOREIGN KEY ([${refEndpointFields}]) REFERENCES ${shouldPrintSchema(foreignEndpointSchema, model)
+      ? `[${foreignEndpointSchema.name}].` : ''}[${foreignEndpointTableName}] ${foreignEndpointFields};\nGO\n\n`;
     return line;
   }
 
@@ -165,10 +167,10 @@ class SqlServerExporter {
         const secondTableFieldsMap = buildJunctionFields2(foreignEndpoint.fieldIds, model, firstTableFieldsMap);
 
         const newTableName = buildNewTableName(refEndpointTable.name, foreignEndpointTable.name, usedTableNames);
-        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName);
+        line += this.buildTableManyToMany(firstTableFieldsMap, secondTableFieldsMap, newTableName, refEndpointSchema, model);
 
-        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, model);
-        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, foreignEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(firstTableFieldsMap, refEndpointFieldName, newTableName, refEndpointTable.name, refEndpointSchema, refEndpointSchema, model);
+        line += this.buildForeignKeyManyToMany(secondTableFieldsMap, foreignEndpointFieldName, newTableName, foreignEndpointTable.name, refEndpointSchema, foreignEndpointSchema, model);
       } else {
         line = `ALTER TABLE ${shouldPrintSchema(foreignEndpointSchema, model)
           ? `[${foreignEndpointSchema.name}].` : ''}[${foreignEndpointTable.name}] ADD `;


### PR DESCRIPTION
## Summary
* Add  schema name for the junction table:
```
Ref schema.table1.column1 <> schema.table2.column2 → will create a junction table: "schema"."table1_table2"
Ref schema1.table1.column1 <> schema2.table2.column2 → will create a junction table "schema1"."table1_table2"
```


## Issue
([issue link here](https://community.dbdiagram.io/t/bug-many-to-many-references-not-honouring-schema-syntax/1539/3))

## Lasting Changes (Technical)
* Add schema name for `buildTableManyToMany`
* Add schema name for `buildForeignKeyManyToMany`
* Add new test for many to many relationships

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review