### PR TITLE
5. Parser base element validator

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
@@ -1,0 +1,84 @@
+import { SyntaxNode } from '../../parser/nodes';
+import { ValidatorContext } from '../validator/validatorContext';
+import {
+  NodeSymbolId,
+  createColumnSymbolId,
+  createEnumFieldSymbolId,
+  createEnumSymbolId,
+  createTableGroupSymbolId,
+  createTableSymbolId,
+} from './symbolIndex';
+import SymbolTable from './symbolTable';
+import {
+  ColumnSymbol,
+  EnumFieldSymbol,
+  EnumSymbol,
+  NodeSymbol,
+  TableGroupFieldSymbol,
+  TableGroupSymbol,
+  TableSymbol,
+} from './symbols';
+
+export function createIdFromContext(
+  name: string,
+  context: ValidatorContext,
+): NodeSymbolId | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return createTableSymbolId(name);
+    case ValidatorContext.EnumContext:
+      return createEnumSymbolId(name);
+    case ValidatorContext.TableGroupContext:
+      return createTableGroupSymbolId(name);
+    default:
+      return undefined;
+  }
+}
+
+export function createSubfieldId(
+  name: string,
+  context: ValidatorContext,
+): NodeSymbolId | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return createColumnSymbolId(name);
+    case ValidatorContext.EnumContext:
+      return createEnumFieldSymbolId(name);
+    case ValidatorContext.TableGroupContext:
+      return createTableGroupSymbolId(name);
+    default:
+      return undefined;
+  }
+}
+
+export function createSymbolFromContext(
+  declaration: SyntaxNode,
+  context: ValidatorContext,
+): NodeSymbol | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return new TableSymbol(new SymbolTable(), declaration);
+    case ValidatorContext.EnumContext:
+      return new EnumSymbol(new SymbolTable(), declaration);
+    case ValidatorContext.TableGroupContext:
+      return new TableGroupSymbol(new SymbolTable(), declaration);
+    default:
+      return undefined;
+  }
+}
+
+export function createSubfieldSymbol(
+  declaration: SyntaxNode,
+  context: ValidatorContext,
+): NodeSymbol | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return new ColumnSymbol(declaration);
+    case ValidatorContext.EnumContext:
+      return new EnumFieldSymbol(declaration);
+    case ValidatorContext.TableGroupContext:
+      return new TableGroupFieldSymbol(declaration);
+    default:
+      return undefined;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/types.ts
@@ -1,0 +1,18 @@
+import { ElementDeclarationNode, SyntaxNode } from '../parser/nodes';
+import { NodeSymbolId } from './symbol/symbolIndex';
+
+export type UnresolvedName = UnresolvedUnqualifiedName | UnresolvedQualifiedName;
+
+export interface UnresolvedUnqualifiedName {
+  id: NodeSymbolId;
+  qualifiers?: undefined;
+  ownerElement: ElementDeclarationNode;
+  referrer: SyntaxNode;
+}
+
+export interface UnresolvedQualifiedName {
+  id: NodeSymbolId;
+  qualifiers: NodeSymbolId[];
+  ownerElement: ElementDeclarationNode;
+  referrer: SyntaxNode;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
@@ -1,0 +1,151 @@
+import { isAccessExpression, isExpressionAVariableNode, isExpressionAQuotedString } from '../utils';
+import { None, Option, Some } from '../option';
+import {
+  FunctionExpressionNode,
+  IdentiferStreamNode,
+  InfixExpressionNode,
+  LiteralNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  TupleExpressionNode,
+  VariableNode,
+} from '../parser/nodes';
+import { isRelationshipOp } from './validator/utils';
+import { SyntaxToken } from '../lexer/tokens';
+
+export function destructureMemberAccessExpression(node: SyntaxNode): Option<SyntaxNode[]> {
+  if (node instanceof PrimaryExpressionNode || node instanceof TupleExpressionNode) {
+    return new Some([node]);
+  }
+
+  if (!isAccessExpression(node)) {
+    return new None();
+  }
+
+  const fragments = destructureMemberAccessExpression(node.leftExpression).unwrap_or(undefined);
+
+  if (!fragments) {
+    return new None();
+  }
+
+  fragments.push(node.rightExpression);
+
+  return new Some(fragments);
+}
+
+export function destructureComplexVariable(node: SyntaxNode): Option<string[]> {
+  const fragments = destructureMemberAccessExpression(node).unwrap_or(undefined);
+
+  if (!fragments) {
+    return new None();
+  }
+
+  const variables: string[] = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const fragment of fragments) {
+    const variable = extractVariableFromExpression(fragment).unwrap_or(undefined);
+    if (!variable) {
+      return new None();
+    }
+
+    variables.push(variable);
+  }
+
+  return new Some(variables);
+}
+
+export function extractVariableFromExpression(node: SyntaxNode): Option<string> {
+  if (!isExpressionAVariableNode(node)) {
+    return new None();
+  }
+
+  return new Some(node.expression.variable.value);
+}
+
+export function destructureIndex(
+  node: SyntaxNode,
+): Option<{ functional: string[]; nonFunctional: string[] }> {
+  if (isValidIndexName(node)) {
+    const indexName = extractIndexName(node);
+
+    return node instanceof FunctionExpressionNode ?
+      new Some({ functional: [indexName], nonFunctional: [] }) :
+      new Some({ functional: [], nonFunctional: [indexName] });
+  }
+
+  if (node instanceof TupleExpressionNode && node.elementList.every(isValidIndexName)) {
+    const functionalIndexName = node.elementList
+      .filter((e) => e instanceof FunctionExpressionNode)
+      .map(extractIndexName);
+    const nonfunctionalIndexName = node.elementList
+      .filter(isExpressionAVariableNode)
+      .map(extractIndexName);
+
+    return new Some({ functional: functionalIndexName, nonFunctional: nonfunctionalIndexName });
+  }
+
+  return new None();
+}
+
+export function extractVarNameFromPrimaryVariable(
+  node: PrimaryExpressionNode & { expression: VariableNode },
+): string {
+  return node.expression.variable.value;
+}
+
+export function extractStringFromIdentifierStream(stream: IdentiferStreamNode): string {
+  return stream.identifiers.map((identifier) => identifier.value).join(' ');
+}
+
+export function extractQuotedStringToken(value?: SyntaxNode): string | undefined {
+  if (!isExpressionAQuotedString(value)) {
+    return undefined;
+  }
+
+  const primaryExp = value as PrimaryExpressionNode;
+  if (primaryExp.expression instanceof VariableNode) {
+    return primaryExp.expression.variable.value;
+  }
+
+  if (primaryExp.expression instanceof LiteralNode) {
+    return primaryExp.expression.literal.value;
+  }
+
+  return undefined; // unreachable
+}
+
+export function isBinaryRelationship(value?: SyntaxNode): boolean {
+  if (!(value instanceof InfixExpressionNode)) {
+    return false;
+  }
+
+  if (!isRelationshipOp(value.op.value)) {
+    return false;
+  }
+
+  return (
+    destructureComplexVariable(value.leftExpression)
+      .and_then(() => destructureComplexVariable(value.rightExpression))
+      .unwrap_or(undefined) !== undefined
+  );
+}
+
+export function isValidIndexName(
+  value?: SyntaxNode,
+): value is (PrimaryExpressionNode & { expression: VariableNode }) | FunctionExpressionNode {
+  return (
+    (value instanceof PrimaryExpressionNode && value.expression instanceof VariableNode) ||
+    value instanceof FunctionExpressionNode
+  );
+}
+
+export function extractIndexName(
+  value: (PrimaryExpressionNode & { expression: VariableNode }) | FunctionExpressionNode,
+): string {
+  if (value instanceof PrimaryExpressionNode) {
+    return value.expression.variable.value;
+  }
+
+  return value.value.value;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/_preset_configs.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/_preset_configs.ts
@@ -1,0 +1,213 @@
+import { CompileErrorCode } from '../../../errors';
+import {
+  UniqueElementValidatorConfig,
+  createAliasValidatorConfig,
+  createBodyValidatorConfig,
+  createNameValidatorConfig,
+  createSettingListValidatorConfig,
+  createUniqueValidatorConfig,
+} from '../types';
+
+// A wrapper for preset configs
+// so that `stopOnError` configuration by element validators is more readable
+class PartialConfig<T extends { stopOnError: boolean }> {
+  partialConfig: T;
+
+  constructor(config: T) {
+    this.partialConfig = config;
+  }
+
+  doNotStopOnError(): T {
+    this.partialConfig.stopOnError = false;
+
+    return this.partialConfig;
+  }
+
+  stopOnError(): T {
+    this.partialConfig.stopOnError = true;
+
+    return this.partialConfig;
+  }
+}
+
+// A config that allows any body form
+const anyBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: true,
+    simpleErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows only simple body
+const simpleBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: true,
+    simpleErrorCode: undefined,
+    allowComplex: false,
+    complexErrorCode: CompileErrorCode.UNEXPECTED_COMPLEX_BODY,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows only complex body
+const complexBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: false,
+    simpleErrorCode: CompileErrorCode.UNEXPECTED_SIMPLE_BODY,
+    allowComplex: true,
+    complexErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows optional alias
+const optionalAliasConfig = new PartialConfig(
+  createAliasValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: true,
+    notAllowErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows optional name
+const optionalNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: true,
+    notAllowErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that mandate name registration
+const registerNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: false,
+    notOptionalErrorCode: CompileErrorCode.NAME_NOT_FOUND,
+    allow: true,
+    notAllowErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_NAME,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that mandates that there are no settings
+const noSettingListConfig = new PartialConfig(
+  createSettingListValidatorConfig(
+    {},
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: false,
+      notAllowErrorCode: CompileErrorCode.UNEXPECTED_SETTINGS,
+      unknownErrorCode: undefined,
+      duplicateErrorCode: undefined,
+      invalidErrorCode: undefined,
+
+      stopOnError: false,
+    },
+  ),
+);
+
+// A config that mandates that the element must be locally unique
+export function locallyUniqueConfig(
+  errorCode: CompileErrorCode,
+): PartialConfig<UniqueElementValidatorConfig> {
+  return new PartialConfig(
+    createUniqueValidatorConfig({
+      globally: false,
+      notGloballyErrorCode: undefined,
+      locally: true,
+      notLocallyErrorCode: errorCode,
+
+      stopOnError: false,
+    }),
+  );
+}
+
+// A config that mandates that the element must be globally unique
+export function globallyUniqueConfig(
+  errorCode: CompileErrorCode,
+): PartialConfig<UniqueElementValidatorConfig> {
+  return new PartialConfig(
+    createUniqueValidatorConfig({
+      globally: true,
+      notGloballyErrorCode: errorCode,
+      locally: false,
+      notLocallyErrorCode: undefined,
+
+      stopOnError: false,
+    }),
+  );
+}
+
+// A config that does not enforce uniqueness constraint
+const noUniqueConfig = new PartialConfig(
+  createUniqueValidatorConfig({
+    globally: false,
+    notGloballyErrorCode: undefined,
+    locally: false,
+    notLocallyErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that does not allow element name
+const noNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: false,
+    notAllowErrorCode: CompileErrorCode.UNEXPECTED_NAME,
+    allowComplex: false,
+    complexErrorCode: CompileErrorCode.UNEXPECTED_NAME,
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that does not allow element alias
+const noAliasConfig = new PartialConfig(
+  createAliasValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: false,
+    notAllowErrorCode: CompileErrorCode.UNEXPECTED_ALIAS,
+    stopOnError: false,
+  }),
+);
+
+export {
+  anyBodyConfig,
+  simpleBodyConfig,
+  complexBodyConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  registerNameConfig,
+  noUniqueConfig,
+  optionalAliasConfig,
+  optionalNameConfig,
+};

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/custom.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/custom.ts
@@ -1,0 +1,68 @@
+import { UnresolvedName } from '../../types';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  simpleBodyConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class CustomValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.CUSTOM;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.CustomContext,
+    errorCode: CompileErrorCode.INVALID_CUSTOM_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = simpleBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isExpressionAQuotedString,
+        errorCode: CompileErrorCode.INVALID_CUSTOM_ELEMENT_VALUE,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_CUSTOM_ELEMENT_VALUE,
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
@@ -1,0 +1,660 @@
+import { UnresolvedName } from '../../types';
+import {
+  AliasValidatorConfig,
+  BodyValidatorConfig,
+  ContextValidatorConfig,
+  ElementKind,
+  NameValidatorConfig,
+  SettingListValidatorConfig,
+  SubFieldValidatorConfig,
+  UniqueElementValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { SyntaxToken } from '../../../lexer/tokens';
+import { None, Option, Some } from '../../../option';
+import {
+  ElementDeclarationNode,
+  ExpressionNode,
+  FunctionApplicationNode,
+  ListExpressionNode,
+  SyntaxNode,
+} from '../../../parser/nodes';
+import { extractVariableNode } from '../../../utils';
+import { destructureComplexVariable, extractStringFromIdentifierStream } from '../../utils';
+import { ContextStack, canBeNestedWithin } from '../validatorContext';
+import {
+  hasComplexBody,
+  hasSimpleBody,
+  isSimpleName,
+  isValidAlias,
+  isValidName,
+  isValidSettingList,
+  pickValidator,
+  registerSchemaStack,
+} from '../utils';
+import { NodeSymbol, SchemaSymbol } from '../../symbol/symbols';
+import SymbolTable from '../../symbol/symbolTable';
+import {
+  createIdFromContext,
+  createSubfieldId,
+  createSubfieldSymbol,
+  createSymbolFromContext,
+} from '../../symbol/utils';
+
+export default abstract class ElementValidator {
+  protected abstract elementKind: ElementKind;
+
+  protected abstract context: ContextValidatorConfig;
+  protected abstract unique: UniqueElementValidatorConfig;
+  protected abstract name: NameValidatorConfig;
+  protected abstract alias: AliasValidatorConfig;
+  protected abstract body: BodyValidatorConfig;
+  protected abstract settingList: SettingListValidatorConfig;
+  protected abstract subfield: SubFieldValidatorConfig;
+
+  protected declarationNode: ElementDeclarationNode;
+  protected publicSchemaSymbol: SchemaSymbol;
+  protected contextStack: ContextStack;
+  protected unresolvedNames: UnresolvedName[];
+  protected errors: CompileError[];
+  protected kindsGloballyFound: Set<ElementKind>;
+  protected kindsLocallyFound: Set<ElementKind>;
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    this.declarationNode = declarationNode;
+    this.publicSchemaSymbol = publicSchemaSymbol;
+    this.contextStack = contextStack;
+    this.unresolvedNames = unresolvedNames;
+    this.errors = errors;
+    this.kindsGloballyFound = kindsGloballyFound;
+    this.kindsLocallyFound = kindsLocallyFound;
+  }
+
+  validate(): boolean {
+    this.contextStack.push(this.context.name);
+    const res =
+      this.validateContext() &&
+      this.validateUnique() &&
+      this.validateName() &&
+      this.validateAlias() &&
+      this.validateSettingList() &&
+      this.validateBodyForm() &&
+      this.validateBodyContent();
+
+    this.contextStack.pop();
+
+    return res;
+  }
+
+  /* Validate uniqueness according to config `this.unique` */
+
+  private validateUnique(): boolean {
+    return (
+      (this.validateGloballyUnique() && this.validateLocallyUnique()) || !this.unique.stopOnError
+    );
+  }
+
+  private validateLocallyUnique(): boolean {
+    if (!this.unique.locally) {
+      return true;
+    }
+
+    if (this.kindsLocallyFound.has(this.elementKind)) {
+      this.logError(
+        this.declarationNode.type,
+        this.unique.notLocallyErrorCode,
+        `A ${this.elementKind} has already been defined in this scope`,
+      );
+
+      return false;
+    }
+
+    this.kindsLocallyFound.add(this.elementKind);
+
+    return true;
+  }
+
+  private validateGloballyUnique(): boolean {
+    if (!this.unique.globally) {
+      return true;
+    }
+
+    if (this.kindsGloballyFound.has(this.elementKind)) {
+      this.logError(
+        this.declarationNode.type,
+        this.unique.notGloballyErrorCode,
+        `A ${this.elementKind} has already been defined in this file`,
+      );
+
+      return false;
+    }
+
+    this.kindsGloballyFound.add(this.elementKind);
+
+    return true;
+  }
+
+  /* Validate context according to config `this.context` */
+
+  private validateContext(): boolean {
+    if (!canBeNestedWithin(this.contextStack.parent(), this.contextStack.top())) {
+      this.logError(
+        this.declarationNode.type,
+        this.context.errorCode,
+        `${this.elementKind} can not appear here`,
+      );
+
+      return !this.context.stopOnError;
+    }
+
+    return true;
+  }
+
+  /* Validate and register name according to config `this.name` */
+
+  private validateName(): boolean {
+    // Default symbol in case one of the check fails which cause registerName to not be called
+    this.declarationNode.symbol = createSymbolFromContext(this.declarationNode, this.context.name);
+
+    return (
+      (this.checkNameInValidForm() &&
+        this.checkNameAllowed() &&
+        this.checkNameOptional() &&
+        this.checkNameComplex() &&
+        // Short-circuting prevents registerName to be called if a previous check fails
+        this.registerName()) ||
+      !this.name.stopOnError
+    );
+  }
+
+  private checkNameInValidForm(): boolean {
+    const { name } = this.declarationNode;
+    if (name && !isValidName(name)) {
+      this.logError(name, CompileErrorCode.INVALID_NAME, 'Invalid element name');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameAllowed(): boolean {
+    if (!this.name.allow && this.declarationNode.name) {
+      this.logError(
+        this.declarationNode.name,
+        this.name.notAllowErrorCode,
+        `${this.elementKind} shouldn't have a name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameOptional(): boolean {
+    if (!this.name.optional && !this.declarationNode.name) {
+      this.logError(
+        this.declarationNode.type,
+        this.name.notOptionalErrorCode,
+        `${this.elementKind} must have a name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameComplex(): boolean {
+    const { name } = this.declarationNode;
+    if (!this.name.allowComplex && name && !isSimpleName(name)) {
+      this.logError(
+        name,
+        this.name.complexErrorCode,
+        `${this.elementKind} must have a double-quoted string or an identifier name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private registerName(): boolean {
+    if (this.declarationNode.name && this.name.shouldRegister) {
+      const { registeredSymbol, ok } = this.registerElement(this.declarationNode.name);
+      this.declarationNode.symbol = registeredSymbol;
+
+      return ok;
+    }
+
+    return true;
+  }
+
+  /* Validate and register alias according to config `this.alias` */
+
+  private validateAlias(): boolean {
+    return (
+      (this.checkAliasInValidForm() &&
+        this.checkAliasAllow() &&
+        this.checkAliasOptional() &&
+        // Short-circuting prevents registerAlias to be called if a previous check fails
+        this.registerAlias()) ||
+      !this.alias.stopOnError
+    );
+  }
+
+  private checkAliasInValidForm() {
+    const { alias } = this.declarationNode;
+    if (alias && !isValidAlias(alias)) {
+      this.logError(alias, CompileErrorCode.INVALID_ALIAS, 'Invalid element alias');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkAliasAllow(): boolean {
+    const { alias } = this.declarationNode;
+
+    if (!this.alias.allow && alias) {
+      this.logError(
+        alias,
+        this.alias.notAllowErrorCode,
+        `${this.elementKind} shouldn't have an alias`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkAliasOptional(): boolean {
+    const { alias } = this.declarationNode;
+
+    if (!this.alias.optional && !alias) {
+      this.logError(
+        this.declarationNode.type,
+        this.alias.notOptionalErrorCode,
+        `${this.elementKind} must have an alias`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private registerAlias(): boolean {
+    const { alias } = this.declarationNode;
+    if (alias && this.name.shouldRegister) {
+      const { ok } = this.registerElement(alias, this.declarationNode.symbol);
+
+      return ok;
+    }
+
+    return true;
+  }
+
+  // Register a name extracted from `nameNode` into the `public` schema
+  // Also check for duplicated name
+  // If `defaultSymbol` is undefined, create the symbol anew corresponding to the name
+  // If `defaultSymbol` is given, the symbol (and its symbol table) is reused
+  private registerElement(
+    nameNode: SyntaxNode,
+    defaultSymbol?: NodeSymbol,
+  ): { registeredSymbol: NodeSymbol; ok: boolean } {
+    const variables = destructureComplexVariable(nameNode).unwrap_or(undefined);
+    if (!variables) {
+      throw new Error(`${this.elementKind} must be a valid complex variable`);
+    }
+    const name = variables.pop();
+    if (!name) {
+      throw new Error(`${this.elementKind} name shouldn't be empty`);
+    }
+
+    const id = createIdFromContext(name, this.context.name);
+    const registerSchema = registerSchemaStack(variables, this.publicSchemaSymbol.symbolTable);
+    if (!id) {
+      throw new Error(`${this.elementKind} fails to create id to register in the symbol table`);
+    }
+
+    const newSymbol = createSymbolFromContext(this.declarationNode, this.context.name);
+    if (!newSymbol) {
+      throw new Error(
+        `${this.elementKind} fails to create a symbol to register in the symbol table`,
+      );
+    }
+
+    if (registerSchema.has(id)) {
+      this.logError(
+        nameNode,
+        this.name.duplicateErrorCode,
+        `This ${this.elementKind} has a duplicated name`,
+      );
+
+      return { registeredSymbol: defaultSymbol || newSymbol, ok: false };
+    }
+    registerSchema.set(id, defaultSymbol || newSymbol);
+
+    return { registeredSymbol: defaultSymbol || newSymbol, ok: true };
+  }
+
+  /* Validate element according to config `this.settingList` */
+
+  private validateSettingList(): boolean {
+    return (
+      (this.checkSettingListInValidForm() &&
+        this.checkSettingListAllow() &&
+        this.checkSettingListOptional() &&
+        (!this.declarationNode.attributeList ||
+          this.validateSettingListContent(this.declarationNode.attributeList, this.settingList))) ||
+      !this.settingList.stopOnError
+    );
+  }
+
+  private checkSettingListInValidForm(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (attributeList && !isValidSettingList(attributeList)) {
+      this.logError(attributeList, CompileErrorCode.INVALID_SETTINGS, 'SettingList must be a list');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkSettingListAllow(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (!this.settingList.allow && attributeList) {
+      this.logError(
+        attributeList,
+        this.settingList.notAllowErrorCode,
+        `${this.elementKind} shouldn't have a setting list`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkSettingListOptional(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (!this.settingList.optional && !attributeList) {
+      this.logError(
+        this.declarationNode.type,
+        this.settingList.notOptionalErrorCode,
+        `${this.elementKind} must have a setting list`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  /* Validate body format according to config `this.body` */
+
+  private validateBodyForm(): boolean {
+    let hasError = false;
+    const node = this.declarationNode;
+
+    if (!this.body.allowComplex && hasComplexBody(node)) {
+      this.logError(
+        node.body,
+        this.body.complexErrorCode,
+        `${this.elementKind} should not have a complex body`,
+      );
+      hasError = true;
+    }
+
+    if (!this.body.allowSimple && hasSimpleBody(node)) {
+      this.logError(
+        node.body,
+        this.body.simpleErrorCode,
+        `${this.elementKind} should not have a simple body`,
+      );
+      hasError = true;
+    }
+
+    return !hasError || !this.body.stopOnError;
+  }
+
+  /* Validate the body content */
+
+  protected validateBodyContent(): boolean {
+    const node = this.declarationNode;
+
+    if (hasComplexBody(node)) {
+      if (!this.body.allowComplex) {
+        return false;
+      }
+
+      const kindsFoundInScope = new Set<ElementKind>();
+      let hasError = false;
+      node.body.body.forEach((sub) => {
+        hasError = this.validateEachOfComplexBody(sub, kindsFoundInScope) || hasError;
+      });
+
+      return !hasError;
+    }
+
+    if (node.body instanceof FunctionApplicationNode) {
+      return this.validateSubField(node.body);
+    }
+
+    return this.validateSubField(new FunctionApplicationNode({ callee: node.body, args: [] }));
+  }
+
+  // Switch to the appropriate validator method based on the type of content
+  // Either a nested element or a subfield
+  protected validateEachOfComplexBody(
+    sub: SyntaxNode,
+    kindsFoundInScope: Set<ElementKind>,
+  ): boolean {
+    if (sub instanceof ElementDeclarationNode) {
+      return this.validateNestedElementDeclaration(sub, kindsFoundInScope);
+    }
+    if (sub instanceof FunctionApplicationNode) {
+      return this.validateSubField(sub);
+    }
+
+    return this.validateSubField(
+      new FunctionApplicationNode({ callee: sub as ExpressionNode, args: [] }),
+    );
+  }
+
+  protected validateNestedElementDeclaration(
+    sub: ElementDeclarationNode,
+    kindsFoundInScope: Set<ElementKind>,
+  ): boolean {
+    // eslint-disable-next-line no-param-reassign
+    sub.parentElement = this.declarationNode;
+
+    const Val = pickValidator(sub);
+
+    const validatorObject = new Val(
+      sub,
+      this.publicSchemaSymbol,
+      this.contextStack,
+      this.unresolvedNames,
+      this.errors,
+      this.kindsGloballyFound,
+      kindsFoundInScope,
+    );
+
+    return validatorObject.validate();
+  }
+
+  /* Validate and register subfield according to config `this.subfield` */
+
+  protected validateSubField(sub: FunctionApplicationNode): boolean {
+    const args = [sub.callee, ...sub.args];
+    if (args.length === 0) {
+      throw new Error('A function application node always has at least 1 callee');
+    }
+
+    const maybeSettingList = args[args.length - 1];
+    this.validateSubFieldSettingList(maybeSettingList);
+    if (maybeSettingList instanceof ListExpressionNode) {
+      args.pop();
+    }
+
+    if (args.length !== this.subfield.argValidators.length) {
+      this.logError(
+        sub,
+        this.subfield.invalidArgNumberErrorCode,
+        `There must be ${this.subfield.argValidators.length} non-setting terms`,
+      );
+
+      return false;
+    }
+
+    let hasError = false;
+
+    for (let i = 0; i < args.length; i += 1) {
+      const res = this.subfield.argValidators[i].validateArg(args[i]);
+      if (!res) {
+        this.logError(args[i], this.subfield.argValidators[i].errorCode, 'Invalid field value');
+        hasError = true;
+      } else {
+        this.subfield.argValidators[i].registerUnresolvedName?.call(
+          undefined,
+          args[i],
+          this.declarationNode,
+          this.unresolvedNames,
+        );
+      }
+    }
+
+    if (this.subfield.shouldRegister && !hasError) {
+      const entry = this.registerSubField(sub, args[0]).unwrap_or(undefined);
+      hasError = entry === undefined || hasError;
+    }
+
+    return !hasError;
+  }
+
+  private registerSubField(declarationNode: SyntaxNode, nameNode: SyntaxNode): Option<NodeSymbol> {
+    if (!this.declarationNode.symbol || !this.declarationNode.symbol.symbolTable) {
+      throw new Error('If an element allows registering subfields, it must own a symbol table');
+    }
+
+    if (!isSimpleName(nameNode)) {
+      throw new Error('If an element allows registering subfields, their name must be simple');
+    }
+    const name = extractVariableNode(nameNode).unwrap().value;
+    const { symbolTable } = this.declarationNode.symbol;
+    if (!name) {
+      throw new Error(`${this.elementKind} subfield's name shouldn't be empty`);
+    }
+
+    const id = createSubfieldId(name, this.context.name);
+    if (!id) {
+      throw new Error(
+        `${this.elementKind} fails to create subfield id to register in the symbol table`,
+      );
+    }
+    if (symbolTable.has(id)) {
+      this.logError(
+        nameNode,
+        this.subfield.duplicateErrorCode,
+        `${this.elementKind} subfield's name is duplicated`,
+      );
+
+      return new None();
+    }
+    const symbol = createSubfieldSymbol(declarationNode, this.context.name);
+    if (!symbol) {
+      throw new Error(
+        `${this.elementKind} fails to create subfield symbol to register in the symbol table`,
+      );
+    }
+
+    return new Some(symbolTable.get(id, symbol));
+  }
+
+  protected validateSubFieldSettingList(maybeSettingList: ExpressionNode): boolean {
+    if (!(maybeSettingList instanceof ListExpressionNode) && !this.subfield.settingList.optional) {
+      this.logError(
+        maybeSettingList,
+        this.subfield.settingList.notOptionalErrorCode,
+        `A ${this.elementKind} subfield must have a settingList`,
+      );
+
+      return false;
+    }
+
+    if (maybeSettingList instanceof ListExpressionNode && !this.subfield.settingList.allow) {
+      this.logError(
+        maybeSettingList,
+        this.subfield.settingList.notAllowErrorCode,
+        `A ${this.elementKind} subfield should not have a settingList`,
+      );
+
+      return false;
+    }
+
+    if (!(maybeSettingList instanceof ListExpressionNode)) {
+      return true;
+    }
+
+    return this.validateSettingListContent(maybeSettingList, this.subfield.settingList);
+  }
+
+  private validateSettingListContent(
+    settingListNode: ListExpressionNode,
+    config: SettingListValidatorConfig,
+  ): boolean {
+    const settingListSet = new Set<string>();
+    let hasError = false;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const setting of settingListNode.elementList) {
+      const name = extractStringFromIdentifierStream(setting.name).toLowerCase();
+      const { value } = setting;
+
+      if (!config.isValid(name, value).isOk()) {
+        this.logError(setting, config.unknownErrorCode, 'Unknown setting');
+        hasError = true;
+      } else if (settingListSet.has(name) && !config.allowDuplicate(name).unwrap()) {
+        this.logError(setting, config.duplicateErrorCode, 'Duplicate setting');
+        hasError = true;
+      } else {
+        settingListSet.add(name);
+        if (!config.isValid(name, value).unwrap()) {
+          this.logError(setting, config.invalidErrorCode, 'Invalid value for this setting');
+          hasError = true;
+        } else {
+          config.registerUnresolvedName(name, value, this.declarationNode, this.unresolvedNames);
+        }
+      }
+    }
+
+    return !hasError;
+  }
+
+  protected logError(
+    nodeOrToken: SyntaxNode | SyntaxToken,
+    code: CompileErrorCode | undefined,
+    message: string,
+  ) {
+    if (code === undefined) {
+      throw Error(`This error shouldn't exist. Maybe a validator is misconfigured
+       Error message: ${message}`);
+    }
+    // eslint-disable-next-line no-unused-expressions
+    this.errors.push(new CompileError(code, message, nodeOrToken));
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/enum.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/enum.ts
@@ -1,0 +1,93 @@
+import { UnresolvedName } from '../../types';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { isExpressionAVariableNode, isExpressionAQuotedString } from '../../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  registerNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class EnumValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.ENUM;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.EnumContext,
+    errorCode: CompileErrorCode.INVALID_ENUM_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isExpressionAVariableNode,
+        errorCode: CompileErrorCode.INVALID_ENUM_ELEMENT_NAME,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_ENUM_ELEMENT,
+    settingList: enumFieldSettingList(),
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_ENUM_ELEMENT_NAME,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}
+
+const enumFieldSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: true,
+        isValid: isExpressionAQuotedString,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_ENUM_ELEMENT_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_ENUM_ELEMENT_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_ENUM_ELEMENT_SETTING,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
@@ -1,0 +1,152 @@
+import { UnresolvedName } from '../../types';
+import { createColumnSymbolId } from '../../symbol/symbolIndex';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { SyntaxToken } from '../../../lexer/tokens';
+import {
+  ElementDeclarationNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  VariableNode,
+} from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../utils';
+import { destructureIndex } from '../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { isVoid } from '../utils';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class IndexesValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.INDEXES;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.IndexesContext,
+    errorCode: CompileErrorCode.INVALID_INDEXES_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: (node) => destructureIndex(node).unwrap_or(undefined) !== undefined,
+        errorCode: CompileErrorCode.INVALID_INDEX,
+        registerUnresolvedName: registerIndexForResolution,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_INDEX,
+    settingList: indexSettingList(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}
+
+export function registerIndexForResolution(
+  node: SyntaxNode,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  const columnIds = destructureIndex(node)
+    .unwrap_or(undefined)
+    ?.nonFunctional.map(createColumnSymbolId);
+
+  if (!columnIds) {
+    throw new Error(
+      'Unreachable - Index should be validated before registerIndexForResolution is called',
+    );
+  }
+
+  columnIds.forEach((id) =>
+    unresolvedNames.push({
+      id,
+      ownerElement,
+      referrer: node,
+    }));
+}
+
+export function isValidIndexesType(value?: SyntaxNode): boolean {
+  if (!(value instanceof PrimaryExpressionNode) || !(value.expression instanceof VariableNode)) {
+    return false;
+  }
+
+  const str = value.expression.variable.value;
+
+  return str === 'btree' || str === 'hash';
+}
+
+const indexSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      name: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      type: {
+        allowDuplicate: false,
+        isValid: isValidIndexesType,
+      },
+      unique: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      pk: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_INDEX_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_INDEX_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_INDEX_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/note.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/note.ts
@@ -1,0 +1,68 @@
+import { UnresolvedName } from '../../types';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  anyBodyConfig,
+  locallyUniqueConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class NoteValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.NOTE;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.NoteContext,
+    errorCode: CompileErrorCode.INVALID_NOTE_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = locallyUniqueConfig(CompileErrorCode.NOTE_REDEFINED).doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = anyBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isExpressionAQuotedString,
+        errorCode: CompileErrorCode.INVALID_NOTE,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_NOTE,
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/project.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/project.ts
@@ -1,0 +1,62 @@
+import { UnresolvedName } from '../../types';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  complexBodyConfig,
+  globallyUniqueConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  optionalNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class ProjectValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.PROJECT;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.ProjectContext,
+    errorCode: CompileErrorCode.INVALID_PROJECT_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = globallyUniqueConfig(CompileErrorCode.PROJECT_REDEFINED).doNotStopOnError();
+
+  protected name = optionalNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_PROJECT_FIELD,
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -1,0 +1,158 @@
+import { UnresolvedName } from '../../types';
+import { registerRelationshipOperand } from './utils';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { SyntaxToken } from '../../../lexer/tokens';
+import {
+  ElementDeclarationNode,
+  IdentiferStreamNode,
+  InfixExpressionNode,
+  SyntaxNode,
+} from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../utils';
+import { extractQuotedStringToken, extractStringFromIdentifierStream } from '../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { isBinaryRelationship } from '../utils';
+import {
+  anyBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  optionalNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+
+export default class RefValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.REF;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.RefContext,
+    errorCode: CompileErrorCode.INVALID_REF_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = optionalNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = anyBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isBinaryRelationship,
+        errorCode: CompileErrorCode.INVALID_REF_RELATIONSHIP,
+        registerUnresolvedName: registerBinaryRelationship,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_REF_FIELD,
+    settingList: refFieldSettings(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}
+
+function registerBinaryRelationship(
+  node: SyntaxNode,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  if (!isBinaryRelationship(node)) {
+    throw new Error(
+      'Unreachable - Must be a binary relationship when registerRelationshipOperands is called',
+    );
+  }
+
+  registerRelationshipOperand(
+    (node as InfixExpressionNode).leftExpression,
+    ownerElement,
+    unresolvedNames,
+  );
+  registerRelationshipOperand(
+    (node as InfixExpressionNode).rightExpression,
+    ownerElement,
+    unresolvedNames,
+  );
+}
+
+function isValidPolicy(value?: SyntaxNode): boolean {
+  if (!Array.isArray(value) && !isExpressionAQuotedString(value)) {
+    return false;
+  }
+
+  let extractedString: string | undefined;
+  if (value instanceof IdentiferStreamNode) {
+    extractedString = extractStringFromIdentifierStream(value);
+  } else {
+    extractedString = extractQuotedStringToken(value);
+  }
+
+  if (extractedString) {
+    switch (extractedString.toLowerCase()) {
+      case 'cascade':
+      case 'no action':
+      case 'set null':
+      case 'set default':
+      case 'restrict':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  return false; // unreachable
+}
+
+const refFieldSettings = () =>
+  createSettingListValidatorConfig(
+    {
+      delete: {
+        allowDuplicate: false,
+        isValid: isValidPolicy,
+      },
+      update: {
+        allowDuplicate: false,
+        isValid: isValidPolicy,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_REF_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_REF_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_REF_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
@@ -1,0 +1,260 @@
+import { UnresolvedName } from '../../types';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import {
+  CallExpressionNode,
+  ElementDeclarationNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+} from '../../../parser/nodes';
+import {
+  isAccessExpression,
+  isExpressionAVariableNode,
+  isExpressionAQuotedString,
+} from '../../../utils';
+import { destructureComplexVariable } from '../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+ isUnaryRelationship, isValidColor, isValidDefaultValue, isVoid,
+} from '../utils';
+import {
+  registerNameConfig,
+  optionalAliasConfig,
+  complexBodyConfig,
+  noUniqueConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import {
+  createEnumFieldSymbolId,
+  createEnumSymbolId,
+  createSchemaSymbolId,
+} from '../../symbol/symbolIndex';
+import { registerRelationshipOperand } from './utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class TableValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.TABLE;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.TableContext,
+    errorCode: CompileErrorCode.INVALID_TABLE_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = optionalAliasConfig.doNotStopOnError();
+
+  protected settingList = createSettingListValidatorConfig(
+    {
+      headercolor: {
+        allowDuplicate: false,
+        isValid: isValidColor,
+      },
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.INVALID_TABLE_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_TABLE_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_TABLE_SETTING,
+      stopOnError: false,
+    },
+  );
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isExpressionAVariableNode,
+        errorCode: CompileErrorCode.INVALID_COLUMN_NAME,
+      },
+      {
+        validateArg: isValidColumnType,
+        errorCode: CompileErrorCode.INVALID_COLUMN_TYPE,
+        registerUnresolvedName: registerEnumTypeIfComplexVariable,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_COLUMN,
+    settingList: columnSettingList(),
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_COLUMN_NAME,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}
+
+function registerEnumTypeIfComplexVariable(
+  node: SyntaxNode,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  if (!isAccessExpression(node)) {
+    return;
+  }
+
+  if (!isValidColumnType(node)) {
+    throw new Error('Unreachable - Invalid type when registerTypeIfComplexVariable is called');
+  }
+
+  const fragments = destructureComplexVariable(node).unwrap();
+  const enumId = createEnumSymbolId(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolId);
+
+  unresolvedNames.push({
+    id: enumId,
+    qualifiers: schemaIdStack,
+    ownerElement,
+    referrer: node,
+  });
+}
+
+function isValidColumnType(type: SyntaxNode): boolean {
+  if (
+    !(
+      type instanceof CallExpressionNode ||
+      isAccessExpression(type) ||
+      type instanceof PrimaryExpressionNode
+    )
+  ) {
+    return false;
+  }
+
+  while (type instanceof CallExpressionNode) {
+    // eslint-disable-next-line no-param-reassign
+    type = type.callee;
+  }
+
+  const variables = destructureComplexVariable(type).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+const columnSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      ref: {
+        allowDuplicate: true,
+        isValid: isUnaryRelationship,
+        registerUnresolvedName: registerUnaryRelationship,
+      },
+      'primary key': {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      default: {
+        allowDuplicate: false,
+        isValid: isValidDefaultValue,
+        registerUnresolvedName: registerEnumValueIfComplexVar,
+      },
+      increment: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      'not null': {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      null: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      pk: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      unique: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_COLUMN_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_COLUMN_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_COLUMN_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );
+
+function registerUnaryRelationship(
+  value: SyntaxNode | undefined,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  if (!isUnaryRelationship(value)) {
+    throw new Error('Unreachable - Must be an unary rel when regiterUnaryRelationship is called');
+  }
+  registerRelationshipOperand(
+    (value as PrefixExpressionNode).expression,
+    ownerElement,
+    unresolvedNames,
+  );
+}
+
+function registerEnumValueIfComplexVar(
+  value: SyntaxNode | undefined,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  if (!isValidDefaultValue(value)) {
+    throw new Error('Unreachable - Invalid default when registerEnumValueIfComplexVar is called');
+  }
+
+  if (value instanceof PrimaryExpressionNode) {
+    return;
+  }
+
+  const fragments = destructureComplexVariable(value as SyntaxNode).unwrap();
+  const enumFieldId = createEnumFieldSymbolId(fragments.pop()!);
+  const enumId = createEnumSymbolId(fragments.pop()!);
+  const schemaId = fragments.map(createSchemaSymbolId);
+
+  unresolvedNames.push({
+    id: enumFieldId,
+    qualifiers: [...schemaId, enumId],
+    ownerElement,
+    referrer: value as SyntaxNode,
+  });
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
@@ -1,0 +1,91 @@
+import { UnresolvedName } from '../../types';
+import { destructureComplexVariable } from '../../utils';
+import { createSchemaSymbolId, createTableSymbolId } from '../../symbol/symbolIndex';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode, SyntaxNode } from '../../../parser/nodes';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  registerNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { isValidName } from '../utils';
+
+export default class TableGroupValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.TABLEGROUP;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.TableGroupContext,
+    errorCode: CompileErrorCode.INVALID_TABLEGROUP_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: isValidName,
+        errorCode: CompileErrorCode.INVALID_TABLEGROUP_ELEMENT_NAME,
+        registerUnresolvedName: registerTableName,
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_TABLEGROUP_FIELD,
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode,
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    unresolvedNames: UnresolvedName[],
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      unresolvedNames,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+    );
+  }
+}
+
+function registerTableName(
+  node: SyntaxNode,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  if (!isValidName(node)) {
+    throw new Error('Unreachable - Must be a valid name when registerTableName is called');
+  }
+  const fragments = destructureComplexVariable(node).unwrap();
+  const tableId = createTableSymbolId(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolId);
+
+  unresolvedNames.push({
+    id: tableId,
+    qualifiers: schemaIdStack.length === 0 ? [createSchemaSymbolId('public')] : schemaIdStack,
+    referrer: node,
+    ownerElement,
+  });
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
@@ -1,0 +1,39 @@
+import { ElementDeclarationNode, NormalExpressionNode } from '../../../parser/nodes';
+import {
+  createColumnSymbolId,
+  createSchemaSymbolId,
+  createTableSymbolId,
+} from '../../symbol/symbolIndex';
+import { UnresolvedName } from '../../types';
+import { destructureComplexVariable } from '../../utils';
+
+// Register a relationship operand for later resolution
+// eslint-disable-next-line import/prefer-default-export
+export function registerRelationshipOperand(
+  node: NormalExpressionNode,
+  ownerElement: ElementDeclarationNode,
+  unresolvedNames: UnresolvedName[],
+) {
+  const fragments = destructureComplexVariable(node).unwrap();
+
+  const columnId = createColumnSymbolId(fragments.pop()!);
+  if (fragments.length === 0) {
+    unresolvedNames.push({
+      id: columnId,
+      ownerElement,
+      referrer: node,
+    });
+
+    return;
+  }
+
+  const tableId = createTableSymbolId(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolId);
+
+  unresolvedNames.push({
+    id: columnId,
+    qualifiers: [...schemaIdStack, tableId],
+    ownerElement,
+    referrer: node,
+  });
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
@@ -1,0 +1,392 @@
+import { ElementDeclarationNode, SyntaxNode } from '../../parser/nodes';
+import { CompileErrorCode } from '../../errors';
+import { SyntaxToken } from '../../lexer/tokens';
+import { None, Option, Some } from '../../option';
+import { ValidatorContext } from './validatorContext';
+import { UnresolvedName } from '../types';
+
+// Each element has its own element kind
+// Except for custom elements, which all fall under one kind
+// e.g
+// Project {
+//   project_name: 'My project' // custom element
+//   version: '1.0.0' // custom element
+// }
+export enum ElementKind {
+  TABLE = 'Table',
+  ENUM = 'Enum',
+  INDEXES = 'Indexes',
+  NOTE = 'Note',
+  PROJECT = 'Project',
+  REF = 'Ref',
+  TABLEGROUP = 'TableGroup',
+  CUSTOM = '<CUSTOM>',
+}
+
+// An object that can validate a certain setting
+// e.g Table [headercolor: #123]
+//   -> headercolor has its own SettingValidator
+export interface SettingValidator {
+  // Whether the setting is allowed to appear more than once
+  // e.g id integer [ref: > Products.uid, ref: ...]
+  //  -> ref can be duplicated
+  // e.g Table [note: 'this is a note']
+  //  -> note can not be duplicated
+  allowDuplicate: boolean;
+
+  // A callback that validates whether `value` is valid for the setting
+  isValid: (value?: SyntaxNode) => boolean;
+
+  // An optional callback that registers the setting value for later name resolution
+  registerUnresolvedName?(
+    value: SyntaxNode | undefined,
+    ownerElement: ElementDeclarationNode,
+    unresolvedNames: UnresolvedName[],
+  ): void;
+}
+
+// An object that can validates a term in an element's subfield
+// By definition, an element's subfield is a single primary expression
+// or a function application, which can have many arguments
+// The callee is also treated as an argument
+// e.g
+// Table Users {
+//   id integer [pk] // 'id' and 'integer' have their own validator
+//                   // '[pk]' is validated by the Table's subfield setting validator
+// }
+//
+export interface ArgumentValidator {
+  // Validator whether the node is a valid argument
+  validateArg(node: SyntaxNode): boolean;
+
+  // Corresponding error code when the arg is invalid
+  errorCode: Readonly<CompileErrorCode>;
+
+  // An optional callback that registers an argument for later name resolution
+  registerUnresolvedName?(
+    node: SyntaxNode,
+    ownerElement: ElementDeclarationNode,
+    unresolvedNames: UnresolvedName[],
+  ): void;
+}
+
+// A configuration object
+// that dictates whether an element can appear within a certain `context`
+// e.g
+//   A Table can not appear inside a RefContext
+export interface ContextValidatorConfig {
+  // Which context is associated with this configuration?
+  name: Readonly<ValidatorContext>;
+  errorCode: Readonly<CompileErrorCode>;
+
+  // Should the validation stops immediately upon context checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates whether an element must be unique globally or locally in the current scope
+// e.g
+//   There can only be one Project -> globally unique
+//   There can not be more than one Notes in a Table -> locally unique
+export interface UniqueElementValidatorConfig {
+  globally: Readonly<boolean>;
+  notGloballyErrorCode?: Readonly<CompileErrorCode>;
+
+  locally: Readonly<boolean>;
+  notLocallyErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stops immediately upon uniqueness checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of an element's name
+// e.g
+//   A Table name is not optional, can be complex (v2.Users) and must be registrated
+//   A Ref name is optional, can be complex and is not registrated (no uniqueness constraint)
+export interface NameValidatorConfig {
+  // Is the name optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have a name
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to be complex
+  allowComplex: Readonly<boolean>;
+  complexErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should it be registered
+  shouldRegister: Readonly<boolean>;
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stops immediately upon name checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of an element's alias
+// e.g
+//   Only Tables are allowed to have aliases
+export interface AliasValidatorConfig {
+  // Is the alias optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have an alias
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon alias checking failure
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the settings allowed on an element or a subfield
+export interface SettingListValidatorConfig {
+  // Is the settingList optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have settingList
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Error Code for unknown setting name
+  unknownErrorCode?: Readonly<CompileErrorCode>;
+  // Error Code for duplicate setting name (if the setting is not allowed to have duplicate)
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+  // Error Code for unknown setting name
+  invalidErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon setting list checking failure
+  stopOnError: Readonly<boolean>;
+
+  // A function that determines whether a specific value is allowed for a specific setting
+  // Return `Some(true)` if it's allowed
+  //        `Some(false)` if it's not allowed
+  //        `None` if the setting name is unknown
+  isValid(name: string, value?: SyntaxNode): Option<boolean>;
+
+  // A function that determines whether a specific setting is allowed to be duplicated
+  // Return value is similar to `isValid`
+  allowDuplicate(name: string): Option<boolean>;
+
+  // A function that can register a value of a setting for later name resolution
+  registerUnresolvedName(
+    settingName: string,
+    value: SyntaxNode | undefined,
+    ownerElement: ElementDeclarationNode,
+    unresolvedNames: UnresolvedName[],
+  ): void;
+}
+
+// A configuration object
+// that dictates the format of an element body
+export interface BodyValidatorConfig {
+  // Can the body be simple
+  // e.g Ref: Users.id < Products.uid
+  allowSimple: Readonly<boolean>;
+  simpleErrorCode?: Readonly<CompileErrorCode>;
+
+  // Can the body be complex
+  // e.g Table Users {
+  //
+  // }
+  allowComplex: Readonly<boolean>;
+  complexErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon body checking failure
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of a subfield
+// e.g A Table subfield (column) must have 2 args, including the callee,
+//     but excluding the setting list (optional)
+export interface SubFieldValidatorConfig {
+  // The list of validators for each argument
+  argValidators: Readonly<ArgumentValidator[]>;
+  invalidArgNumberErrorCode?: Readonly<CompileErrorCode>;
+
+  // The setting list configuration of the subfield
+  settingList: Readonly<SettingListValidatorConfig>;
+
+  // Should a subfield's callee be registered
+  // For example, a Table's column name can not be duplicated
+  shouldRegister: Readonly<boolean>;
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+}
+
+export function createContextValidatorConfig(
+  config: ContextValidatorConfig,
+): ContextValidatorConfig {
+  return config;
+}
+
+export function createUniqueValidatorConfig(
+  config: UniqueElementValidatorConfig,
+): UniqueElementValidatorConfig {
+  if (config.globally && !config.notGloballyErrorCode) {
+    throw new Error(
+      'Misconfigurartion: If an element is globally unique, notGloballyErrorCode must be set',
+    );
+  }
+
+  if (config.locally && !config.notLocallyErrorCode) {
+    throw new Error(
+      'Misconfigurartion: If an element is locally unique, notLocallyErrorCode must be set',
+    );
+  }
+
+  return config;
+}
+
+export function createNameValidatorConfig(config: NameValidatorConfig): NameValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If name is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error('Misconfiguration: If name is not allowed, notAllowErrorCode must be present');
+  }
+
+  if (config.shouldRegister && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If name should be registered, duplicateErrorCode must be present',
+    );
+  }
+
+  return config;
+}
+
+export function createAliasValidatorConfig(config: AliasValidatorConfig): AliasValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If alias is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error('Misconfiguration: If alias is not allowed, notAllowErrorCode must be present');
+  }
+
+  return config;
+}
+
+export function createSettingListValidatorConfig(
+  validatorMap: { [settingName: string]: SettingValidator },
+  config: {
+    optional: boolean;
+    notOptionalErrorCode?: CompileErrorCode;
+    allow: boolean;
+    notAllowErrorCode?: CompileErrorCode;
+    unknownErrorCode?: CompileErrorCode;
+    duplicateErrorCode?: CompileErrorCode;
+    invalidErrorCode?: CompileErrorCode;
+    stopOnError: boolean;
+  },
+): SettingListValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is not allowed, notAllowErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.unknownErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, unknownErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, duplicateErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.invalidErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, notAllowErrorCode must be present',
+    );
+  }
+
+  return {
+    ...config,
+
+    isValid(name: string, value?: SyntaxNode): Option<boolean> {
+      const validator = validatorMap[name];
+      if (!validator) {
+        return new None();
+      }
+
+      return new Some(validator.isValid(value));
+    },
+
+    allowDuplicate(name: string): Option<boolean> {
+      const validator = validatorMap[name];
+      if (!validator) {
+        return new None();
+      }
+
+      return new Some(validator.allowDuplicate);
+    },
+
+    registerUnresolvedName(
+      settingName: string,
+      value: SyntaxNode | undefined,
+      ownerElement: ElementDeclarationNode,
+      unresolvedNames: UnresolvedName[],
+    ): void {
+      const validator = validatorMap[settingName];
+      if (!validator) {
+        throw new Error(
+          "Unreachable - registerUnresolvedName must be called after it's sure the setting's there",
+        );
+      }
+
+      validator.registerUnresolvedName?.call(undefined, value, ownerElement, unresolvedNames);
+    },
+  };
+}
+
+export function createBodyValidatorConfig(config: BodyValidatorConfig): BodyValidatorConfig {
+  if (!config.allowSimple && !config.simpleErrorCode) {
+    throw new Error('Misconfiguration: If simple body is not allowed, simpleErrorCode must be set');
+  }
+
+  if (!config.allowComplex && !config.complexErrorCode) {
+    throw new Error(
+      'Misconfiguration: If complex body is not allowed, complexErrorCode must be set',
+    );
+  }
+
+  return config;
+}
+
+export function createSubFieldValidatorConfig(
+  config: SubFieldValidatorConfig,
+): SubFieldValidatorConfig {
+  if (config.argValidators.length > 0 && !config.invalidArgNumberErrorCode) {
+    throw new Error(
+      'Misconfiguration: If subfield accepts arguments, invalidArgNumberErrorCode must be present',
+    );
+  }
+
+  if (config.shouldRegister && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If subfield should be registered, duplicateErrorCode must be present',
+    );
+  }
+
+  return config;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
@@ -1,0 +1,185 @@
+import { SyntaxToken, SyntaxTokenKind } from '../../lexer/tokens';
+import {
+  BlockExpressionNode,
+  ElementDeclarationNode,
+  ListExpressionNode,
+  LiteralNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  VariableNode,
+} from '../../parser/nodes';
+import { isAccessExpression, isHexChar } from '../../utils';
+import { destructureComplexVariable, isBinaryRelationship } from '../utils';
+import CustomValidator from './elementValidators/custom';
+import EnumValidator from './elementValidators/enum';
+import IndexesValidator from './elementValidators/indexes';
+import NoteValidator from './elementValidators/note';
+import ProjectValidator from './elementValidators/project';
+import RefValidator from './elementValidators/ref';
+import TableValidator from './elementValidators/table';
+import TableGroupValidator from './elementValidators/tableGroup';
+import { createSchemaSymbolId } from '../symbol/symbolIndex';
+import { SchemaSymbol } from '../symbol/symbols';
+import SymbolTable from '../symbol/symbolTable';
+
+// Pick a validator suitable for `element`
+export function pickValidator(element: ElementDeclarationNode) {
+  switch (element.type.value.toLowerCase()) {
+    case 'enum':
+      return EnumValidator;
+    case 'table':
+      return TableValidator;
+    case 'tablegroup':
+      return TableGroupValidator;
+    case 'project':
+      return ProjectValidator;
+    case 'ref':
+      return RefValidator;
+    case 'note':
+      return NoteValidator;
+    case 'indexes':
+      return IndexesValidator;
+    default:
+      return CustomValidator;
+  }
+}
+
+// Is the name valid (either simple or complex)
+export function isValidName(nameNode: SyntaxNode): boolean {
+  return !!destructureComplexVariable(nameNode).unwrap_or(false);
+}
+
+// Is the alias valid (only simple name is allowed)
+export function isValidAlias(
+  aliasNode: SyntaxNode,
+): aliasNode is PrimaryExpressionNode & { expression: VariableNode } {
+  return isSimpleName(aliasNode);
+}
+
+// Is the name valid and simple
+export function isSimpleName(
+  nameNode: SyntaxNode,
+): nameNode is PrimaryExpressionNode & { expression: VariableNode } {
+  return nameNode instanceof PrimaryExpressionNode && nameNode.expression instanceof VariableNode;
+}
+
+// Is the argument a ListExpression
+export function isValidSettingList(
+  settingListNode: SyntaxNode,
+): settingListNode is ListExpressionNode {
+  return settingListNode instanceof ListExpressionNode;
+}
+
+// Does the element has complex body
+export function hasComplexBody(
+  node: ElementDeclarationNode,
+): node is ElementDeclarationNode & { body: BlockExpressionNode; bodyColon: undefined } {
+  return node.body instanceof BlockExpressionNode && !node.bodyColon;
+}
+
+// Does the element has simple body
+export function hasSimpleBody(
+  node: ElementDeclarationNode,
+): node is ElementDeclarationNode & { bodyColon: SyntaxToken } {
+  return !!node.bodyColon;
+}
+
+// Register the `variables` array as a stack of schema, the following nested within the former
+// `initialSchema` is the schema in which the first variable of `variables` is nested within
+export function registerSchemaStack(variables: string[], initialSchema: SymbolTable): SymbolTable {
+  let prevSchema = initialSchema;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const curName of variables) {
+    let curSchema: SymbolTable | undefined;
+    const curId = createSchemaSymbolId(curName);
+
+    if (!prevSchema.has(curId)) {
+      curSchema = new SymbolTable();
+      const curSymbol = new SchemaSymbol(curSchema);
+      prevSchema.set(curId, curSymbol);
+    } else {
+      curSchema = prevSchema.get(curId)?.symbolTable;
+      if (!curSchema) {
+        throw new Error('Expect a symbol table in a schema symbol');
+      }
+    }
+    prevSchema = curSchema;
+  }
+
+  return prevSchema;
+}
+
+export function isRelationshipOp(op: string): boolean {
+  return op === '-' || op === '<>' || op === '>' || op === '<';
+}
+
+export function isValidColor(value?: SyntaxNode): boolean {
+  if (
+    !(value instanceof PrimaryExpressionNode) ||
+    !(value.expression instanceof LiteralNode) ||
+    !(value.expression.literal.kind === SyntaxTokenKind.COLOR_LITERAL)
+  ) {
+    return false;
+  }
+
+  const color = value.expression.literal.value;
+
+  // e.g. #fff or #0abcde
+  if (color.length !== 4 && color.length !== 7) {
+    return false;
+  }
+
+  if (color[0] !== '#') {
+    return false;
+  }
+
+  for (let i = 1; i < color.length; i += 1) {
+    if (!isHexChar(color[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Is the value non-existent
+export function isVoid(value?: SyntaxNode): boolean {
+  return (
+    value === undefined ||
+    (!Array.isArray(value) && value.end === -1 && value.start === -1) ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
+// Is the `value` a valid value for a column's `default` setting
+// It's a valid only if it's a literal or a complex variable (potentially an enum member)
+export function isValidDefaultValue(value?: SyntaxNode): boolean {
+  if (value instanceof PrimaryExpressionNode && value.expression instanceof LiteralNode) {
+    return true;
+  }
+
+  if (!value || Array.isArray(value) || !isAccessExpression(value)) {
+    return false;
+  }
+
+  const variables = destructureComplexVariable(value).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+export function isUnaryRelationship(value?: SyntaxNode): boolean {
+  if (!(value instanceof PrefixExpressionNode)) {
+    return false;
+  }
+
+  if (!isRelationshipOp(value.op.value)) {
+    return false;
+  }
+
+  const variables = destructureComplexVariable(value.expression).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+export { isBinaryRelationship };

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validator.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validator.ts
@@ -1,0 +1,64 @@
+import Report from '../../report';
+import { CompileError } from '../../errors';
+import { ProgramNode } from '../../parser/nodes';
+import { ContextStack } from './validatorContext';
+import { SchemaSymbol } from '../symbol/symbols';
+import { pickValidator } from './utils';
+import { ElementKind } from './types';
+import { createSchemaSymbolId } from '../symbol/symbolIndex';
+import SymbolTable from '../symbol/symbolTable';
+import { UnresolvedName } from '../types';
+
+export default class Validator {
+  private ast: ProgramNode;
+
+  private publicSchemaSymbol: SchemaSymbol;
+
+  private contextStack: ContextStack;
+
+  private kindsGloballyFound: Set<ElementKind>;
+  private kindsLocallyFound: Set<ElementKind>;
+
+  private unresolvedNames: UnresolvedName[];
+
+  private errors: CompileError[];
+
+  constructor(ast: ProgramNode) {
+    this.ast = ast;
+    this.contextStack = new ContextStack();
+    this.errors = [];
+    this.publicSchemaSymbol = new SchemaSymbol(new SymbolTable());
+    this.kindsGloballyFound = new Set();
+    this.kindsLocallyFound = new Set();
+    this.unresolvedNames = [];
+
+    this.publicSchemaSymbol.symbolTable.set(
+      createSchemaSymbolId('public'),
+      this.publicSchemaSymbol,
+    );
+  }
+
+  validate(): Report<
+    { program: ProgramNode; schema: SchemaSymbol; unresolvedNames: UnresolvedName[] },
+    CompileError
+  > {
+    this.ast.body.forEach((element) => {
+      const Val = pickValidator(element);
+      const validatorObject = new Val(
+        element,
+        this.publicSchemaSymbol,
+        this.contextStack,
+        this.unresolvedNames,
+        this.errors,
+        this.kindsGloballyFound,
+        this.kindsLocallyFound,
+      );
+      validatorObject.validate();
+    });
+
+    return new Report(
+      { program: this.ast, schema: this.publicSchemaSymbol, unresolvedNames: this.unresolvedNames },
+      this.errors,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validatorContext.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validatorContext.ts
@@ -1,0 +1,88 @@
+export const enum ValidatorContext {
+  TopLevelContext,
+  ProjectContext,
+  TableContext,
+  TableGroupContext,
+  EnumContext,
+  RefContext,
+  IndexesContext,
+  NoteContext,
+  CustomContext,
+}
+
+export function canBeNestedWithin(
+  container: ValidatorContext,
+  containee: ValidatorContext,
+): boolean {
+  switch (container) {
+    case ValidatorContext.TopLevelContext:
+      return (
+        containee === ValidatorContext.ProjectContext ||
+        containee === ValidatorContext.TableContext ||
+        containee === ValidatorContext.TableGroupContext ||
+        containee === ValidatorContext.EnumContext ||
+        containee === ValidatorContext.RefContext
+      );
+    case ValidatorContext.ProjectContext:
+      return (
+        containee === ValidatorContext.TableContext ||
+        containee === ValidatorContext.TableGroupContext ||
+        containee === ValidatorContext.EnumContext ||
+        containee === ValidatorContext.NoteContext ||
+        containee === ValidatorContext.RefContext ||
+        containee === ValidatorContext.CustomContext
+      );
+    case ValidatorContext.TableContext:
+      return (
+        containee === ValidatorContext.IndexesContext ||
+        containee === ValidatorContext.NoteContext ||
+        containee === ValidatorContext.RefContext
+      );
+    default:
+      return false;
+  }
+}
+
+export function canContainField(container: ValidatorContext, fieldName: string) {
+  // eslint-disable-next-line
+  const _fieldName = fieldName.toLowerCase();
+
+  switch (container) {
+    case ValidatorContext.ProjectContext:
+      return true;
+    case ValidatorContext.TableContext:
+      return _fieldName === 'note' || _fieldName === 'ref';
+    default:
+      return false;
+  }
+}
+
+export class ContextStack {
+  private stack: ValidatorContext[] = [ValidatorContext.TopLevelContext];
+
+  push(ctx: ValidatorContext) {
+    this.stack.push(ctx);
+  }
+
+  pop(): ValidatorContext {
+    return this.stack.length === 1 ? this.stack[0] : this.stack.pop()!;
+  }
+
+  top(): ValidatorContext {
+    return this.stack[this.stack.length - 1];
+  }
+
+  parent(): ValidatorContext {
+    return this.stack.length === 1 ? this.stack[0] : this.stack[this.stack.length - 2];
+  }
+
+  isWithinContext(ctx: ValidatorContext): boolean {
+    for (let i = this.stack.length - 1; i >= 0; i -= 1) {
+      if (this.stack[i] === ctx) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
* Implement the validator for DBML parser
* Previous PR: #422
* Next PR: #424 
* Implementation details: [Notion](https://www.notion.so/holistics/Analyzer-4bc8949df2744e198f7d287141a5e738)

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review