### PR TITLE
Update dbml domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </div>
 DBML (database markup language) is a simple, readable DSL language designed to define database structures.
 
-For more information, please check out [DBML homepage](https://dbml.org)
+For more information, please check out [DBML homepage](https://dbml.dbdiagram.io)
 
 ## Benefits
 

--- a/dbml-homepage/deploy.sh
+++ b/dbml-homepage/deploy.sh
@@ -10,7 +10,6 @@ npm run build
 cd docs/.vuepress/dist
 
 # if you are deploying to a custom domain
-# echo 'www.dbml.org' > CNAME
 echo 'https://dbml.dbdiagram.io' > CNAME
 
 cp "home/index.html" "./"

--- a/dbml-homepage/docs/docs/README.md
+++ b/dbml-homepage/docs/docs/README.md
@@ -27,7 +27,6 @@ outlines the full syntax documentations of DBML.
 - [Enum Definition](#enum-definition)
 - [TableGroup](#tablegroup)
 - [Syntax Consistency](#syntax-consistency)
-- [Community Contributions](#community-contributions)
 
 ##### Take a look at an example below:
 

--- a/packages/dbml-cli/README.md
+++ b/packages/dbml-cli/README.md
@@ -1,6 +1,6 @@
 # @dbml/cli
 
-See our website [@dbml/cli](https://www.dbml.org/cli/) for more information
+See our website [@dbml/cli](https://dbml.dbdiagram.io/cli/) for more information
 
 ## Installation
 ```shell

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -17,7 +17,7 @@
     "sql2dbml": "bin/sql2dbml.js"
   },
   "author": "Holistics <dev@holistics.io>",
-  "homepage": "https://dbml.org",
+  "homepage": "https://dbml.dbdiagram.io",
   "repository": "https://github.com/holistics/dbml/tree/master/packages/dbml-cli",
   "keywords": [
     "dbml",

--- a/packages/dbml-core/README.md
+++ b/packages/dbml-core/README.md
@@ -1,6 +1,6 @@
 # @dbml/core
 
-See our website [@dbml/core](https://www.dbml.org/js-module/#core) for more information
+See our website [@dbml/core](https://dbml.dbdiagram.io/js-module/#core) for more information
 
 ## Installation
 ```shell

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -4,7 +4,7 @@
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
-  "homepage": "https://dbml.org",
+  "homepage": "https://dbml.dbdiagram.io",
   "repository": "https://github.com/holistics/dbml/tree/master/packages/dbml-core",
   "keywords": [
     "dbml",


### PR DESCRIPTION
## Summary
Update the dbml domain to https://dbml.dbdiagram.io

## Issue
https://github.com/holistics/dbml/issues/353

## Lasting Changes (Technical)
- Update the dbml domain to https://dbml.dbdiagram.io
- Docs: Remove a broken link "Community Contributions"


## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review