### PR TITLE
Included enum example for names with spaces

### DIFF
--- a/dbml-homepage/docs/docs/README.md
+++ b/dbml-homepage/docs/docs/README.md
@@ -394,6 +394,15 @@ When hovering over the column in the canvas, the enum values will be displayed.
     } 
 **Note:** if `schema_name` prefix is omitted, it'll default to `public` schema
 
+If your enum values contain spaces or other special characters you can use double quotes.
+
+    enum grade {
+        "A+"
+        "A"
+        "A-"
+        "Not Yet Set"
+    }
+
 ## TableGroup
 `TableGroup` allows users to group the related or associated tables together.
 


### PR DESCRIPTION
## Summary
* Modified the documentation to include an enum example that has a quoted name with spaces

## Issue
(issue link here)

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [x] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [x] Code Review