### PR TITLE
2. Simple Report serializer

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
@@ -1,0 +1,11 @@
+import { CompileError } from '../errors';
+import { ProgramNode } from '../parser/nodes';
+import Report from '../report';
+
+export function serialize(report: Report<ProgramNode, CompileError>): string {
+  return JSON.stringify(
+    report,
+    (key, value) => (['symbol', 'parentElement'].includes(key) ? undefined : value),
+    2,
+  );
+}


### PR DESCRIPTION
## Summary
* Add a simple serializer as the later phases would cause the AST to have circular references, JSON.stringify by default would recurse infinitely.
* Previous PR: #414 
* Next PR: #420 

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review