### PR TITLE
docs: more reasonable example of default

### DIFF
--- a/dbml-homepage/docs/docs/README.md
+++ b/dbml-homepage/docs/docs/README.md
@@ -160,7 +160,7 @@ Example,
         id integer [primary key]
         username varchar(255) [not null, unique]
         full_name varchar(255) [not null]
-        gender varchar(1) [default: 'm']
+        source varchar(255) [default: 'direct']
         created_at timestamp [default: `now()`]
         rating integer [default: 10]
     }


### PR DESCRIPTION
## Summary
* Existing string example for column default doesn't really make sense to have a default gender.
* Swap it out for a `source` column. This is a common field referring to marketing channels and `'direct'` would be a reasonable default if no other source is provided.

## Issue
none

## Lasting Changes (Technical)
Just a doc example update

## Checklist

Please check directly on the box once each of these are done

- [X] Documentation (if necessary)
