### PR TITLE
Rendering schema name for table comments

### DIFF
--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/input/multiple_schema.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/input/multiple_schema.in.dbml
@@ -19,11 +19,13 @@ Table public.users {
 Table products {
   id int [pk]
   name varchar
+  note: 'This table contains products'
 }
 
 Table schemaA.products as A {
   id int [pk]
   name varchar [ref: > EU.id]
+  note: 'This table also contains products'
 }
 
 Table schemaA.locations {

--- a/packages/dbml-core/__tests__/exporter/mysql_exporter/output/multiple_schema.out.sql
+++ b/packages/dbml-core/__tests__/exporter/mysql_exporter/output/multiple_schema.out.sql
@@ -37,6 +37,10 @@ CREATE TABLE `schemaA`.`locations` (
   `name` varchar(255)
 );
 
+ALTER TABLE `products` COMMENT = 'This table contains products';
+
+ALTER TABLE `schemaA`.`products` COMMENT = 'This table also contains products';
+
 ALTER TABLE `ecommerce`.`users` ADD FOREIGN KEY (`id`) REFERENCES `users` (`id`);
 
 ALTER TABLE `ecommerce`.`users` ADD CONSTRAINT `name_optional` FOREIGN KEY (`id`) REFERENCES `users` (`name`);

--- a/packages/dbml-core/src/export/MysqlExporter.js
+++ b/packages/dbml-core/src/export/MysqlExporter.js
@@ -241,7 +241,10 @@ class MySQLExporter {
       let line = '';
       if (comment.type === 'table') {
         const table = model.tables[comment.tableId];
-        line += `ALTER TABLE \`${table.name}\` COMMENT = '${table.note.replace(/'/g, "\\'")}'`;
+        const schema = model.schemas[table.schemaId];
+
+        line += `ALTER TABLE ${shouldPrintSchema(schema, model)
+          ? `\`${schema.name}\`.` : ''}\`${table.name}\` COMMENT = '${table.note.replace(/'/g, "\\'")}'`;
       }
       line += ';\n';
       return line;


### PR DESCRIPTION
The table comments DDL did not contain the schema name.

## Summary
Added rendering of schema name, same way as it is done for other "alter table" commands.

## Issue
Has not been reported as an issue yet.

## Lasting Changes (Technical)
None.

## Checklist

Please check directly on the box once each of these are done

- [x] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [x] Integration Tests Passed
- [x] Code Review