### PR TITLE
Ignore on update current timestamp in mysql

### DIFF
--- a/packages/dbml-core/__tests__/importer/mysql_importer/input/on_update_current_timestamp.in.sql
+++ b/packages/dbml-core/__tests__/importer/mysql_importer/input/on_update_current_timestamp.in.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `authorization_records` (
+`id` INT  AUTO_INCREMENT NOT NULL,
+`project_name` VARCHAR(100) NOT NULL,
+`updated_date`  DATETIME  DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+`created_date`  DATETIME  DEFAULT CURRENT_TIMESTAMP NOT NULL,
+PRIMARY KEY (`id`),
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table DemoTable737 (
+   StudentId int NOT NULL AUTO_INCREMENT PRIMARY KEY ON UPDATE CURRENT_TIMESTAMP,
+   StudentName varchar(100),
+   StudentAdmissiondate datetime
+);

--- a/packages/dbml-core/__tests__/importer/mysql_importer/output/on_update_current_timestamp.out.dbml
+++ b/packages/dbml-core/__tests__/importer/mysql_importer/output/on_update_current_timestamp.out.dbml
@@ -1,0 +1,12 @@
+Table "authorization_records" {
+  "id" INT [pk, not null, increment]
+  "project_name" VARCHAR(100) [not null]
+  "updated_date" DATETIME [not null, default: `CURRENT_TIMESTAMP`]
+  "created_date" DATETIME [not null, default: `CURRENT_TIMESTAMP`]
+}
+
+Table "DemoTable737" {
+  "StudentId" int [pk, not null, increment]
+  "StudentName" varchar(100)
+  "StudentAdmissiondate" datetime
+}

--- a/packages/dbml-core/src/parse/mysql/parser.pegjs
+++ b/packages/dbml-core/src/parse/mysql/parser.pegjs
@@ -232,9 +232,6 @@ FieldSettings = fieldSettingsArray:FieldSetting*
 			fieldSettings.dbdefault = field.value;
 		else if(field.type === "comment")
 			fieldSettings.note = field.value;
-		else if(field.type === "update") {
-			console.log(field);
-		}
 		else if (field !== "not_supported") {
 			fieldSettings[field] = true;
 		}
@@ -260,7 +257,7 @@ FieldSetting "field setting"
     ) { return "not_supported" }
 	/ _ v:Default {return {type: "default", value: v} }
 	/ _ v:Comment { return {type: "comment", value: v }}
-	/ _ "ON"i _ "UPDATE"i _ type
+	/ _ "ON"i _ "UPDATE"i _ type { return "not_supported" }
 
 // Default: Support "DEFAULT (value|expr)" syntax
 Default

--- a/packages/dbml-core/src/parse/mysql/parser.pegjs
+++ b/packages/dbml-core/src/parse/mysql/parser.pegjs
@@ -232,6 +232,9 @@ FieldSettings = fieldSettingsArray:FieldSetting*
 			fieldSettings.dbdefault = field.value;
 		else if(field.type === "comment")
 			fieldSettings.note = field.value;
+		else if(field.type === "update") {
+			console.log(field);
+		}
 		else if (field !== "not_supported") {
 			fieldSettings[field] = true;
 		}
@@ -257,6 +260,7 @@ FieldSetting "field setting"
     ) { return "not_supported" }
 	/ _ v:Default {return {type: "default", value: v} }
 	/ _ v:Comment { return {type: "comment", value: v }}
+	/ _ "ON"i _ "UPDATE"i _ type
 
 // Default: Support "DEFAULT (value|expr)" syntax
 Default

--- a/packages/dbml-core/src/parse/mysqlParser.js
+++ b/packages/dbml-core/src/parse/mysqlParser.js
@@ -319,6 +319,9 @@ function peg$parse(input, options) {
       			fieldSettings.dbdefault = field.value;
       		else if(field.type === "comment")
       			fieldSettings.note = field.value;
+      		else if(field.type === "update") {
+      			console.log(field);
+      		}
       		else if (field !== "not_supported") {
       			fieldSettings[field] = true;
       		}
@@ -2952,6 +2955,59 @@ function peg$parse(input, options) {
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
+                    }
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$currPos;
+                      s1 = peg$parse_();
+                      if (s1 !== peg$FAILED) {
+                        if (input.substr(peg$currPos, 2).toLowerCase() === peg$c17) {
+                          s2 = input.substr(peg$currPos, 2);
+                          peg$currPos += 2;
+                        } else {
+                          s2 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                        }
+                        if (s2 !== peg$FAILED) {
+                          s3 = peg$parse_();
+                          if (s3 !== peg$FAILED) {
+                            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c19) {
+                              s4 = input.substr(peg$currPos, 6);
+                              peg$currPos += 6;
+                            } else {
+                              s4 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c20); }
+                            }
+                            if (s4 !== peg$FAILED) {
+                              s5 = peg$parse_();
+                              if (s5 !== peg$FAILED) {
+                                s6 = peg$parsetype();
+                                if (s6 !== peg$FAILED) {
+                                  s1 = [s1, s2, s3, s4, s5, s6];
+                                  s0 = s1;
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     }
                   }
                 }

--- a/packages/dbml-core/src/parse/mysqlParser.js
+++ b/packages/dbml-core/src/parse/mysqlParser.js
@@ -319,9 +319,6 @@ function peg$parse(input, options) {
       			fieldSettings.dbdefault = field.value;
       		else if(field.type === "comment")
       			fieldSettings.note = field.value;
-      		else if(field.type === "update") {
-      			console.log(field);
-      		}
       		else if (field !== "not_supported") {
       			fieldSettings[field] = true;
       		}
@@ -2982,7 +2979,8 @@ function peg$parse(input, options) {
                               if (s5 !== peg$FAILED) {
                                 s6 = peg$parsetype();
                                 if (s6 !== peg$FAILED) {
-                                  s1 = [s1, s2, s3, s4, s5, s6];
+                                  peg$savedPos = s0;
+                                  s1 = peg$c79();
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;


### PR DESCRIPTION
## Summary
* Ignore syntax ON UPDATE in fieldSettings

## Issue
https://github.com/holistics/dbml/issues/279
https://github.com/holistics/dbml/issues/272
https://github.com/holistics/dbml/issues/141
https://github.com/holistics/dbml/issues/217
https://github.com/holistics/dbml/issues/237#issuecomment-1078768726

## Lasting Changes (Technical)
* Added  grammar ` / _ "ON"i _ "UPDATE"i _ type { return "not_supported" }`  in fieldSettings in MySQL parser.

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review