### PR TITLE
Remove redundant build step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,7 @@ jobs:
         cache: 'yarn'
     - name: Install root dependencies
       run: yarn install --frozen-lockfile
-    - name: Install packages dependencies
+    - name: Install dependencies and build packages
       run: yarn bootstrap
-    - name: Build all packages
-      run: yarn build
     - name: Run unit tests
       run: yarn test


### PR DESCRIPTION
## Summary
* Remove redundant `yarn build` step

## Issue
(issue link here)

## Lasting Changes (Technical)
- Remove `yarn build` step in CI test workflow:
  - Reason: `yarn bootstrap` step will run `npm run prepublish` in all workspace packages which mean it will run `npm run build` too
  - Lerna bootstrap docs: https://github.com/lerna/lerna/blob/main/libs/commands/bootstrap/README.md
  - Result from CI job: https://github.com/holistics/dbml/actions/runs/4530731973/jobs/7980029303
    - `@dbml/core` runs build in bootstrap step:
    ![image](https://user-images.githubusercontent.com/44129390/228909174-3da47f68-7573-4e10-9b57-7d3f698d1038.png)
     - `@dbml/cli` runs build in bootstrap step:
    ![image](https://user-images.githubusercontent.com/44129390/228909965-6087ab04-87d9-47bc-993b-ac70bce73a13.png)


## Checklist

Please check directly on the box once each of these is done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [x] Integration Tests Passed
- [ ] Code Review