### PR TITLE
Fix default values for MS-SQL parser

### DIFF
--- a/packages/dbml-core/__tests__/importer/mssql_importer/input/default_parameters.in.sql
+++ b/packages/dbml-core/__tests__/importer/mssql_importer/input/default_parameters.in.sql
@@ -1,0 +1,32 @@
+CREATE TABLE [test] (
+  [text1] varchar(255) DEFAULT 'Test',
+  [text2] varchar(255) DEFAULT ('Test'),
+  [text3] varchar(255) DEFAULT (('Test')),
+  [text4] varchar(255) DEFAULT ((('Test'))),
+
+  [number1] int DEFAULT 0,
+  [number2] int DEFAULT (0),
+  [number3] int DEFAULT ((0)),
+  [number4] int DEFAULT (((0))),
+
+  [date1] datetime DEFAULT now(),
+  [date2] datetime DEFAULT (now()),
+  [date3] datetime DEFAULT ((now())),
+  [date4] datetime DEFAULT (((now())))
+)
+
+ALTER TABLE [test] ADD DEFAULT 'Test2' FOR [text1] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT ('Test2') FOR [text2] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT (('Test2')) FOR [text3] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT ((('Test2'))) FOR [text4] WITH VALUES
+
+ALTER TABLE [test] ADD DEFAULT 1 FOR [number1] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT (1) FOR [number2] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT ((1)) FOR [number3] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT (((1))) FOR [number4] WITH VALUES
+
+ALTER TABLE [test] ADD DEFAULT now() FOR [date1] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT (now()) FOR [date2] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT ((now())) FOR [date3] WITH VALUES
+ALTER TABLE [test] ADD DEFAULT (((now()))) FOR [date4] WITH VALUES
+GO

--- a/packages/dbml-core/__tests__/importer/mssql_importer/output/default_parameters.out.dbml
+++ b/packages/dbml-core/__tests__/importer/mssql_importer/output/default_parameters.out.dbml
@@ -1,0 +1,14 @@
+Table "test" {
+  "text1" varchar(255) [default: "Test2"]
+  "text2" varchar(255) [default: "Test2"]
+  "text3" varchar(255) [default: "Test2"]
+  "text4" varchar(255) [default: "Test2"]
+  "number1" int [default: 1]
+  "number2" int [default: 1]
+  "number3" int [default: 1]
+  "number4" int [default: 1]
+  "date1" datetime [default: `now()`]
+  "date2" datetime [default: `now()`]
+  "date3" datetime [default: `now()`]
+  "date4" datetime [default: `now()`]
+}

--- a/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
+++ b/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
@@ -66,7 +66,9 @@ const Lang = P.createLanguage({
       r.ConstExpr,
       KP.RParen,
     ).map(value => value[1]),
-    P.alt(pFunction, pConst, KP.KeywordNull.thru(streamline('boolean'))),
+    pFunction,
+    pConst,
+    KP.KeywordNull.thru(streamline('boolean')),
   ),
   ConstraintName: () => P.seq(KP.KeywordConstraint, pIdentifier).map(value => value[1]),
 });

--- a/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
+++ b/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
@@ -60,11 +60,14 @@ const Lang = P.createLanguage({
     A.makeDefaultConstraint,
   ),
 
-  ConstExpr: () => P.seq(
-    KP.LParen.fallback(null),
-    P.alt(pFunction, P.seq(KP.LParen.fallback(null), pConst, KP.RParen.fallback(null)), KP.KeywordNull.thru(streamline('boolean'))),
-    KP.RParen.fallback(null),
-  ).map(value => value[1]),
+  ConstExpr: (r) => P.alt(
+    P.seq(
+      KP.LParen,
+      r.ConstExpr,
+      KP.RParen,
+    ).map(value => value[1]),
+    P.alt(pFunction, pConst, KP.KeywordNull.thru(streamline('boolean'))),
+  ),
   ConstraintName: () => P.seq(KP.KeywordConstraint, pIdentifier).map(value => value[1]),
 });
 

--- a/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
+++ b/packages/dbml-core/src/parse/mssql/constraint_definition/index.js
@@ -62,7 +62,7 @@ const Lang = P.createLanguage({
 
   ConstExpr: () => P.seq(
     KP.LParen.fallback(null),
-    P.alt(pFunction, pConst, KP.KeywordNull.thru(streamline('boolean'))),
+    P.alt(pFunction, P.seq(KP.LParen.fallback(null), pConst, KP.RParen.fallback(null)), KP.KeywordNull.thru(streamline('boolean'))),
     KP.RParen.fallback(null),
   ).map(value => value[1]),
   ConstraintName: () => P.seq(KP.KeywordConstraint, pIdentifier).map(value => value[1]),


### PR DESCRIPTION
## Summary
Fix parsing of default values for MSSQL

## Issue
#321 - sql2dbml -- mssql parsing for defaults

## Lasting Changes (Technical)
Changed MSSQL language definition to accept double-parenthesis around constant values (`DEFAULT ((0))`)

## Checklist

Please check directly on the box once each of these are done
- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review