### PR TITLE
change(bearer_workflows): only scan pr diff

### DIFF
--- a/.github/workflows/bearer.yml
+++ b/.github/workflows/bearer.yml
@@ -1,10 +1,8 @@
 name: Bearer PR Check
 
 on:
-  push:
-    branches:
-      - master
-
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -12,6 +10,7 @@ permissions:
 jobs:
   rule_check:
     runs-on: ubuntu-22.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Report
@@ -20,12 +19,13 @@ jobs:
         with:
           format: rdjson
           output: rd.json
+          diff: true
           config-file: 'bearer.yml'
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest
       - name: Run reviewdog
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cat rd.json | reviewdog -f=rdjson -reporter=github-check -filter-mode=nofilter
+          REVIEWDOG_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
+        run:
+          cat rd.json | reviewdog -f=rdjson -reporter=github-pr-check


### PR DESCRIPTION
## Summary
Previous: scan when merge master

This PR: scan when [open, sync, reopen] a PR and only scan files changed

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review