### PR TITLE
7. add node & symbol ids to support proper serialization

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/binder.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/binder.ts
@@ -2,7 +2,7 @@ import { CompileError, CompileErrorCode } from '../../errors';
 import { ProgramNode, SyntaxNode } from '../../parser/nodes';
 import { UnresolvedName } from '../types';
 import Report from '../../report';
-import { destructureId } from '../symbol/symbolIndex';
+import { destructureIndex } from '../symbol/symbolIndex';
 import { findSymbol } from '../utils';
 
 export default class Binder {
@@ -34,7 +34,7 @@ export default class Binder {
     const [accessId, ...remainingIds] = ids;
     const accessSymbol = findSymbol(accessId, ownerElement);
     if (accessSymbol === undefined) {
-      const { type, name } = destructureId(accessId);
+      const { type, name } = destructureIndex(accessId);
       this.logError(referrer, `Can not find ${type} '${name}'`);
 
       return;
@@ -46,11 +46,11 @@ export default class Binder {
 
     const elementId = remainingIds.pop()!;
 
-    let { type: prevType, name: prevName } = destructureId(accessId);
+    let { type: prevType, name: prevName } = destructureIndex(accessId);
     let prevScope = accessSymbol.symbolTable!;
     // eslint-disable-next-line no-restricted-syntax
     for (const qualifierId of remainingIds) {
-      const { type: curType, name: curName } = destructureId(qualifierId);
+      const { type: curType, name: curName } = destructureIndex(qualifierId);
       const curSymbol = prevScope.get(qualifierId);
 
       if (!curSymbol) {
@@ -69,7 +69,7 @@ export default class Binder {
     }
 
     if (!prevScope.has(elementId)) {
-      const { type, name } = destructureId(elementId);
+      const { type, name } = destructureIndex(elementId);
       this.logError(referrer, `${prevType} '${prevName}' does not have ${type} '${name}'`);
 
       return;

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolIndex.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolIndex.ts
@@ -1,35 +1,35 @@
 // Used to index a symbol table to obtain a symbol
-export type NodeSymbolId = string;
+export type NodeSymbolIndex = string;
 
-export function createSchemaSymbolId(key: string): NodeSymbolId {
+export function createSchemaSymbolIndex(key: string): NodeSymbolIndex {
   return `Schema:${key}`;
 }
 
-export function createTableSymbolId(key: string): NodeSymbolId {
+export function createTableSymbolIndex(key: string): NodeSymbolIndex {
   return `Table:${key}`;
 }
 
-export function createColumnSymbolId(key: string): NodeSymbolId {
+export function createColumnSymbolIndex(key: string): NodeSymbolIndex {
   return `Column:${key}`;
 }
 
-export function createEnumSymbolId(key: string): NodeSymbolId {
+export function createEnumSymbolIndex(key: string): NodeSymbolIndex {
   return `Enum:${key}`;
 }
 
-export function createEnumFieldSymbolId(key: string): NodeSymbolId {
+export function createEnumFieldSymbolIndex(key: string): NodeSymbolIndex {
   return `Enum field:${key}`;
 }
 
-export function createTableGroupSymbolId(key: string): NodeSymbolId {
+export function createTableGroupSymbolIndex(key: string): NodeSymbolIndex {
   return `TableGroup:${key}`;
 }
 
-export function TableGroupFieldSymbolId(key: string): NodeSymbolId {
+export function TableGroupFieldSymbolIndex(key: string): NodeSymbolIndex {
   return `Tablegroup field:${key}`;
 }
 
-export function destructureId(id: NodeSymbolId): { name: string; type: string } {
+export function destructureIndex(id: NodeSymbolIndex): { name: string; type: string } {
   const [type, name] = id.split(':');
 
   return {
@@ -38,8 +38,8 @@ export function destructureId(id: NodeSymbolId): { name: string; type: string } 
   };
 }
 
-export function isPublicSchemaId(id: NodeSymbolId): boolean {
-  const { type, name } = destructureId(id);
+export function isPublicSchemaIndex(id: NodeSymbolIndex): boolean {
+  const { type, name } = destructureIndex(id);
 
   return type === 'Schema' && name === 'public';
 }

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolTable.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolTable.ts
@@ -1,24 +1,24 @@
-import { NodeSymbolId } from './symbolIndex';
+import { NodeSymbolIndex } from './symbolIndex';
 import { NodeSymbol } from './symbols';
 
 export default class SymbolTable {
-  private table: Map<NodeSymbolId, NodeSymbol>;
+  private table: Map<NodeSymbolIndex, NodeSymbol>;
 
   constructor() {
     this.table = new Map();
   }
 
-  has(id: NodeSymbolId): boolean {
+  has(id: NodeSymbolIndex): boolean {
     return this.table.has(id);
   }
 
-  set(id: NodeSymbolId, value: NodeSymbol) {
+  set(id: NodeSymbolIndex, value: NodeSymbol) {
     this.table.set(id, value);
   }
 
-  get(id: NodeSymbolId): NodeSymbol | undefined;
-  get(id: NodeSymbolId, defaultValue: NodeSymbol): NodeSymbol;
-  get(id: NodeSymbolId, defaultValue?: NodeSymbol): NodeSymbol | undefined {
+  get(id: NodeSymbolIndex): NodeSymbol | undefined;
+  get(id: NodeSymbolIndex, defaultValue: NodeSymbol): NodeSymbol;
+  get(id: NodeSymbolIndex, defaultValue?: NodeSymbol): NodeSymbol | undefined {
     return (
       this.table.get(id) ||
       (defaultValue !== undefined && this.set(id, defaultValue)) ||

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbols.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbols.ts
@@ -1,7 +1,21 @@
 import SymbolTable from './symbolTable';
 import { SyntaxNode } from '../../parser/nodes';
 
+export type NodeSymbolId = number;
+export class NodeSymbolIdGenerator {
+  private static id = 0;
+
+  static reset() {
+    this.id = 0;
+  }
+
+  static nextId(): NodeSymbolId {
+    return this.id++;
+  }
+}
+
 export interface NodeSymbol {
+  id: NodeSymbolId;
   symbolTable?: SymbolTable;
   declaration?: SyntaxNode;
   references: SyntaxNode[];
@@ -9,11 +23,14 @@ export interface NodeSymbol {
 
 // A symbol for a schema, contains the schema's symbol table
 export class SchemaSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   symbolTable: SymbolTable;
 
   references: SyntaxNode[] = [];
 
-  constructor(symbolTable: SymbolTable) {
+  constructor(symbolTable: SymbolTable, id: NodeSymbolId = NodeSymbolIdGenerator.nextId()) {
+    this.id = id;
     this.symbolTable = symbolTable;
   }
 }
@@ -21,13 +38,20 @@ export class SchemaSymbol implements NodeSymbol {
 // A symbol for an enum, contains the enum's symbol table
 // which is used to hold all the enum field symbols of the enum
 export class EnumSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   symbolTable: SymbolTable;
 
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(symbolTable: SymbolTable, declaration: SyntaxNode) {
+  constructor(
+    symbolTable: SymbolTable,
+    declaration: SyntaxNode,
+    id: NodeSymbolId = NodeSymbolIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.symbolTable = symbolTable;
     this.declaration = declaration;
   }
@@ -35,11 +59,14 @@ export class EnumSymbol implements NodeSymbol {
 
 // A symbol for an enum field
 export class EnumFieldSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(declaration: SyntaxNode) {
+  constructor(declaration: SyntaxNode, id: NodeSymbolId = NodeSymbolIdGenerator.nextId()) {
+    this.id = id;
     this.declaration = declaration;
   }
 }
@@ -47,13 +74,20 @@ export class EnumFieldSymbol implements NodeSymbol {
 // A symbol for a table, contains the table's symbol table
 // which is used to hold all the column symbols of the table
 export class TableSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   symbolTable: SymbolTable;
 
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(symbolTable: SymbolTable, declaration: SyntaxNode) {
+  constructor(
+    symbolTable: SymbolTable,
+    declaration: SyntaxNode,
+    id: NodeSymbolId = NodeSymbolIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.symbolTable = symbolTable;
     this.declaration = declaration;
   }
@@ -61,11 +95,14 @@ export class TableSymbol implements NodeSymbol {
 
 // A symbol for a column field
 export class ColumnSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(declaration: SyntaxNode) {
+  constructor(declaration: SyntaxNode, id: NodeSymbolId = NodeSymbolIdGenerator.nextId()) {
+    this.id = id;
     this.declaration = declaration;
   }
 }
@@ -73,13 +110,20 @@ export class ColumnSymbol implements NodeSymbol {
 // A symbol for a tablegroup, contains the symbol table for the tablegroup
 // which is used to hold all the symbols of the table group fields
 export class TableGroupSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   symbolTable: SymbolTable;
 
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(symbolTable: SymbolTable, declaration: SyntaxNode) {
+  constructor(
+    symbolTable: SymbolTable,
+    declaration: SyntaxNode,
+    id: NodeSymbolId = NodeSymbolIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.symbolTable = symbolTable;
     this.declaration = declaration;
   }
@@ -87,11 +131,14 @@ export class TableGroupSymbol implements NodeSymbol {
 
 // A symbol for a tablegroup field
 export class TableGroupFieldSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
   declaration: SyntaxNode;
 
   references: SyntaxNode[] = [];
 
-  constructor(declaration: SyntaxNode) {
+  constructor(declaration: SyntaxNode, id: NodeSymbolId = NodeSymbolIdGenerator.nextId()) {
+    this.id = id;
     this.declaration = declaration;
   }
 }

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
@@ -1,12 +1,12 @@
 import { SyntaxNode } from '../../parser/nodes';
 import { ValidatorContext } from '../validator/validatorContext';
 import {
-  NodeSymbolId,
-  createColumnSymbolId,
-  createEnumFieldSymbolId,
-  createEnumSymbolId,
-  createTableGroupSymbolId,
-  createTableSymbolId,
+  NodeSymbolIndex,
+  createColumnSymbolIndex,
+  createEnumFieldSymbolIndex,
+  createEnumSymbolIndex,
+  createTableGroupSymbolIndex,
+  createTableSymbolIndex,
 } from './symbolIndex';
 import SymbolTable from './symbolTable';
 import {
@@ -22,14 +22,14 @@ import {
 export function createIdFromContext(
   name: string,
   context: ValidatorContext,
-): NodeSymbolId | undefined {
+): NodeSymbolIndex | undefined {
   switch (context) {
     case ValidatorContext.TableContext:
-      return createTableSymbolId(name);
+      return createTableSymbolIndex(name);
     case ValidatorContext.EnumContext:
-      return createEnumSymbolId(name);
+      return createEnumSymbolIndex(name);
     case ValidatorContext.TableGroupContext:
-      return createTableGroupSymbolId(name);
+      return createTableGroupSymbolIndex(name);
     default:
       return undefined;
   }
@@ -38,14 +38,14 @@ export function createIdFromContext(
 export function createSubfieldId(
   name: string,
   context: ValidatorContext,
-): NodeSymbolId | undefined {
+): NodeSymbolIndex | undefined {
   switch (context) {
     case ValidatorContext.TableContext:
-      return createColumnSymbolId(name);
+      return createColumnSymbolIndex(name);
     case ValidatorContext.EnumContext:
-      return createEnumFieldSymbolId(name);
+      return createEnumFieldSymbolIndex(name);
     case ValidatorContext.TableGroupContext:
-      return createTableGroupSymbolId(name);
+      return createTableGroupSymbolIndex(name);
     default:
       return undefined;
   }

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/types.ts
@@ -1,8 +1,8 @@
 import { ElementDeclarationNode, SyntaxNode } from '../parser/nodes';
-import { NodeSymbolId } from './symbol/symbolIndex';
+import { NodeSymbolIndex } from './symbol/symbolIndex';
 
 export interface UnresolvedName {
-  ids: NodeSymbolId[];
+  ids: NodeSymbolIndex[];
   ownerElement: ElementDeclarationNode;
   referrer: SyntaxNode;
 }

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
@@ -13,7 +13,7 @@ import {
   VariableNode,
 } from '../parser/nodes';
 import { isRelationshipOp } from './validator/utils';
-import { NodeSymbolId, isPublicSchemaId } from './symbol/symbolIndex';
+import { NodeSymbolIndex, isPublicSchemaIndex } from './symbol/symbolIndex';
 import { NodeSymbol } from './symbol/symbols';
 
 export function destructureMemberAccessExpression(node: SyntaxNode): Option<SyntaxNode[]> {
@@ -157,11 +157,11 @@ export function extractIndexName(
 // find the closest outer scope that contains `id`
 // and return the symbol corresponding to `id` in that scope
 export function findSymbol(
-  id: NodeSymbolId,
+  id: NodeSymbolIndex,
   startElement: ElementDeclarationNode,
 ): NodeSymbol | undefined {
   let curElement: ElementDeclarationNode | ProgramNode | undefined = startElement;
-  const isPublicSchema = isPublicSchemaId(id);
+  const isPublicSchema = isPublicSchemaIndex(id);
 
   while (curElement) {
     if (curElement.symbol?.symbolTable?.has(id)) {

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
@@ -33,7 +33,6 @@ import {
   registerSchemaStack,
 } from '../utils';
 import { NodeSymbol, SchemaSymbol } from '../../symbol/symbols';
-import SymbolTable from '../../symbol/symbolTable';
 import {
   createIdFromContext,
   createSubfieldId,

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
@@ -1,5 +1,5 @@
 import { UnresolvedName } from '../../types';
-import { createColumnSymbolId } from '../../symbol/symbolIndex';
+import { createColumnSymbolIndex } from '../../symbol/symbolIndex';
 import {
   ElementKind,
   createContextValidatorConfig,
@@ -7,7 +7,6 @@ import {
   createSubFieldValidatorConfig,
 } from '../types';
 import { CompileError, CompileErrorCode } from '../../../errors';
-import { SyntaxToken } from '../../../lexer/tokens';
 import {
   ElementDeclarationNode,
   PrimaryExpressionNode,
@@ -89,7 +88,7 @@ export function registerIndexForResolution(
 ) {
   const columnIds = destructureIndex(node)
     .unwrap_or(undefined)
-    ?.nonFunctional.map(createColumnSymbolId);
+    ?.nonFunctional.map(createColumnSymbolIndex);
 
   if (!columnIds) {
     throw new Error(

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -7,7 +7,6 @@ import {
   createSubFieldValidatorConfig,
 } from '../types';
 import { CompileError, CompileErrorCode } from '../../../errors';
-import { SyntaxToken } from '../../../lexer/tokens';
 import {
   ElementDeclarationNode,
   IdentiferStreamNode,

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
@@ -32,12 +32,11 @@ import {
 } from './_preset_configs';
 import { SchemaSymbol } from '../../symbol/symbols';
 import {
-  createEnumFieldSymbolId,
-  createEnumSymbolId,
-  createSchemaSymbolId,
+  createEnumFieldSymbolIndex,
+  createEnumSymbolIndex,
+  createSchemaSymbolIndex,
 } from '../../symbol/symbolIndex';
 import { registerRelationshipOperand } from './utils';
-import { SyntaxToken } from '../../../lexer/tokens';
 
 export default class TableValidator extends ElementValidator {
   protected elementKind: ElementKind = ElementKind.TABLE;
@@ -132,8 +131,8 @@ function registerEnumTypeIfComplexVariable(
   }
 
   const fragments = destructureComplexVariable(node).unwrap();
-  const enumId = createEnumSymbolId(fragments.pop()!);
-  const schemaIdStack = fragments.map(createSchemaSymbolId);
+  const enumId = createEnumSymbolIndex(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolIndex);
 
   unresolvedNames.push({
     ids: [...schemaIdStack, enumId],
@@ -246,9 +245,9 @@ function registerEnumValueIfComplexVar(
   }
 
   const fragments = destructureComplexVariable(value as SyntaxNode).unwrap();
-  const enumFieldId = createEnumFieldSymbolId(fragments.pop()!);
-  const enumId = createEnumSymbolId(fragments.pop()!);
-  const schemaId = fragments.map(createSchemaSymbolId);
+  const enumFieldId = createEnumFieldSymbolIndex(fragments.pop()!);
+  const enumId = createEnumSymbolIndex(fragments.pop()!);
+  const schemaId = fragments.map(createSchemaSymbolIndex);
 
   unresolvedNames.push({
     ids: [...schemaId, enumId, enumFieldId],

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
@@ -1,6 +1,6 @@
 import { UnresolvedName } from '../../types';
 import { destructureComplexVariable } from '../../utils';
-import { createSchemaSymbolId, createTableSymbolId } from '../../symbol/symbolIndex';
+import { createSchemaSymbolIndex, createTableSymbolIndex } from '../../symbol/symbolIndex';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import { ElementDeclarationNode, SyntaxNode } from '../../../parser/nodes';
 import { ContextStack, ValidatorContext } from '../validatorContext';
@@ -79,9 +79,10 @@ function registerTableName(
     throw new Error('Unreachable - Must be a valid name when registerTableName is called');
   }
   const fragments = destructureComplexVariable(node).unwrap();
-  const tableId = createTableSymbolId(fragments.pop()!);
-  const schemaIdStack = fragments.map(createSchemaSymbolId);
-  const qualifiers = schemaIdStack.length === 0 ? [createSchemaSymbolId('public')] : schemaIdStack;
+  const tableId = createTableSymbolIndex(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolIndex);
+  const qualifiers =
+    schemaIdStack.length === 0 ? [createSchemaSymbolIndex('public')] : schemaIdStack;
   unresolvedNames.push({
     ids: [...qualifiers, tableId],
     referrer: node,

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
@@ -1,8 +1,8 @@
 import { ElementDeclarationNode, NormalExpressionNode } from '../../../parser/nodes';
 import {
-  createColumnSymbolId,
-  createSchemaSymbolId,
-  createTableSymbolId,
+  createColumnSymbolIndex,
+  createSchemaSymbolIndex,
+  createTableSymbolIndex,
 } from '../../symbol/symbolIndex';
 import { UnresolvedName } from '../../types';
 import { destructureComplexVariable } from '../../utils';
@@ -16,7 +16,7 @@ export function registerRelationshipOperand(
 ) {
   const fragments = destructureComplexVariable(node).unwrap();
 
-  const columnId = createColumnSymbolId(fragments.pop()!);
+  const columnId = createColumnSymbolIndex(fragments.pop()!);
   if (fragments.length === 0) {
     unresolvedNames.push({
       ids: [columnId],
@@ -27,8 +27,8 @@ export function registerRelationshipOperand(
     return;
   }
 
-  const tableId = createTableSymbolId(fragments.pop()!);
-  const schemaIdStack = fragments.map(createSchemaSymbolId);
+  const tableId = createTableSymbolIndex(fragments.pop()!);
+  const schemaIdStack = fragments.map(createSchemaSymbolIndex);
 
   unresolvedNames.push({
     ids: [...schemaIdStack, tableId, columnId],

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
@@ -1,6 +1,5 @@
 import { ElementDeclarationNode, SyntaxNode } from '../../parser/nodes';
 import { CompileErrorCode } from '../../errors';
-import { SyntaxToken } from '../../lexer/tokens';
 import { None, Option, Some } from '../../option';
 import { ValidatorContext } from './validatorContext';
 import { UnresolvedName } from '../types';

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
@@ -19,7 +19,7 @@ import ProjectValidator from './elementValidators/project';
 import RefValidator from './elementValidators/ref';
 import TableValidator from './elementValidators/table';
 import TableGroupValidator from './elementValidators/tableGroup';
-import { createSchemaSymbolId } from '../symbol/symbolIndex';
+import { createSchemaSymbolIndex } from '../symbol/symbolIndex';
 import { SchemaSymbol } from '../symbol/symbols';
 import SymbolTable from '../symbol/symbolTable';
 
@@ -92,7 +92,7 @@ export function registerSchemaStack(variables: string[], initialSchema: SymbolTa
   // eslint-disable-next-line no-restricted-syntax
   for (const curName of variables) {
     let curSchema: SymbolTable | undefined;
-    const curId = createSchemaSymbolId(curName);
+    const curId = createSchemaSymbolIndex(curName);
 
     if (!prevSchema.has(curId)) {
       curSchema = new SymbolTable();

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/nodes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/nodes.ts
@@ -2,10 +2,24 @@ import { findEnd, last } from '../utils';
 import { SyntaxToken } from '../lexer/tokens';
 import { NodeSymbol } from '../analyzer/symbol/symbols';
 
+export type SyntaxNodeId = number;
+export class SyntaxNodeIdGenerator {
+  private static id = 0;
+
+  static reset() {
+    this.id = 0;
+  }
+
+  static nextId(): SyntaxNodeId {
+    return this.id++;
+  }
+}
+
 export interface SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
   kind: SyntaxNodeKind;
-  start: number;
-  end: number;
+  start: Readonly<number>;
+  end: Readonly<number>;
   symbol?: NodeSymbol;
   referee?: NodeSymbol; // The symbol that this syntax node refers to
 }
@@ -36,6 +50,8 @@ export enum SyntaxNodeKind {
 }
 
 export class ProgramNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.PROGRAM = SyntaxNodeKind.PROGRAM;
 
   start: Readonly<number>;
@@ -48,7 +64,11 @@ export class ProgramNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ body, eof }: { body: ElementDeclarationNode[]; eof: SyntaxToken }) {
+  constructor(
+    { body, eof }: { body: ElementDeclarationNode[]; eof: SyntaxToken },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = 0;
     this.end = eof.offset;
     this.body = body;
@@ -57,6 +77,8 @@ export class ProgramNode implements SyntaxNode {
 }
 
 export class ElementDeclarationNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.ELEMENT_DECLARATION = SyntaxNodeKind.ELEMENT_DECLARATION;
 
   start: Readonly<number>;
@@ -81,23 +103,27 @@ export class ElementDeclarationNode implements SyntaxNode {
 
   parentElement?: ElementDeclarationNode | ProgramNode;
 
-  constructor({
-    type,
-    name,
-    as,
-    alias,
-    attributeList,
-    bodyColon,
-    body,
-  }: {
-    type: SyntaxToken;
-    name?: NormalExpressionNode;
-    as?: SyntaxToken;
-    alias?: NormalExpressionNode;
-    attributeList?: ListExpressionNode;
-    bodyColon?: SyntaxToken;
-    body: BlockExpressionNode | ExpressionNode;
-  }) {
+  constructor(
+    {
+      type,
+      name,
+      as,
+      alias,
+      attributeList,
+      bodyColon,
+      body,
+    }: {
+      type: SyntaxToken;
+      name?: NormalExpressionNode;
+      as?: SyntaxToken;
+      alias?: NormalExpressionNode;
+      attributeList?: ListExpressionNode;
+      bodyColon?: SyntaxToken;
+      body: BlockExpressionNode | ExpressionNode;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = type.offset;
     this.end = body.end;
     this.type = type;
@@ -111,6 +137,8 @@ export class ElementDeclarationNode implements SyntaxNode {
 }
 
 export class IdentiferStreamNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.IDENTIFIER_STREAM = SyntaxNodeKind.IDENTIFIER_STREAM;
 
   start: Readonly<number>;
@@ -119,7 +147,11 @@ export class IdentiferStreamNode implements SyntaxNode {
 
   identifiers: SyntaxToken[];
 
-  constructor({ identifiers }: { identifiers: SyntaxToken[] }) {
+  constructor(
+    { identifiers }: { identifiers: SyntaxToken[] },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     if (identifiers.length === 0) {
       throw new Error("An IdentifierStreamNode shouldn't be created with zero tokens");
     }
@@ -128,7 +160,10 @@ export class IdentiferStreamNode implements SyntaxNode {
     this.end = findEnd(last(identifiers)!);
   }
 }
+
 export class AttributeNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.ATTRIBUTE = SyntaxNodeKind.ATTRIBUTE;
 
   start: Readonly<number>;
@@ -143,15 +178,19 @@ export class AttributeNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    name,
-    colon,
-    value,
-  }: {
-    name: IdentiferStreamNode;
-    colon?: SyntaxToken;
-    value?: NormalExpressionNode | IdentiferStreamNode;
-  }) {
+  constructor(
+    {
+      name,
+      colon,
+      value,
+    }: {
+      name: IdentiferStreamNode;
+      colon?: SyntaxToken;
+      value?: NormalExpressionNode | IdentiferStreamNode;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.name = name;
     this.value = value;
     this.colon = colon;
@@ -183,6 +222,8 @@ export type ExpressionNode =
   | FunctionApplicationNode;
 
 export class PrefixExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.PREFIX_EXPRESSION = SyntaxNodeKind.PREFIX_EXPRESSION;
 
   start: Readonly<number>;
@@ -195,7 +236,11 @@ export class PrefixExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ op, expression }: { op: SyntaxToken; expression: NormalExpressionNode }) {
+  constructor(
+    { op, expression }: { op: SyntaxToken; expression: NormalExpressionNode },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = op.offset;
     this.end = expression.end;
     this.op = op;
@@ -204,6 +249,8 @@ export class PrefixExpressionNode implements SyntaxNode {
 }
 
 export class InfixExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.INFIX_EXPRESSION = SyntaxNodeKind.INFIX_EXPRESSION;
 
   start: Readonly<number>;
@@ -218,15 +265,19 @@ export class InfixExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    op,
-    leftExpression,
-    rightExpression,
-  }: {
-    op: SyntaxToken;
-    leftExpression: NormalExpressionNode;
-    rightExpression: NormalExpressionNode;
-  }) {
+  constructor(
+    {
+      op,
+      leftExpression,
+      rightExpression,
+    }: {
+      op: SyntaxToken;
+      leftExpression: NormalExpressionNode;
+      rightExpression: NormalExpressionNode;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = leftExpression.start;
     this.end = rightExpression.end;
     this.op = op;
@@ -236,6 +287,8 @@ export class InfixExpressionNode implements SyntaxNode {
 }
 
 export class PostfixExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.POSTFIX_EXPRESSION = SyntaxNodeKind.POSTFIX_EXPRESSION;
 
   start: Readonly<number>;
@@ -248,7 +301,11 @@ export class PostfixExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ op, expression }: { op: SyntaxToken; expression: NormalExpressionNode }) {
+  constructor(
+    { op, expression }: { op: SyntaxToken; expression: NormalExpressionNode },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = expression.start;
     this.end = op.offset + 1;
     this.op = op;
@@ -257,6 +314,8 @@ export class PostfixExpressionNode implements SyntaxNode {
 }
 
 export class FunctionExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.FUNCTION_EXPRESSION = SyntaxNodeKind.FUNCTION_EXPRESSION;
 
   start: Readonly<number>;
@@ -267,7 +326,11 @@ export class FunctionExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ value }: { value: SyntaxToken }) {
+  constructor(
+    { value }: { value: SyntaxToken },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = value.offset;
     this.end = value.offset + value.length;
     this.value = value;
@@ -275,6 +338,8 @@ export class FunctionExpressionNode implements SyntaxNode {
 }
 
 export class FunctionApplicationNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.FUNCTION_APPLICATION = SyntaxNodeKind.FUNCTION_APPLICATION;
 
   start: Readonly<number>;
@@ -287,7 +352,11 @@ export class FunctionApplicationNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ callee, args }: { callee: ExpressionNode; args: ExpressionNode[] }) {
+  constructor(
+    { callee, args }: { callee: ExpressionNode; args: ExpressionNode[] },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = callee.start;
     if (args.length === 0) {
       this.end = callee.end;
@@ -300,6 +369,8 @@ export class FunctionApplicationNode implements SyntaxNode {
 }
 
 export class BlockExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.BLOCK_EXPRESSION = SyntaxNodeKind.BLOCK_EXPRESSION;
 
   start: Readonly<number>;
@@ -314,15 +385,19 @@ export class BlockExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    blockOpenBrace,
-    body,
-    blockCloseBrace,
-  }: {
-    blockOpenBrace: SyntaxToken;
-    body: ExpressionNode[];
-    blockCloseBrace: SyntaxToken;
-  }) {
+  constructor(
+    {
+      blockOpenBrace,
+      body,
+      blockCloseBrace,
+    }: {
+      blockOpenBrace: SyntaxToken;
+      body: ExpressionNode[];
+      blockCloseBrace: SyntaxToken;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = blockOpenBrace.offset;
     this.end = blockCloseBrace.offset + 1;
     this.blockOpenBrace = blockOpenBrace;
@@ -332,6 +407,8 @@ export class BlockExpressionNode implements SyntaxNode {
 }
 
 export class ListExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.LIST_EXPRESSION = SyntaxNodeKind.LIST_EXPRESSION;
 
   start: Readonly<number>;
@@ -348,17 +425,21 @@ export class ListExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    listOpenBracket,
-    elementList,
-    commaList,
-    listCloseBracket,
-  }: {
-    listOpenBracket: SyntaxToken;
-    elementList: AttributeNode[];
-    commaList: SyntaxToken[];
-    listCloseBracket: SyntaxToken;
-  }) {
+  constructor(
+    {
+      listOpenBracket,
+      elementList,
+      commaList,
+      listCloseBracket,
+    }: {
+      listOpenBracket: SyntaxToken;
+      elementList: AttributeNode[];
+      commaList: SyntaxToken[];
+      listCloseBracket: SyntaxToken;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = listOpenBracket.offset;
     this.end = listCloseBracket.offset + 1;
     this.listOpenBracket = listOpenBracket;
@@ -369,6 +450,8 @@ export class ListExpressionNode implements SyntaxNode {
 }
 
 export class TupleExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.TUPLE_EXPRESSION | SyntaxNodeKind.GROUP_EXPRESSION =
     SyntaxNodeKind.TUPLE_EXPRESSION;
 
@@ -386,17 +469,21 @@ export class TupleExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    tupleOpenParen,
-    elementList,
-    commaList,
-    tupleCloseParen,
-  }: {
-    tupleOpenParen: SyntaxToken;
-    elementList: NormalExpressionNode[];
-    commaList: SyntaxToken[];
-    tupleCloseParen: SyntaxToken;
-  }) {
+  constructor(
+    {
+      tupleOpenParen,
+      elementList,
+      commaList,
+      tupleCloseParen,
+    }: {
+      tupleOpenParen: SyntaxToken;
+      elementList: NormalExpressionNode[];
+      commaList: SyntaxToken[];
+      tupleCloseParen: SyntaxToken;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = tupleOpenParen.offset;
     this.end = tupleCloseParen.offset + 1;
     this.tupleOpenParen = tupleOpenParen;
@@ -411,25 +498,33 @@ export class GroupExpressionNode extends TupleExpressionNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    groupOpenParen,
-    expression,
-    groupCloseParen,
-  }: {
-    groupOpenParen: SyntaxToken;
-    expression: NormalExpressionNode;
-    groupCloseParen: SyntaxToken;
-  }) {
-    super({
-      tupleOpenParen: groupOpenParen,
-      elementList: [expression],
-      commaList: [],
-      tupleCloseParen: groupCloseParen,
-    });
+  constructor(
+    {
+      groupOpenParen,
+      expression,
+      groupCloseParen,
+    }: {
+      groupOpenParen: SyntaxToken;
+      expression: NormalExpressionNode;
+      groupCloseParen: SyntaxToken;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    super(
+      {
+        tupleOpenParen: groupOpenParen,
+        elementList: [expression],
+        commaList: [],
+        tupleCloseParen: groupCloseParen,
+      },
+      id,
+    );
   }
 }
 
 export class CallExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.CALL_EXPRESSION = SyntaxNodeKind.CALL_EXPRESSION;
 
   start: Readonly<number>;
@@ -442,13 +537,17 @@ export class CallExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({
-    callee,
-    argumentList,
-  }: {
-    callee: NormalExpressionNode;
-    argumentList: TupleExpressionNode;
-  }) {
+  constructor(
+    {
+      callee,
+      argumentList,
+    }: {
+      callee: NormalExpressionNode;
+      argumentList: TupleExpressionNode;
+    },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = callee.start;
     this.end = argumentList.end;
     this.callee = callee;
@@ -457,6 +556,8 @@ export class CallExpressionNode implements SyntaxNode {
 }
 
 export class LiteralNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.LITERAL = SyntaxNodeKind.LITERAL;
 
   start: Readonly<number>;
@@ -467,7 +568,11 @@ export class LiteralNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ literal }: { literal: SyntaxToken }) {
+  constructor(
+    { literal }: { literal: SyntaxToken },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = literal.offset;
     this.end = literal.offset + literal.length;
     this.literal = literal;
@@ -475,6 +580,8 @@ export class LiteralNode implements SyntaxNode {
 }
 
 export class VariableNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.VARIABLE = SyntaxNodeKind.VARIABLE;
 
   start: Readonly<number>;
@@ -485,7 +592,11 @@ export class VariableNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ variable }: { variable: SyntaxToken }) {
+  constructor(
+    { variable }: { variable: SyntaxToken },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = variable.offset;
     this.end = variable.offset + variable.length;
     this.variable = variable;
@@ -493,6 +604,8 @@ export class VariableNode implements SyntaxNode {
 }
 
 export class PrimaryExpressionNode implements SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+
   kind: SyntaxNodeKind.PRIMARY_EXPRESSION = SyntaxNodeKind.PRIMARY_EXPRESSION;
 
   start: Readonly<number>;
@@ -503,7 +616,11 @@ export class PrimaryExpressionNode implements SyntaxNode {
 
   symbol?: NodeSymbol;
 
-  constructor({ expression }: { expression: LiteralNode | VariableNode }) {
+  constructor(
+    { expression }: { expression: LiteralNode | VariableNode },
+    id: SyntaxNodeId = SyntaxNodeIdGenerator.nextId(),
+  ) {
+    this.id = id;
     this.start = expression.start;
     this.end = expression.end;
     this.expression = expression;

--- a/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
@@ -1,23 +1,64 @@
-import { CompileError } from '../errors';
-import { ProgramNode } from '../parser/nodes';
+import { NodeSymbol } from '../analyzer/symbol/symbols';
+import { ProgramNode, SyntaxNode } from '../parser/nodes';
 import Report from '../report';
+import { CompileError } from '../errors';
 
-export function serialize(report: Report<ProgramNode, CompileError>): string {
+export function serialize(
+  report: Report<ProgramNode, CompileError>,
+  pretty: boolean = false,
+): string {
   return JSON.stringify(
     report,
-    (key, value) => {
-      if (['parentElement', 'declaration', 'references'].includes(key)) {
-        return undefined;
+    function (key: string, value: any) {
+      // If `value` is not `symbol` of the root node
+      // Just output the `symbol`'s id is enough
+      // As the symbol's information is already reachable from the root node's symbol
+      if (!(this instanceof ProgramNode) && key === 'symbol') {
+        return (value as NodeSymbol)?.id;
       }
-      if (value instanceof Map) {
+
+      // If `value` is the `symbol` of the root node
+      // output the symbol table in full,
+      // just the ids of the SyntaxNodes that refer to this symbol
+      // and just the id the root node declaration are enough
+      if (/* this instanceof SyntaxNode && */ key === 'symbol') {
         return {
-          dataType: 'Map',
-          value: Array.from(value.entries()),
+          symbolTable: (value as NodeSymbol)?.symbolTable,
+          id: (value as NodeSymbol)?.id,
+
+          references: (value as NodeSymbol)?.references.map((ref) => ref.id),
+          declaration: (value as NodeSymbol)?.declaration?.id,
         };
+      }
+
+      // If `value` is the NodeSymbol that a SyntaxNode refers to
+      // just the id of the `referee` is enough
+      if (/* this instanceof SyntaxNode && */ key === 'referee') {
+        return (value as NodeSymbol)?.id;
+      }
+
+      // If `value` is the parent element of the current SyntaxNode
+      // just the id of the parent is enough
+      if (/* this instanceof SyntaxNode && */ key === 'parentElement') {
+        return (value as SyntaxNode)?.id;
+      }
+
+      // If `value` is the declaration node that owns this symbol
+      // just the id of the declaration node is enough
+      if (/* this instanceof NodeSymbol && */ key === 'declaration') {
+        return (value as SyntaxNode)?.id;
+      }
+
+      // If `value` is the symbol table of a NodeSymbol
+      // output the `table` field of `value`
+      // The conversion to Object is necessary
+      // as by default, Map serializes to {}
+      if (/* this instanceof NodeSymbol && */ key === 'symbolTable') {
+        return Object.fromEntries((value as any).table);
       }
 
       return value;
     },
-    2,
+    pretty ? 2 : 0,
   );
 }


### PR DESCRIPTION
## Summary
* Support serialization by using an id to refer to nodes and symbols in certain cases.
* This implementation is deprecated (see #432) as the id generators are global instances of singleton classes.
* Notable changes:
   * `serialize.ts`
   * nodes and symbols now accept ids in their constructors
   * `NodeSymbolId` is now renamed to `NodeSymbolIndex` to reserve the name for Symbol id

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review