### PR TITLE
Fix lexer single line comment

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/lexer/lexer.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/lexer/lexer.ts
@@ -265,7 +265,8 @@ export default class Lexer {
       allowNewline, // Whether newline is allowed
       allowEof, // Whether EOF is allowed
       raw, // Whether to interpret '\' as a backlash
-    }: { allowNewline: boolean; allowEof: boolean; raw: boolean },
+      consumeStopSequence = true,
+    }: { allowNewline: boolean; allowEof: boolean; raw: boolean, consumeStopSequence?: boolean },
   ) {
     let string = '';
 
@@ -302,7 +303,9 @@ export default class Lexer {
       return;
     }
 
-    this.match(stopSequence);
+    if (consumeStopSequence) {
+      this.match(stopSequence);
+    }
     this.tokens.push(SyntaxToken.create(tokenKind, this.start, this.current, string, false));
   }
 
@@ -343,6 +346,7 @@ export default class Lexer {
       allowNewline: true,
       allowEof: true,
       raw: true,
+      consumeStopSequence: false,
     });
   }
 

--- a/packages/dbml-core/src/parse/dbml/src/services/suggestions/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/suggestions/utils.ts
@@ -203,10 +203,7 @@ export class TokenLogicalLineIterator extends TokenIterator {
     const aId = compiler.token.nonTrivial.afterOrContainOnSameLine(offset).unwrap_or(-1);
     const bId = compiler.token.nonTrivial.beforeOrContainOnSameLine(offset).unwrap_or(-1);
     if (aId === -1 && bId === -1) {
-      return new TokenLogicalLineIterator(
-        [],
-        -1,
-      );
+      return new TokenLogicalLineIterator([], -1);
     }
     const id = aId !== -1 ? aId : bId;
     let start: number | undefined;
@@ -231,7 +228,7 @@ export class TokenLogicalLineIterator extends TokenIterator {
 
     return new TokenLogicalLineIterator(
       compiler.token.flatStream().slice(start, end),
-      aId !== -1 ? aId - start : -1,
+      bId !== -1 ? bId - start : -1,
     );
   }
 }

--- a/packages/dbml-core/src/parse/dbml/tests/lexer/output/comment.out.json
+++ b/packages/dbml-core/src/parse/dbml/tests/lexer/output/comment.out.json
@@ -22,9 +22,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 34,
-            "line": 1,
-            "column": 0
+            "offset": 33,
+            "line": 0,
+            "column": 33
           },
           "value": " This is a single-line comment\r",
           "leadingTrivia": [],
@@ -33,6 +33,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 0,
+          "end": 33
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 33,
+            "line": 0,
+            "column": 33
+          },
+          "endPos": {
+            "offset": 34,
+            "line": 1,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 33,
           "end": 34
         },
         {
@@ -127,9 +148,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 96,
-            "line": 12,
-            "column": 0
+            "offset": 95,
+            "line": 11,
+            "column": 11
           },
           "value": " This is\r",
           "leadingTrivia": [],
@@ -138,6 +159,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 84,
+          "end": 95
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 95,
+            "line": 11,
+            "column": 11
+          },
+          "endPos": {
+            "offset": 96,
+            "line": 12,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 95,
           "end": 96
         },
         {
@@ -148,9 +190,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 102,
-            "line": 13,
-            "column": 0
+            "offset": 101,
+            "line": 12,
+            "column": 5
           },
           "value": " a\r",
           "leadingTrivia": [],
@@ -159,6 +201,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 96,
+          "end": 101
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 101,
+            "line": 12,
+            "column": 5
+          },
+          "endPos": {
+            "offset": 102,
+            "line": 13,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 101,
           "end": 102
         },
         {
@@ -169,9 +232,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 112,
-            "line": 14,
-            "column": 0
+            "offset": 111,
+            "line": 13,
+            "column": 9
           },
           "value": " bunch\r",
           "leadingTrivia": [],
@@ -180,6 +243,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 102,
+          "end": 111
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 111,
+            "line": 13,
+            "column": 9
+          },
+          "endPos": {
+            "offset": 112,
+            "line": 14,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 111,
           "end": 112
         },
         {
@@ -190,9 +274,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 119,
-            "line": 15,
-            "column": 0
+            "offset": 118,
+            "line": 14,
+            "column": 6
           },
           "value": " of\r",
           "leadingTrivia": [],
@@ -201,6 +285,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 112,
+          "end": 118
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 118,
+            "line": 14,
+            "column": 6
+          },
+          "endPos": {
+            "offset": 119,
+            "line": 15,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 118,
           "end": 119
         },
         {
@@ -211,9 +316,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 130,
-            "line": 16,
-            "column": 0
+            "offset": 129,
+            "line": 15,
+            "column": 10
           },
           "value": " single\r",
           "leadingTrivia": [],
@@ -222,6 +327,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 119,
+          "end": 129
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 129,
+            "line": 15,
+            "column": 10
+          },
+          "endPos": {
+            "offset": 130,
+            "line": 16,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 129,
           "end": 130
         },
         {
@@ -232,9 +358,9 @@
             "column": 0
           },
           "endPos": {
-            "offset": 139,
-            "line": 17,
-            "column": 0
+            "offset": 138,
+            "line": 16,
+            "column": 8
           },
           "value": " line\r",
           "leadingTrivia": [],
@@ -243,6 +369,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 130,
+          "end": 138
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 138,
+            "line": 16,
+            "column": 8
+          },
+          "endPos": {
+            "offset": 139,
+            "line": 17,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 138,
           "end": 139
         },
         {

--- a/packages/dbml-core/src/parse/dbml/tests/lexer/output/number.out.json
+++ b/packages/dbml-core/src/parse/dbml/tests/lexer/output/number.out.json
@@ -87,9 +87,9 @@
             "column": 4
           },
           "endPos": {
-            "offset": 21,
-            "line": 1,
-            "column": 0
+            "offset": 20,
+            "line": 0,
+            "column": 20
           },
           "value": " whole number\r",
           "leadingTrivia": [],
@@ -98,6 +98,27 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 4,
+          "end": 20
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 20,
+            "line": 0,
+            "column": 20
+          },
+          "endPos": {
+            "offset": 21,
+            "line": 1,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 20,
           "end": 21
         }
       ],
@@ -194,9 +215,9 @@
             "column": 9
           },
           "endPos": {
-            "offset": 56,
-            "line": 2,
-            "column": 0
+            "offset": 55,
+            "line": 1,
+            "column": 34
           },
           "value": " floating-point number\r",
           "leadingTrivia": [],
@@ -205,18 +226,18 @@
           "trailingInvalid": [],
           "isInvalid": false,
           "start": 30,
-          "end": 56
+          "end": 55
         },
         {
           "kind": "<newline>",
           "startPos": {
-            "offset": 57,
-            "line": 2,
-            "column": 1
+            "offset": 55,
+            "line": 1,
+            "column": 34
           },
           "endPos": {
-            "offset": 58,
-            "line": 3,
+            "offset": 56,
+            "line": 2,
             "column": 0
           },
           "value": "\n",
@@ -225,8 +246,8 @@
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": false,
-          "start": 57,
-          "end": 58
+          "start": 55,
+          "end": 56
         }
       ],
       "leadingInvalid": [],
@@ -244,7 +265,29 @@
             "column": 4
           },
           "value": "8.6a",
-          "leadingTrivia": [],
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 57,
+                "line": 2,
+                "column": 1
+              },
+              "endPos": {
+                "offset": 58,
+                "line": 3,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 57,
+              "end": 58
+            }
+          ],
           "trailingTrivia": [
             {
               "kind": "<space>",
@@ -425,7 +468,29 @@
           "column": 4
         },
         "value": "8.6a",
-        "leadingTrivia": [],
+        "leadingTrivia": [
+          {
+            "kind": "<newline>",
+            "startPos": {
+              "offset": 57,
+              "line": 2,
+              "column": 1
+            },
+            "endPos": {
+              "offset": 58,
+              "line": 3,
+              "column": 0
+            },
+            "value": "\n",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 57,
+            "end": 58
+          }
+        ],
         "trailingTrivia": [
           {
             "kind": "<space>",

--- a/packages/dbml-core/src/parse/dbml/tests/parser/output/trailing_comments.out.json
+++ b/packages/dbml-core/src/parse/dbml/tests/parser/output/trailing_comments.out.json
@@ -1,7 +1,7 @@
 {
   "value": {
     "kind": "<program>",
-    "id": 89,
+    "id": 90,
     "startPos": {
       "offset": 0,
       "line": 0,
@@ -15,7 +15,7 @@
     "body": [
       {
         "kind": "<element-declaration>",
-        "id": 88,
+        "id": 89,
         "startPos": {
           "offset": 0,
           "line": 0,
@@ -150,7 +150,7 @@
         },
         "body": {
           "kind": "<block-expression>",
-          "id": 87,
+          "id": 88,
           "startPos": {
             "offset": 15,
             "line": 0,
@@ -1091,7 +1091,7 @@
             },
             {
               "kind": "<element-declaration>",
-              "id": 85,
+              "id": 86,
               "startPos": {
                 "offset": 100,
                 "line": 6,
@@ -1211,7 +1211,7 @@
               },
               "body": {
                 "kind": "<block-expression>",
-                "id": 84,
+                "id": 85,
                 "startPos": {
                   "offset": 108,
                   "line": 6,
@@ -1268,16 +1268,16 @@
                 "body": [
                   {
                     "kind": "<function-application>",
-                    "id": 43,
+                    "id": 32,
                     "startPos": {
                       "offset": 117,
                       "line": 7,
                       "column": 6
                     },
                     "endPos": {
-                      "offset": 219,
-                      "line": 8,
-                      "column": 57
+                      "offset": 135,
+                      "line": 7,
+                      "column": 24
                     },
                     "callee": {
                       "kind": "<tuple-expression>",
@@ -1790,9 +1790,9 @@
                                 "column": 25
                               },
                               "endPos": {
-                                "offset": 162,
-                                "line": 8,
-                                "column": 0
+                                "offset": 161,
+                                "line": 7,
+                                "column": 50
                               },
                               "value": " composite primary key\r",
                               "leadingTrivia": [],
@@ -1801,8 +1801,100 @@
                               "trailingInvalid": [],
                               "isInvalid": false,
                               "start": 136,
-                              "end": 162
+                              "end": 161
                             },
+                            {
+                              "kind": "<newline>",
+                              "startPos": {
+                                "offset": 161,
+                                "line": 7,
+                                "column": 50
+                              },
+                              "endPos": {
+                                "offset": 162,
+                                "line": 8,
+                                "column": 0
+                              },
+                              "value": "\n",
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
+                              "leadingInvalid": [],
+                              "trailingInvalid": [],
+                              "isInvalid": false,
+                              "start": 161,
+                              "end": 162
+                            }
+                          ],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 134,
+                          "end": 135
+                        },
+                        "start": 131,
+                        "end": 135,
+                        "fullStart": 131,
+                        "fullEnd": 162
+                      }
+                    ],
+                    "start": 117,
+                    "end": 135,
+                    "fullStart": 111,
+                    "fullEnd": 162
+                  },
+                  {
+                    "kind": "<function-application>",
+                    "id": 44,
+                    "startPos": {
+                      "offset": 168,
+                      "line": 8,
+                      "column": 6
+                    },
+                    "endPos": {
+                      "offset": 219,
+                      "line": 8,
+                      "column": 57
+                    },
+                    "callee": {
+                      "kind": "<primary-expression>",
+                      "id": 34,
+                      "startPos": {
+                        "offset": 168,
+                        "line": 8,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 178,
+                        "line": 8,
+                        "column": 16
+                      },
+                      "expression": {
+                        "kind": "<variable>",
+                        "id": 33,
+                        "startPos": {
+                          "offset": 168,
+                          "line": 8,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 178,
+                          "line": 8,
+                          "column": 16
+                        },
+                        "variable": {
+                          "kind": "<identifier>",
+                          "startPos": {
+                            "offset": 168,
+                            "line": 8,
+                            "column": 6
+                          },
+                          "endPos": {
+                            "offset": 178,
+                            "line": 8,
+                            "column": 16
+                          },
+                          "value": "created_at",
+                          "leadingTrivia": [
                             {
                               "kind": "<space>",
                               "startPos": {
@@ -1930,99 +2022,49 @@
                               "end": 168
                             }
                           ],
+                          "trailingTrivia": [
+                            {
+                              "kind": "<space>",
+                              "startPos": {
+                                "offset": 178,
+                                "line": 8,
+                                "column": 16
+                              },
+                              "endPos": {
+                                "offset": 179,
+                                "line": 8,
+                                "column": 17
+                              },
+                              "value": " ",
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
+                              "leadingInvalid": [],
+                              "trailingInvalid": [],
+                              "isInvalid": false,
+                              "start": 178,
+                              "end": 179
+                            }
+                          ],
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 134,
-                          "end": 135
-                        },
-                        "start": 131,
-                        "end": 135,
-                        "fullStart": 131,
-                        "fullEnd": 168
-                      },
-                      {
-                        "kind": "<primary-expression>",
-                        "id": 33,
-                        "startPos": {
-                          "offset": 168,
-                          "line": 8,
-                          "column": 6
-                        },
-                        "endPos": {
-                          "offset": 178,
-                          "line": 8,
-                          "column": 16
-                        },
-                        "expression": {
-                          "kind": "<variable>",
-                          "id": 32,
-                          "startPos": {
-                            "offset": 168,
-                            "line": 8,
-                            "column": 6
-                          },
-                          "endPos": {
-                            "offset": 178,
-                            "line": 8,
-                            "column": 16
-                          },
-                          "variable": {
-                            "kind": "<identifier>",
-                            "startPos": {
-                              "offset": 168,
-                              "line": 8,
-                              "column": 6
-                            },
-                            "endPos": {
-                              "offset": 178,
-                              "line": 8,
-                              "column": 16
-                            },
-                            "value": "created_at",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [
-                              {
-                                "kind": "<space>",
-                                "startPos": {
-                                  "offset": 178,
-                                  "line": 8,
-                                  "column": 16
-                                },
-                                "endPos": {
-                                  "offset": 179,
-                                  "line": 8,
-                                  "column": 17
-                                },
-                                "value": " ",
-                                "leadingTrivia": [],
-                                "trailingTrivia": [],
-                                "leadingInvalid": [],
-                                "trailingInvalid": [],
-                                "isInvalid": false,
-                                "start": 178,
-                                "end": 179
-                              }
-                            ],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 168,
-                            "end": 178
-                          },
                           "start": 168,
-                          "end": 178,
-                          "fullStart": 168,
-                          "fullEnd": 179
+                          "end": 178
                         },
                         "start": 168,
                         "end": 178,
-                        "fullStart": 168,
+                        "fullStart": 162,
                         "fullEnd": 179
                       },
+                      "start": 168,
+                      "end": 178,
+                      "fullStart": 162,
+                      "fullEnd": 179
+                    },
+                    "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 42,
+                        "id": 43,
                         "startPos": {
                           "offset": 179,
                           "line": 8,
@@ -2057,10 +2099,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 37,
+                            "id": 38,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 34,
+                              "id": 35,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -2101,7 +2143,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 36,
+                              "id": 37,
                               "startPos": {
                                 "offset": 186,
                                 "line": 8,
@@ -2114,7 +2156,7 @@
                               },
                               "expression": {
                                 "kind": "<literal>",
-                                "id": 35,
+                                "id": 36,
                                 "startPos": {
                                   "offset": 186,
                                   "line": 8,
@@ -2216,10 +2258,10 @@
                           },
                           {
                             "kind": "<attribute>",
-                            "id": 41,
+                            "id": 42,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 38,
+                              "id": 39,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -2260,7 +2302,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 40,
+                              "id": 41,
                               "startPos": {
                                 "offset": 212,
                                 "line": 8,
@@ -2273,7 +2315,7 @@
                               },
                               "expression": {
                                 "kind": "<literal>",
-                                "id": 39,
+                                "id": 40,
                                 "startPos": {
                                   "offset": 212,
                                   "line": 8,
@@ -2468,14 +2510,14 @@
                         "fullEnd": 221
                       }
                     ],
-                    "start": 117,
+                    "start": 168,
                     "end": 219,
-                    "fullStart": 111,
+                    "fullStart": 162,
                     "fullEnd": 221
                   },
                   {
                     "kind": "<primary-expression>",
-                    "id": 45,
+                    "id": 46,
                     "startPos": {
                       "offset": 227,
                       "line": 9,
@@ -2488,7 +2530,7 @@
                     },
                     "expression": {
                       "kind": "<variable>",
-                      "id": 44,
+                      "id": 45,
                       "startPos": {
                         "offset": 227,
                         "line": 9,
@@ -2681,7 +2723,7 @@
                   },
                   {
                     "kind": "<function-application>",
-                    "id": 54,
+                    "id": 55,
                     "startPos": {
                       "offset": 247,
                       "line": 10,
@@ -2694,7 +2736,7 @@
                     },
                     "callee": {
                       "kind": "<tuple-expression>",
-                      "id": 50,
+                      "id": 51,
                       "startPos": {
                         "offset": 247,
                         "line": 10,
@@ -2856,7 +2898,7 @@
                       "elementList": [
                         {
                           "kind": "<primary-expression>",
-                          "id": 47,
+                          "id": 48,
                           "startPos": {
                             "offset": 248,
                             "line": 10,
@@ -2869,7 +2911,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 46,
+                            "id": 47,
                             "startPos": {
                               "offset": 248,
                               "line": 10,
@@ -2913,7 +2955,7 @@
                         },
                         {
                           "kind": "<primary-expression>",
-                          "id": 49,
+                          "id": 50,
                           "startPos": {
                             "offset": 257,
                             "line": 10,
@@ -2926,7 +2968,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 48,
+                            "id": 49,
                             "startPos": {
                               "offset": 257,
                               "line": 10,
@@ -3065,7 +3107,7 @@
                     "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 53,
+                        "id": 54,
                         "startPos": {
                           "offset": 271,
                           "line": 10,
@@ -3100,10 +3142,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 52,
+                            "id": 53,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 51,
+                              "id": 52,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -3215,7 +3257,7 @@
                   },
                   {
                     "kind": "<function-application>",
-                    "id": 62,
+                    "id": 63,
                     "startPos": {
                       "offset": 287,
                       "line": 11,
@@ -3228,7 +3270,7 @@
                     },
                     "callee": {
                       "kind": "<primary-expression>",
-                      "id": 56,
+                      "id": 57,
                       "startPos": {
                         "offset": 287,
                         "line": 11,
@@ -3241,7 +3283,7 @@
                       },
                       "expression": {
                         "kind": "<variable>",
-                        "id": 55,
+                        "id": 56,
                         "startPos": {
                           "offset": 287,
                           "line": 11,
@@ -3435,7 +3477,7 @@
                     "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 61,
+                        "id": 62,
                         "startPos": {
                           "offset": 300,
                           "line": 11,
@@ -3470,10 +3512,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 60,
+                            "id": 61,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 57,
+                              "id": 58,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -3514,7 +3556,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 59,
+                              "id": 60,
                               "startPos": {
                                 "offset": 307,
                                 "line": 11,
@@ -3527,7 +3569,7 @@
                               },
                               "expression": {
                                 "kind": "<variable>",
-                                "id": 58,
+                                "id": 59,
                                 "startPos": {
                                   "offset": 307,
                                   "line": 11,
@@ -3685,7 +3727,7 @@
                   },
                   {
                     "kind": "<group-expression>",
-                    "id": 68,
+                    "id": 69,
                     "startPos": {
                       "offset": 320,
                       "line": 12,
@@ -3847,7 +3889,7 @@
                     "elementList": [
                       {
                         "kind": "<infix-expression>",
-                        "id": 67,
+                        "id": 68,
                         "startPos": {
                           "offset": 321,
                           "line": 12,
@@ -3881,7 +3923,7 @@
                         },
                         "leftExpression": {
                           "kind": "<primary-expression>",
-                          "id": 64,
+                          "id": 65,
                           "startPos": {
                             "offset": 321,
                             "line": 12,
@@ -3894,7 +3936,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 63,
+                            "id": 64,
                             "startPos": {
                               "offset": 321,
                               "line": 12,
@@ -3938,7 +3980,7 @@
                         },
                         "rightExpression": {
                           "kind": "<primary-expression>",
-                          "id": 66,
+                          "id": 67,
                           "startPos": {
                             "offset": 324,
                             "line": 12,
@@ -3951,7 +3993,7 @@
                           },
                           "expression": {
                             "kind": "<literal>",
-                            "id": 65,
+                            "id": 66,
                             "startPos": {
                               "offset": 324,
                               "line": 12,
@@ -4050,7 +4092,7 @@
                   },
                   {
                     "kind": "<tuple-expression>",
-                    "id": 75,
+                    "id": 76,
                     "startPos": {
                       "offset": 334,
                       "line": 13,
@@ -4212,7 +4254,7 @@
                     "elementList": [
                       {
                         "kind": "<infix-expression>",
-                        "id": 73,
+                        "id": 74,
                         "startPos": {
                           "offset": 335,
                           "line": 13,
@@ -4246,7 +4288,7 @@
                         },
                         "leftExpression": {
                           "kind": "<primary-expression>",
-                          "id": 70,
+                          "id": 71,
                           "startPos": {
                             "offset": 335,
                             "line": 13,
@@ -4259,7 +4301,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 69,
+                            "id": 70,
                             "startPos": {
                               "offset": 335,
                               "line": 13,
@@ -4303,7 +4345,7 @@
                         },
                         "rightExpression": {
                           "kind": "<primary-expression>",
-                          "id": 72,
+                          "id": 73,
                           "startPos": {
                             "offset": 338,
                             "line": 13,
@@ -4316,7 +4358,7 @@
                           },
                           "expression": {
                             "kind": "<literal>",
-                            "id": 71,
+                            "id": 72,
                             "startPos": {
                               "offset": 338,
                               "line": 13,
@@ -4365,7 +4407,7 @@
                       },
                       {
                         "kind": "<function-expression>",
-                        "id": 74,
+                        "id": 75,
                         "startPos": {
                           "offset": 340,
                           "line": 13,
@@ -4476,7 +4518,7 @@
                   },
                   {
                     "kind": "<tuple-expression>",
-                    "id": 83,
+                    "id": 84,
                     "startPos": {
                       "offset": 360,
                       "line": 14,
@@ -4638,7 +4680,7 @@
                     "elementList": [
                       {
                         "kind": "<infix-expression>",
-                        "id": 80,
+                        "id": 81,
                         "startPos": {
                           "offset": 361,
                           "line": 14,
@@ -4672,7 +4714,7 @@
                         },
                         "leftExpression": {
                           "kind": "<primary-expression>",
-                          "id": 77,
+                          "id": 78,
                           "startPos": {
                             "offset": 361,
                             "line": 14,
@@ -4685,7 +4727,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 76,
+                            "id": 77,
                             "startPos": {
                               "offset": 361,
                               "line": 14,
@@ -4729,7 +4771,7 @@
                         },
                         "rightExpression": {
                           "kind": "<primary-expression>",
-                          "id": 79,
+                          "id": 80,
                           "startPos": {
                             "offset": 364,
                             "line": 14,
@@ -4742,7 +4784,7 @@
                           },
                           "expression": {
                             "kind": "<literal>",
-                            "id": 78,
+                            "id": 79,
                             "startPos": {
                               "offset": 364,
                               "line": 14,
@@ -4791,7 +4833,7 @@
                       },
                       {
                         "kind": "<primary-expression>",
-                        "id": 82,
+                        "id": 83,
                         "startPos": {
                           "offset": 366,
                           "line": 14,
@@ -4804,7 +4846,7 @@
                         },
                         "expression": {
                           "kind": "<variable>",
-                          "id": 81,
+                          "id": 82,
                           "startPos": {
                             "offset": 366,
                             "line": 14,

--- a/packages/dbml-core/src/parse/dbml/tests/validator/output/complex_indexes.out.json
+++ b/packages/dbml-core/src/parse/dbml/tests/validator/output/complex_indexes.out.json
@@ -1,7 +1,7 @@
 {
   "value": {
     "kind": "<program>",
-    "id": 77,
+    "id": 78,
     "startPos": {
       "offset": 0,
       "line": 0,
@@ -15,7 +15,7 @@
     "body": [
       {
         "kind": "<element-declaration>",
-        "id": 76,
+        "id": 77,
         "startPos": {
           "offset": 0,
           "line": 0,
@@ -150,7 +150,7 @@
         },
         "body": {
           "kind": "<block-expression>",
-          "id": 75,
+          "id": 76,
           "startPos": {
             "offset": 15,
             "line": 0,
@@ -1095,7 +1095,7 @@
             },
             {
               "kind": "<element-declaration>",
-              "id": 73,
+              "id": 74,
               "startPos": {
                 "offset": 100,
                 "line": 6,
@@ -1215,7 +1215,7 @@
               },
               "body": {
                 "kind": "<block-expression>",
-                "id": 72,
+                "id": 73,
                 "startPos": {
                   "offset": 108,
                   "line": 6,
@@ -1272,16 +1272,16 @@
                 "body": [
                   {
                     "kind": "<function-application>",
-                    "id": 43,
+                    "id": 32,
                     "startPos": {
                       "offset": 117,
                       "line": 7,
                       "column": 6
                     },
                     "endPos": {
-                      "offset": 219,
-                      "line": 8,
-                      "column": 57
+                      "offset": 135,
+                      "line": 7,
+                      "column": 24
                     },
                     "callee": {
                       "kind": "<tuple-expression>",
@@ -1794,9 +1794,9 @@
                                 "column": 25
                               },
                               "endPos": {
-                                "offset": 162,
-                                "line": 8,
-                                "column": 0
+                                "offset": 161,
+                                "line": 7,
+                                "column": 50
                               },
                               "value": " composite primary key\r",
                               "leadingTrivia": [],
@@ -1805,8 +1805,100 @@
                               "trailingInvalid": [],
                               "isInvalid": false,
                               "start": 136,
-                              "end": 162
+                              "end": 161
                             },
+                            {
+                              "kind": "<newline>",
+                              "startPos": {
+                                "offset": 161,
+                                "line": 7,
+                                "column": 50
+                              },
+                              "endPos": {
+                                "offset": 162,
+                                "line": 8,
+                                "column": 0
+                              },
+                              "value": "\n",
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
+                              "leadingInvalid": [],
+                              "trailingInvalid": [],
+                              "isInvalid": false,
+                              "start": 161,
+                              "end": 162
+                            }
+                          ],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 134,
+                          "end": 135
+                        },
+                        "start": 131,
+                        "end": 135,
+                        "fullStart": 131,
+                        "fullEnd": 162
+                      }
+                    ],
+                    "start": 117,
+                    "end": 135,
+                    "fullStart": 111,
+                    "fullEnd": 162
+                  },
+                  {
+                    "kind": "<function-application>",
+                    "id": 44,
+                    "startPos": {
+                      "offset": 168,
+                      "line": 8,
+                      "column": 6
+                    },
+                    "endPos": {
+                      "offset": 219,
+                      "line": 8,
+                      "column": 57
+                    },
+                    "callee": {
+                      "kind": "<primary-expression>",
+                      "id": 34,
+                      "startPos": {
+                        "offset": 168,
+                        "line": 8,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 178,
+                        "line": 8,
+                        "column": 16
+                      },
+                      "expression": {
+                        "kind": "<variable>",
+                        "id": 33,
+                        "startPos": {
+                          "offset": 168,
+                          "line": 8,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 178,
+                          "line": 8,
+                          "column": 16
+                        },
+                        "variable": {
+                          "kind": "<identifier>",
+                          "startPos": {
+                            "offset": 168,
+                            "line": 8,
+                            "column": 6
+                          },
+                          "endPos": {
+                            "offset": 178,
+                            "line": 8,
+                            "column": 16
+                          },
+                          "value": "created_at",
+                          "leadingTrivia": [
                             {
                               "kind": "<space>",
                               "startPos": {
@@ -1934,99 +2026,49 @@
                               "end": 168
                             }
                           ],
+                          "trailingTrivia": [
+                            {
+                              "kind": "<space>",
+                              "startPos": {
+                                "offset": 178,
+                                "line": 8,
+                                "column": 16
+                              },
+                              "endPos": {
+                                "offset": 179,
+                                "line": 8,
+                                "column": 17
+                              },
+                              "value": " ",
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
+                              "leadingInvalid": [],
+                              "trailingInvalid": [],
+                              "isInvalid": false,
+                              "start": 178,
+                              "end": 179
+                            }
+                          ],
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 134,
-                          "end": 135
-                        },
-                        "start": 131,
-                        "end": 135,
-                        "fullStart": 131,
-                        "fullEnd": 168
-                      },
-                      {
-                        "kind": "<primary-expression>",
-                        "id": 33,
-                        "startPos": {
-                          "offset": 168,
-                          "line": 8,
-                          "column": 6
-                        },
-                        "endPos": {
-                          "offset": 178,
-                          "line": 8,
-                          "column": 16
-                        },
-                        "expression": {
-                          "kind": "<variable>",
-                          "id": 32,
-                          "startPos": {
-                            "offset": 168,
-                            "line": 8,
-                            "column": 6
-                          },
-                          "endPos": {
-                            "offset": 178,
-                            "line": 8,
-                            "column": 16
-                          },
-                          "variable": {
-                            "kind": "<identifier>",
-                            "startPos": {
-                              "offset": 168,
-                              "line": 8,
-                              "column": 6
-                            },
-                            "endPos": {
-                              "offset": 178,
-                              "line": 8,
-                              "column": 16
-                            },
-                            "value": "created_at",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [
-                              {
-                                "kind": "<space>",
-                                "startPos": {
-                                  "offset": 178,
-                                  "line": 8,
-                                  "column": 16
-                                },
-                                "endPos": {
-                                  "offset": 179,
-                                  "line": 8,
-                                  "column": 17
-                                },
-                                "value": " ",
-                                "leadingTrivia": [],
-                                "trailingTrivia": [],
-                                "leadingInvalid": [],
-                                "trailingInvalid": [],
-                                "isInvalid": false,
-                                "start": 178,
-                                "end": 179
-                              }
-                            ],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 168,
-                            "end": 178
-                          },
                           "start": 168,
-                          "end": 178,
-                          "fullStart": 168,
-                          "fullEnd": 179
+                          "end": 178
                         },
                         "start": 168,
                         "end": 178,
-                        "fullStart": 168,
+                        "fullStart": 162,
                         "fullEnd": 179
                       },
+                      "start": 168,
+                      "end": 178,
+                      "fullStart": 162,
+                      "fullEnd": 179
+                    },
+                    "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 42,
+                        "id": 43,
                         "startPos": {
                           "offset": 179,
                           "line": 8,
@@ -2061,10 +2103,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 37,
+                            "id": 38,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 34,
+                              "id": 35,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -2105,7 +2147,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 36,
+                              "id": 37,
                               "startPos": {
                                 "offset": 186,
                                 "line": 8,
@@ -2118,7 +2160,7 @@
                               },
                               "expression": {
                                 "kind": "<literal>",
-                                "id": 35,
+                                "id": 36,
                                 "startPos": {
                                   "offset": 186,
                                   "line": 8,
@@ -2220,10 +2262,10 @@
                           },
                           {
                             "kind": "<attribute>",
-                            "id": 41,
+                            "id": 42,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 38,
+                              "id": 39,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -2264,7 +2306,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 40,
+                              "id": 41,
                               "startPos": {
                                 "offset": 212,
                                 "line": 8,
@@ -2277,7 +2319,7 @@
                               },
                               "expression": {
                                 "kind": "<literal>",
-                                "id": 39,
+                                "id": 40,
                                 "startPos": {
                                   "offset": 212,
                                   "line": 8,
@@ -2472,14 +2514,14 @@
                         "fullEnd": 221
                       }
                     ],
-                    "start": 117,
+                    "start": 168,
                     "end": 219,
-                    "fullStart": 111,
+                    "fullStart": 162,
                     "fullEnd": 221
                   },
                   {
                     "kind": "<primary-expression>",
-                    "id": 45,
+                    "id": 46,
                     "startPos": {
                       "offset": 227,
                       "line": 9,
@@ -2492,7 +2534,7 @@
                     },
                     "expression": {
                       "kind": "<variable>",
-                      "id": 44,
+                      "id": 45,
                       "startPos": {
                         "offset": 227,
                         "line": 9,
@@ -2685,7 +2727,7 @@
                   },
                   {
                     "kind": "<function-application>",
-                    "id": 54,
+                    "id": 55,
                     "startPos": {
                       "offset": 247,
                       "line": 10,
@@ -2698,7 +2740,7 @@
                     },
                     "callee": {
                       "kind": "<tuple-expression>",
-                      "id": 50,
+                      "id": 51,
                       "startPos": {
                         "offset": 247,
                         "line": 10,
@@ -2860,7 +2902,7 @@
                       "elementList": [
                         {
                           "kind": "<primary-expression>",
-                          "id": 47,
+                          "id": 48,
                           "startPos": {
                             "offset": 248,
                             "line": 10,
@@ -2873,7 +2915,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 46,
+                            "id": 47,
                             "startPos": {
                               "offset": 248,
                               "line": 10,
@@ -2917,7 +2959,7 @@
                         },
                         {
                           "kind": "<primary-expression>",
-                          "id": 49,
+                          "id": 50,
                           "startPos": {
                             "offset": 257,
                             "line": 10,
@@ -2930,7 +2972,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 48,
+                            "id": 49,
                             "startPos": {
                               "offset": 257,
                               "line": 10,
@@ -3069,7 +3111,7 @@
                     "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 53,
+                        "id": 54,
                         "startPos": {
                           "offset": 271,
                           "line": 10,
@@ -3104,10 +3146,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 52,
+                            "id": 53,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 51,
+                              "id": 52,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -3219,7 +3261,7 @@
                   },
                   {
                     "kind": "<function-application>",
-                    "id": 62,
+                    "id": 63,
                     "startPos": {
                       "offset": 287,
                       "line": 11,
@@ -3232,7 +3274,7 @@
                     },
                     "callee": {
                       "kind": "<primary-expression>",
-                      "id": 56,
+                      "id": 57,
                       "startPos": {
                         "offset": 287,
                         "line": 11,
@@ -3245,7 +3287,7 @@
                       },
                       "expression": {
                         "kind": "<variable>",
-                        "id": 55,
+                        "id": 56,
                         "startPos": {
                           "offset": 287,
                           "line": 11,
@@ -3439,7 +3481,7 @@
                     "args": [
                       {
                         "kind": "<list-expression>",
-                        "id": 61,
+                        "id": 62,
                         "startPos": {
                           "offset": 300,
                           "line": 11,
@@ -3474,10 +3516,10 @@
                         "elementList": [
                           {
                             "kind": "<attribute>",
-                            "id": 60,
+                            "id": 61,
                             "name": {
                               "kind": "<identifer-stream>",
-                              "id": 57,
+                              "id": 58,
                               "identifiers": [
                                 {
                                   "kind": "<identifier>",
@@ -3518,7 +3560,7 @@
                             },
                             "value": {
                               "kind": "<primary-expression>",
-                              "id": 59,
+                              "id": 60,
                               "startPos": {
                                 "offset": 307,
                                 "line": 11,
@@ -3531,7 +3573,7 @@
                               },
                               "expression": {
                                 "kind": "<variable>",
-                                "id": 58,
+                                "id": 59,
                                 "startPos": {
                                   "offset": 307,
                                   "line": 11,
@@ -3689,7 +3731,7 @@
                   },
                   {
                     "kind": "<group-expression>",
-                    "id": 64,
+                    "id": 65,
                     "startPos": {
                       "offset": 320,
                       "line": 12,
@@ -3851,7 +3893,7 @@
                     "elementList": [
                       {
                         "kind": "<function-expression>",
-                        "id": 63,
+                        "id": 64,
                         "startPos": {
                           "offset": 321,
                           "line": 12,
@@ -3940,7 +3982,7 @@
                   },
                   {
                     "kind": "<tuple-expression>",
-                    "id": 67,
+                    "id": 68,
                     "startPos": {
                       "offset": 336,
                       "line": 13,
@@ -4102,7 +4144,7 @@
                     "elementList": [
                       {
                         "kind": "<function-expression>",
-                        "id": 65,
+                        "id": 66,
                         "startPos": {
                           "offset": 337,
                           "line": 13,
@@ -4141,7 +4183,7 @@
                       },
                       {
                         "kind": "<function-expression>",
-                        "id": 66,
+                        "id": 67,
                         "startPos": {
                           "offset": 344,
                           "line": 13,
@@ -4252,7 +4294,7 @@
                   },
                   {
                     "kind": "<tuple-expression>",
-                    "id": 71,
+                    "id": 72,
                     "startPos": {
                       "offset": 364,
                       "line": 14,
@@ -4414,7 +4456,7 @@
                     "elementList": [
                       {
                         "kind": "<function-expression>",
-                        "id": 68,
+                        "id": 69,
                         "startPos": {
                           "offset": 365,
                           "line": 14,
@@ -4453,7 +4495,7 @@
                       },
                       {
                         "kind": "<primary-expression>",
-                        "id": 70,
+                        "id": 71,
                         "startPos": {
                           "offset": 372,
                           "line": 14,
@@ -4466,7 +4508,7 @@
                         },
                         "expression": {
                           "kind": "<variable>",
-                          "id": 69,
+                          "id": 70,
                           "startPos": {
                             "offset": 372,
                             "line": 14,
@@ -4676,7 +4718,7 @@
               "end": 380,
               "fullStart": 97,
               "fullEnd": 382,
-              "parentElement": 76
+              "parentElement": 77
             }
           ],
           "blockCloseBrace": {
@@ -4731,7 +4773,7 @@
         "end": 383,
         "fullStart": 0,
         "fullEnd": 385,
-        "parentElement": 77,
+        "parentElement": 78,
         "symbol": 2
       }
     ],
@@ -4809,1227 +4851,12 @@
               "declaration": 21
             }
           },
-          "declaration": 76
+          "declaration": 77
         }
       },
       "id": 0,
       "references": []
     }
   },
-  "errors": [
-    {
-      "code": 3043,
-      "diagnostic": "An Indexes field must be a function expression, a column name or a tuple of such",
-      "nodeOrToken": {
-        "kind": "<function-application>",
-        "id": 43,
-        "startPos": {
-          "offset": 117,
-          "line": 7,
-          "column": 6
-        },
-        "endPos": {
-          "offset": 219,
-          "line": 8,
-          "column": 57
-        },
-        "callee": {
-          "kind": "<tuple-expression>",
-          "id": 28,
-          "startPos": {
-            "offset": 117,
-            "line": 7,
-            "column": 6
-          },
-          "endPos": {
-            "offset": 130,
-            "line": 7,
-            "column": 19
-          },
-          "tupleOpenParen": {
-            "kind": "<lparen>",
-            "startPos": {
-              "offset": 117,
-              "line": 7,
-              "column": 6
-            },
-            "endPos": {
-              "offset": 118,
-              "line": 7,
-              "column": 7
-            },
-            "value": "(",
-            "leadingTrivia": [
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 111,
-                  "line": 7,
-                  "column": 0
-                },
-                "endPos": {
-                  "offset": 112,
-                  "line": 7,
-                  "column": 1
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 111,
-                "end": 112
-              },
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 112,
-                  "line": 7,
-                  "column": 1
-                },
-                "endPos": {
-                  "offset": 113,
-                  "line": 7,
-                  "column": 2
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 112,
-                "end": 113
-              },
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 113,
-                  "line": 7,
-                  "column": 2
-                },
-                "endPos": {
-                  "offset": 114,
-                  "line": 7,
-                  "column": 3
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 113,
-                "end": 114
-              },
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 114,
-                  "line": 7,
-                  "column": 3
-                },
-                "endPos": {
-                  "offset": 115,
-                  "line": 7,
-                  "column": 4
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 114,
-                "end": 115
-              },
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 115,
-                  "line": 7,
-                  "column": 4
-                },
-                "endPos": {
-                  "offset": 116,
-                  "line": 7,
-                  "column": 5
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 115,
-                "end": 116
-              },
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 116,
-                  "line": 7,
-                  "column": 5
-                },
-                "endPos": {
-                  "offset": 117,
-                  "line": 7,
-                  "column": 6
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 116,
-                "end": 117
-              }
-            ],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 117,
-            "end": 118
-          },
-          "elementList": [
-            {
-              "kind": "<primary-expression>",
-              "id": 25,
-              "startPos": {
-                "offset": 118,
-                "line": 7,
-                "column": 7
-              },
-              "endPos": {
-                "offset": 120,
-                "line": 7,
-                "column": 9
-              },
-              "expression": {
-                "kind": "<variable>",
-                "id": 24,
-                "startPos": {
-                  "offset": 118,
-                  "line": 7,
-                  "column": 7
-                },
-                "endPos": {
-                  "offset": 120,
-                  "line": 7,
-                  "column": 9
-                },
-                "variable": {
-                  "kind": "<identifier>",
-                  "startPos": {
-                    "offset": 118,
-                    "line": 7,
-                    "column": 7
-                  },
-                  "endPos": {
-                    "offset": 120,
-                    "line": 7,
-                    "column": 9
-                  },
-                  "value": "id",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 118,
-                  "end": 120
-                },
-                "start": 118,
-                "end": 120,
-                "fullStart": 118,
-                "fullEnd": 120
-              },
-              "start": 118,
-              "end": 120,
-              "fullStart": 118,
-              "fullEnd": 120
-            },
-            {
-              "kind": "<primary-expression>",
-              "id": 27,
-              "startPos": {
-                "offset": 122,
-                "line": 7,
-                "column": 11
-              },
-              "endPos": {
-                "offset": 129,
-                "line": 7,
-                "column": 18
-              },
-              "expression": {
-                "kind": "<variable>",
-                "id": 26,
-                "startPos": {
-                  "offset": 122,
-                  "line": 7,
-                  "column": 11
-                },
-                "endPos": {
-                  "offset": 129,
-                  "line": 7,
-                  "column": 18
-                },
-                "variable": {
-                  "kind": "<identifier>",
-                  "startPos": {
-                    "offset": 122,
-                    "line": 7,
-                    "column": 11
-                  },
-                  "endPos": {
-                    "offset": 129,
-                    "line": 7,
-                    "column": 18
-                  },
-                  "value": "country",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 122,
-                  "end": 129
-                },
-                "start": 122,
-                "end": 129,
-                "fullStart": 122,
-                "fullEnd": 129
-              },
-              "start": 122,
-              "end": 129,
-              "fullStart": 122,
-              "fullEnd": 129
-            }
-          ],
-          "commaList": [
-            {
-              "kind": "<comma>",
-              "startPos": {
-                "offset": 120,
-                "line": 7,
-                "column": 9
-              },
-              "endPos": {
-                "offset": 121,
-                "line": 7,
-                "column": 10
-              },
-              "value": ",",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 121,
-                    "line": 7,
-                    "column": 10
-                  },
-                  "endPos": {
-                    "offset": 122,
-                    "line": 7,
-                    "column": 11
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 121,
-                  "end": 122
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 120,
-              "end": 121
-            }
-          ],
-          "tupleCloseParen": {
-            "kind": "<rparen>",
-            "startPos": {
-              "offset": 129,
-              "line": 7,
-              "column": 18
-            },
-            "endPos": {
-              "offset": 130,
-              "line": 7,
-              "column": 19
-            },
-            "value": ")",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 130,
-                  "line": 7,
-                  "column": 19
-                },
-                "endPos": {
-                  "offset": 131,
-                  "line": 7,
-                  "column": 20
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 130,
-                "end": 131
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 129,
-            "end": 130
-          },
-          "start": 117,
-          "end": 130,
-          "fullStart": 111,
-          "fullEnd": 131
-        },
-        "args": [
-          {
-            "kind": "<list-expression>",
-            "id": 31,
-            "startPos": {
-              "offset": 131,
-              "line": 7,
-              "column": 20
-            },
-            "endPos": {
-              "offset": 135,
-              "line": 7,
-              "column": 24
-            },
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 131,
-                "line": 7,
-                "column": 20
-              },
-              "endPos": {
-                "offset": 132,
-                "line": 7,
-                "column": 21
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 131,
-              "end": 132
-            },
-            "elementList": [
-              {
-                "kind": "<attribute>",
-                "id": 30,
-                "name": {
-                  "kind": "<identifer-stream>",
-                  "id": 29,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 132,
-                        "line": 7,
-                        "column": 21
-                      },
-                      "endPos": {
-                        "offset": 134,
-                        "line": 7,
-                        "column": 23
-                      },
-                      "value": "pk",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 132,
-                      "end": 134
-                    }
-                  ],
-                  "startPos": {
-                    "offset": 132,
-                    "line": 7,
-                    "column": 21
-                  },
-                  "endPos": {
-                    "offset": 134,
-                    "line": 7,
-                    "column": 23
-                  },
-                  "start": 132,
-                  "end": 134,
-                  "fullStart": 132,
-                  "fullEnd": 134
-                },
-                "startPos": {
-                  "offset": 132,
-                  "line": 7,
-                  "column": 21
-                },
-                "endPos": {
-                  "offset": 134,
-                  "line": 7,
-                  "column": 23
-                },
-                "start": 132,
-                "end": 134,
-                "fullStart": 132,
-                "fullEnd": 134
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 134,
-                "line": 7,
-                "column": 23
-              },
-              "endPos": {
-                "offset": 135,
-                "line": 7,
-                "column": 24
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 135,
-                    "line": 7,
-                    "column": 24
-                  },
-                  "endPos": {
-                    "offset": 136,
-                    "line": 7,
-                    "column": 25
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 135,
-                  "end": 136
-                },
-                {
-                  "kind": "<single-line-comment>",
-                  "startPos": {
-                    "offset": 136,
-                    "line": 7,
-                    "column": 25
-                  },
-                  "endPos": {
-                    "offset": 162,
-                    "line": 8,
-                    "column": 0
-                  },
-                  "value": " composite primary key\r",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 136,
-                  "end": 162
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 162,
-                    "line": 8,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 163,
-                    "line": 8,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 162,
-                  "end": 163
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 163,
-                    "line": 8,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 164,
-                    "line": 8,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 163,
-                  "end": 164
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 164,
-                    "line": 8,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 165,
-                    "line": 8,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 164,
-                  "end": 165
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 165,
-                    "line": 8,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 166,
-                    "line": 8,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 165,
-                  "end": 166
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 166,
-                    "line": 8,
-                    "column": 4
-                  },
-                  "endPos": {
-                    "offset": 167,
-                    "line": 8,
-                    "column": 5
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 166,
-                  "end": 167
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 167,
-                    "line": 8,
-                    "column": 5
-                  },
-                  "endPos": {
-                    "offset": 168,
-                    "line": 8,
-                    "column": 6
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 167,
-                  "end": 168
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 134,
-              "end": 135
-            },
-            "start": 131,
-            "end": 135,
-            "fullStart": 131,
-            "fullEnd": 168
-          },
-          {
-            "kind": "<primary-expression>",
-            "id": 33,
-            "startPos": {
-              "offset": 168,
-              "line": 8,
-              "column": 6
-            },
-            "endPos": {
-              "offset": 178,
-              "line": 8,
-              "column": 16
-            },
-            "expression": {
-              "kind": "<variable>",
-              "id": 32,
-              "startPos": {
-                "offset": 168,
-                "line": 8,
-                "column": 6
-              },
-              "endPos": {
-                "offset": 178,
-                "line": 8,
-                "column": 16
-              },
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 168,
-                  "line": 8,
-                  "column": 6
-                },
-                "endPos": {
-                  "offset": 178,
-                  "line": 8,
-                  "column": 16
-                },
-                "value": "created_at",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 178,
-                      "line": 8,
-                      "column": 16
-                    },
-                    "endPos": {
-                      "offset": 179,
-                      "line": 8,
-                      "column": 17
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 178,
-                    "end": 179
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 168,
-                "end": 178
-              },
-              "start": 168,
-              "end": 178,
-              "fullStart": 168,
-              "fullEnd": 179
-            },
-            "start": 168,
-            "end": 178,
-            "fullStart": 168,
-            "fullEnd": 179
-          },
-          {
-            "kind": "<list-expression>",
-            "id": 42,
-            "startPos": {
-              "offset": 179,
-              "line": 8,
-              "column": 17
-            },
-            "endPos": {
-              "offset": 219,
-              "line": 8,
-              "column": 57
-            },
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 179,
-                "line": 8,
-                "column": 17
-              },
-              "endPos": {
-                "offset": 180,
-                "line": 8,
-                "column": 18
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 179,
-              "end": 180
-            },
-            "elementList": [
-              {
-                "kind": "<attribute>",
-                "id": 37,
-                "name": {
-                  "kind": "<identifer-stream>",
-                  "id": 34,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 180,
-                        "line": 8,
-                        "column": 18
-                      },
-                      "endPos": {
-                        "offset": 184,
-                        "line": 8,
-                        "column": 22
-                      },
-                      "value": "name",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 180,
-                      "end": 184
-                    }
-                  ],
-                  "startPos": {
-                    "offset": 180,
-                    "line": 8,
-                    "column": 18
-                  },
-                  "endPos": {
-                    "offset": 184,
-                    "line": 8,
-                    "column": 22
-                  },
-                  "start": 180,
-                  "end": 184,
-                  "fullStart": 180,
-                  "fullEnd": 184
-                },
-                "value": {
-                  "kind": "<primary-expression>",
-                  "id": 36,
-                  "startPos": {
-                    "offset": 186,
-                    "line": 8,
-                    "column": 24
-                  },
-                  "endPos": {
-                    "offset": 204,
-                    "line": 8,
-                    "column": 42
-                  },
-                  "expression": {
-                    "kind": "<literal>",
-                    "id": 35,
-                    "startPos": {
-                      "offset": 186,
-                      "line": 8,
-                      "column": 24
-                    },
-                    "endPos": {
-                      "offset": 204,
-                      "line": 8,
-                      "column": 42
-                    },
-                    "literal": {
-                      "kind": "<string>",
-                      "startPos": {
-                        "offset": 186,
-                        "line": 8,
-                        "column": 24
-                      },
-                      "endPos": {
-                        "offset": 204,
-                        "line": 8,
-                        "column": 42
-                      },
-                      "value": "created_at_index",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 186,
-                      "end": 204
-                    },
-                    "start": 186,
-                    "end": 204,
-                    "fullStart": 186,
-                    "fullEnd": 204
-                  },
-                  "start": 186,
-                  "end": 204,
-                  "fullStart": 186,
-                  "fullEnd": 204
-                },
-                "colon": {
-                  "kind": "<colon>",
-                  "startPos": {
-                    "offset": 184,
-                    "line": 8,
-                    "column": 22
-                  },
-                  "endPos": {
-                    "offset": 185,
-                    "line": 8,
-                    "column": 23
-                  },
-                  "value": ":",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 185,
-                        "line": 8,
-                        "column": 23
-                      },
-                      "endPos": {
-                        "offset": 186,
-                        "line": 8,
-                        "column": 24
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 185,
-                      "end": 186
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 184,
-                  "end": 185
-                },
-                "startPos": {
-                  "offset": 180,
-                  "line": 8,
-                  "column": 18
-                },
-                "endPos": {
-                  "offset": 204,
-                  "line": 8,
-                  "column": 42
-                },
-                "start": 180,
-                "end": 204,
-                "fullStart": 180,
-                "fullEnd": 204
-              },
-              {
-                "kind": "<attribute>",
-                "id": 41,
-                "name": {
-                  "kind": "<identifer-stream>",
-                  "id": 38,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 206,
-                        "line": 8,
-                        "column": 44
-                      },
-                      "endPos": {
-                        "offset": 210,
-                        "line": 8,
-                        "column": 48
-                      },
-                      "value": "note",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 206,
-                      "end": 210
-                    }
-                  ],
-                  "startPos": {
-                    "offset": 206,
-                    "line": 8,
-                    "column": 44
-                  },
-                  "endPos": {
-                    "offset": 210,
-                    "line": 8,
-                    "column": 48
-                  },
-                  "start": 206,
-                  "end": 210,
-                  "fullStart": 206,
-                  "fullEnd": 210
-                },
-                "value": {
-                  "kind": "<primary-expression>",
-                  "id": 40,
-                  "startPos": {
-                    "offset": 212,
-                    "line": 8,
-                    "column": 50
-                  },
-                  "endPos": {
-                    "offset": 218,
-                    "line": 8,
-                    "column": 56
-                  },
-                  "expression": {
-                    "kind": "<literal>",
-                    "id": 39,
-                    "startPos": {
-                      "offset": 212,
-                      "line": 8,
-                      "column": 50
-                    },
-                    "endPos": {
-                      "offset": 218,
-                      "line": 8,
-                      "column": 56
-                    },
-                    "literal": {
-                      "kind": "<string>",
-                      "startPos": {
-                        "offset": 212,
-                        "line": 8,
-                        "column": 50
-                      },
-                      "endPos": {
-                        "offset": 218,
-                        "line": 8,
-                        "column": 56
-                      },
-                      "value": "Date",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 212,
-                      "end": 218
-                    },
-                    "start": 212,
-                    "end": 218,
-                    "fullStart": 212,
-                    "fullEnd": 218
-                  },
-                  "start": 212,
-                  "end": 218,
-                  "fullStart": 212,
-                  "fullEnd": 218
-                },
-                "colon": {
-                  "kind": "<colon>",
-                  "startPos": {
-                    "offset": 210,
-                    "line": 8,
-                    "column": 48
-                  },
-                  "endPos": {
-                    "offset": 211,
-                    "line": 8,
-                    "column": 49
-                  },
-                  "value": ":",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 211,
-                        "line": 8,
-                        "column": 49
-                      },
-                      "endPos": {
-                        "offset": 212,
-                        "line": 8,
-                        "column": 50
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 211,
-                      "end": 212
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 210,
-                  "end": 211
-                },
-                "startPos": {
-                  "offset": 206,
-                  "line": 8,
-                  "column": 44
-                },
-                "endPos": {
-                  "offset": 218,
-                  "line": 8,
-                  "column": 56
-                },
-                "start": 206,
-                "end": 218,
-                "fullStart": 206,
-                "fullEnd": 218
-              }
-            ],
-            "commaList": [
-              {
-                "kind": "<comma>",
-                "startPos": {
-                  "offset": 204,
-                  "line": 8,
-                  "column": 42
-                },
-                "endPos": {
-                  "offset": 205,
-                  "line": 8,
-                  "column": 43
-                },
-                "value": ",",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 205,
-                      "line": 8,
-                      "column": 43
-                    },
-                    "endPos": {
-                      "offset": 206,
-                      "line": 8,
-                      "column": 44
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 205,
-                    "end": 206
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 204,
-                "end": 205
-              }
-            ],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 218,
-                "line": 8,
-                "column": 56
-              },
-              "endPos": {
-                "offset": 219,
-                "line": 8,
-                "column": 57
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<newline>",
-                  "startPos": {
-                    "offset": 220,
-                    "line": 8,
-                    "column": 58
-                  },
-                  "endPos": {
-                    "offset": 221,
-                    "line": 9,
-                    "column": 0
-                  },
-                  "value": "\n",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 220,
-                  "end": 221
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 218,
-              "end": 219
-            },
-            "start": 179,
-            "end": 219,
-            "fullStart": 179,
-            "fullEnd": 221
-          }
-        ],
-        "start": 117,
-        "end": 219,
-        "fullStart": 111,
-        "fullEnd": 221
-      },
-      "start": 117,
-      "end": 219,
-      "name": "CompileError"
-    }
-  ]
+  "errors": []
 }

--- a/packages/dbml-core/src/parse/dbml/tests/validator/output/table_settings.out.json
+++ b/packages/dbml-core/src/parse/dbml/tests/validator/output/table_settings.out.json
@@ -1,7 +1,7 @@
 {
   "value": {
     "kind": "<program>",
-    "id": 96,
+    "id": 97,
     "startPos": {
       "offset": 0,
       "line": 0,
@@ -15,7 +15,7 @@
     "body": [
       {
         "kind": "<element-declaration>",
-        "id": 80,
+        "id": 81,
         "startPos": {
           "offset": 0,
           "line": 0,
@@ -1119,7 +1119,7 @@
         },
         "body": {
           "kind": "<block-expression>",
-          "id": 79,
+          "id": 80,
           "startPos": {
             "offset": 109,
             "line": 4,
@@ -1176,16 +1176,16 @@
           "body": [
             {
               "kind": "<function-application>",
-              "id": 29,
+              "id": 22,
               "startPos": {
                 "offset": 116,
                 "line": 5,
                 "column": 4
               },
               "endPos": {
-                "offset": 177,
-                "line": 6,
-                "column": 26
+                "offset": 140,
+                "line": 5,
+                "column": 28
               },
               "callee": {
                 "kind": "<primary-expression>",
@@ -1677,9 +1677,9 @@
                           "column": 32
                         },
                         "endPos": {
-                          "offset": 151,
-                          "line": 6,
-                          "column": 0
+                          "offset": 150,
+                          "line": 5,
+                          "column": 38
                         },
                         "value": " pk\r",
                         "leadingTrivia": [],
@@ -1688,8 +1688,101 @@
                         "trailingInvalid": [],
                         "isInvalid": false,
                         "start": 144,
-                        "end": 151
+                        "end": 150
                       },
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 150,
+                          "line": 5,
+                          "column": 38
+                        },
+                        "endPos": {
+                          "offset": 151,
+                          "line": 6,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 150,
+                        "end": 151
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 139,
+                    "end": 140
+                  },
+                  "start": 127,
+                  "end": 140,
+                  "fullStart": 127,
+                  "fullEnd": 151
+                }
+              ],
+              "start": 116,
+              "end": 140,
+              "fullStart": 112,
+              "fullEnd": 151,
+              "symbol": 3
+            },
+            {
+              "kind": "<function-application>",
+              "id": 30,
+              "startPos": {
+                "offset": 155,
+                "line": 6,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 177,
+                "line": 6,
+                "column": 26
+              },
+              "callee": {
+                "kind": "<primary-expression>",
+                "id": 24,
+                "startPos": {
+                  "offset": 155,
+                  "line": 6,
+                  "column": 4
+                },
+                "endPos": {
+                  "offset": 159,
+                  "line": 6,
+                  "column": 8
+                },
+                "expression": {
+                  "kind": "<variable>",
+                  "id": 23,
+                  "startPos": {
+                    "offset": 155,
+                    "line": 6,
+                    "column": 4
+                  },
+                  "endPos": {
+                    "offset": 159,
+                    "line": 6,
+                    "column": 8
+                  },
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 155,
+                      "line": 6,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 159,
+                      "line": 6,
+                      "column": 8
+                    },
+                    "value": "name",
+                    "leadingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
@@ -1775,99 +1868,49 @@
                         "end": 155
                       }
                     ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 159,
+                          "line": 6,
+                          "column": 8
+                        },
+                        "endPos": {
+                          "offset": 160,
+                          "line": 6,
+                          "column": 9
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 159,
+                        "end": 160
+                      }
+                    ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 139,
-                    "end": 140
-                  },
-                  "start": 127,
-                  "end": 140,
-                  "fullStart": 127,
-                  "fullEnd": 155
-                },
-                {
-                  "kind": "<primary-expression>",
-                  "id": 23,
-                  "startPos": {
-                    "offset": 155,
-                    "line": 6,
-                    "column": 4
-                  },
-                  "endPos": {
-                    "offset": 159,
-                    "line": 6,
-                    "column": 8
-                  },
-                  "expression": {
-                    "kind": "<variable>",
-                    "id": 22,
-                    "startPos": {
-                      "offset": 155,
-                      "line": 6,
-                      "column": 4
-                    },
-                    "endPos": {
-                      "offset": 159,
-                      "line": 6,
-                      "column": 8
-                    },
-                    "variable": {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 155,
-                        "line": 6,
-                        "column": 4
-                      },
-                      "endPos": {
-                        "offset": 159,
-                        "line": 6,
-                        "column": 8
-                      },
-                      "value": "name",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<space>",
-                          "startPos": {
-                            "offset": 159,
-                            "line": 6,
-                            "column": 8
-                          },
-                          "endPos": {
-                            "offset": 160,
-                            "line": 6,
-                            "column": 9
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 159,
-                          "end": 160
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 155,
-                      "end": 159
-                    },
                     "start": 155,
-                    "end": 159,
-                    "fullStart": 155,
-                    "fullEnd": 160
+                    "end": 159
                   },
                   "start": 155,
                   "end": 159,
-                  "fullStart": 155,
+                  "fullStart": 151,
                   "fullEnd": 160
                 },
+                "start": 155,
+                "end": 159,
+                "fullStart": 151,
+                "fullEnd": 160
+              },
+              "args": [
                 {
                   "kind": "<primary-expression>",
-                  "id": 25,
+                  "id": 26,
                   "startPos": {
                     "offset": 160,
                     "line": 6,
@@ -1880,7 +1923,7 @@
                   },
                   "expression": {
                     "kind": "<variable>",
-                    "id": 24,
+                    "id": 25,
                     "startPos": {
                       "offset": 160,
                       "line": 6,
@@ -1946,7 +1989,7 @@
                 },
                 {
                   "kind": "<list-expression>",
-                  "id": 28,
+                  "id": 29,
                   "startPos": {
                     "offset": 167,
                     "line": 6,
@@ -1981,10 +2024,10 @@
                   "elementList": [
                     {
                       "kind": "<attribute>",
-                      "id": 27,
+                      "id": 28,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 26,
+                        "id": 27,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -2279,14 +2322,15 @@
                   "fullEnd": 199
                 }
               ],
-              "start": 116,
+              "start": 155,
               "end": 177,
-              "fullStart": 112,
-              "fullEnd": 199
+              "fullStart": 151,
+              "fullEnd": 199,
+              "symbol": 4
             },
             {
               "kind": "<function-application>",
-              "id": 47,
+              "id": 48,
               "startPos": {
                 "offset": 203,
                 "line": 7,
@@ -2299,7 +2343,7 @@
               },
               "callee": {
                 "kind": "<primary-expression>",
-                "id": 31,
+                "id": 32,
                 "startPos": {
                   "offset": 203,
                   "line": 7,
@@ -2312,7 +2356,7 @@
                 },
                 "expression": {
                   "kind": "<variable>",
-                  "id": 30,
+                  "id": 31,
                   "startPos": {
                     "offset": 203,
                     "line": 7,
@@ -2464,7 +2508,7 @@
               "args": [
                 {
                   "kind": "<primary-expression>",
-                  "id": 33,
+                  "id": 34,
                   "startPos": {
                     "offset": 207,
                     "line": 7,
@@ -2477,7 +2521,7 @@
                   },
                   "expression": {
                     "kind": "<variable>",
-                    "id": 32,
+                    "id": 33,
                     "startPos": {
                       "offset": 207,
                       "line": 7,
@@ -2543,7 +2587,7 @@
                 },
                 {
                   "kind": "<list-expression>",
-                  "id": 46,
+                  "id": 47,
                   "startPos": {
                     "offset": 215,
                     "line": 7,
@@ -2578,10 +2622,10 @@
                   "elementList": [
                     {
                       "kind": "<attribute>",
-                      "id": 37,
+                      "id": 38,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 34,
+                        "id": 35,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -2622,7 +2666,7 @@
                       },
                       "value": {
                         "kind": "<primary-expression>",
-                        "id": 36,
+                        "id": 37,
                         "startPos": {
                           "offset": 225,
                           "line": 7,
@@ -2635,7 +2679,7 @@
                         },
                         "expression": {
                           "kind": "<literal>",
-                          "id": 35,
+                          "id": 36,
                           "startPos": {
                             "offset": 225,
                             "line": 7,
@@ -2737,10 +2781,10 @@
                     },
                     {
                       "kind": "<attribute>",
-                      "id": 41,
+                      "id": 42,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 38,
+                        "id": 39,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -2781,7 +2825,7 @@
                       },
                       "value": {
                         "kind": "<primary-expression>",
-                        "id": 40,
+                        "id": 41,
                         "startPos": {
                           "offset": 235,
                           "line": 7,
@@ -2794,7 +2838,7 @@
                         },
                         "expression": {
                           "kind": "<literal>",
-                          "id": 39,
+                          "id": 40,
                           "startPos": {
                             "offset": 235,
                             "line": 7,
@@ -2896,10 +2940,10 @@
                     },
                     {
                       "kind": "<attribute>",
-                      "id": 45,
+                      "id": 46,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 42,
+                        "id": 43,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -2940,7 +2984,7 @@
                       },
                       "value": {
                         "kind": "<primary-expression>",
-                        "id": 44,
+                        "id": 45,
                         "startPos": {
                           "offset": 259,
                           "line": 7,
@@ -2953,7 +2997,7 @@
                         },
                         "expression": {
                           "kind": "<literal>",
-                          "id": 43,
+                          "id": 44,
                           "startPos": {
                             "offset": 259,
                             "line": 7,
@@ -3195,11 +3239,11 @@
               "end": 282,
               "fullStart": 199,
               "fullEnd": 284,
-              "symbol": 3
+              "symbol": 5
             },
             {
               "kind": "<function-application>",
-              "id": 66,
+              "id": 67,
               "startPos": {
                 "offset": 319,
                 "line": 10,
@@ -3212,7 +3256,7 @@
               },
               "callee": {
                 "kind": "<primary-expression>",
-                "id": 49,
+                "id": 50,
                 "startPos": {
                   "offset": 319,
                   "line": 10,
@@ -3225,7 +3269,7 @@
                 },
                 "expression": {
                   "kind": "<variable>",
-                  "id": 48,
+                  "id": 49,
                   "startPos": {
                     "offset": 319,
                     "line": 10,
@@ -3503,7 +3547,7 @@
               "args": [
                 {
                   "kind": "<infix-expression>",
-                  "id": 54,
+                  "id": 55,
                   "startPos": {
                     "offset": 326,
                     "line": 10,
@@ -3537,7 +3581,7 @@
                   },
                   "leftExpression": {
                     "kind": "<primary-expression>",
-                    "id": 51,
+                    "id": 52,
                     "startPos": {
                       "offset": 326,
                       "line": 10,
@@ -3550,7 +3594,7 @@
                     },
                     "expression": {
                       "kind": "<variable>",
-                      "id": 50,
+                      "id": 51,
                       "startPos": {
                         "offset": 326,
                         "line": 10,
@@ -3594,7 +3638,7 @@
                   },
                   "rightExpression": {
                     "kind": "<primary-expression>",
-                    "id": 53,
+                    "id": 54,
                     "startPos": {
                       "offset": 329,
                       "line": 10,
@@ -3607,7 +3651,7 @@
                     },
                     "expression": {
                       "kind": "<variable>",
-                      "id": 52,
+                      "id": 53,
                       "startPos": {
                         "offset": 329,
                         "line": 10,
@@ -3678,7 +3722,7 @@
                 },
                 {
                   "kind": "<list-expression>",
-                  "id": 65,
+                  "id": 66,
                   "startPos": {
                     "offset": 336,
                     "line": 10,
@@ -3713,10 +3757,10 @@
                   "elementList": [
                     {
                       "kind": "<attribute>",
-                      "id": 64,
+                      "id": 65,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 55,
+                        "id": 56,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -3757,7 +3801,7 @@
                       },
                       "value": {
                         "kind": "<infix-expression>",
-                        "id": 63,
+                        "id": 64,
                         "startPos": {
                           "offset": 346,
                           "line": 10,
@@ -3791,7 +3835,7 @@
                         },
                         "leftExpression": {
                           "kind": "<infix-expression>",
-                          "id": 60,
+                          "id": 61,
                           "startPos": {
                             "offset": 346,
                             "line": 10,
@@ -3825,7 +3869,7 @@
                           },
                           "leftExpression": {
                             "kind": "<primary-expression>",
-                            "id": 57,
+                            "id": 58,
                             "startPos": {
                               "offset": 346,
                               "line": 10,
@@ -3838,7 +3882,7 @@
                             },
                             "expression": {
                               "kind": "<variable>",
-                              "id": 56,
+                              "id": 57,
                               "startPos": {
                                 "offset": 346,
                                 "line": 10,
@@ -3882,7 +3926,7 @@
                           },
                           "rightExpression": {
                             "kind": "<primary-expression>",
-                            "id": 59,
+                            "id": 60,
                             "startPos": {
                               "offset": 349,
                               "line": 10,
@@ -3895,7 +3939,7 @@
                             },
                             "expression": {
                               "kind": "<variable>",
-                              "id": 58,
+                              "id": 59,
                               "startPos": {
                                 "offset": 349,
                                 "line": 10,
@@ -3944,7 +3988,7 @@
                         },
                         "rightExpression": {
                           "kind": "<primary-expression>",
-                          "id": 62,
+                          "id": 63,
                           "startPos": {
                             "offset": 356,
                             "line": 10,
@@ -3957,7 +4001,7 @@
                           },
                           "expression": {
                             "kind": "<variable>",
-                            "id": 61,
+                            "id": 62,
                             "startPos": {
                               "offset": 356,
                               "line": 10,
@@ -4117,11 +4161,11 @@
               "end": 360,
               "fullStart": 284,
               "fullEnd": 362,
-              "symbol": 4
+              "symbol": 6
             },
             {
               "kind": "<function-application>",
-              "id": 78,
+              "id": 79,
               "startPos": {
                 "offset": 366,
                 "line": 11,
@@ -4134,7 +4178,7 @@
               },
               "callee": {
                 "kind": "<primary-expression>",
-                "id": 68,
+                "id": 69,
                 "startPos": {
                   "offset": 366,
                   "line": 11,
@@ -4147,7 +4191,7 @@
                 },
                 "expression": {
                   "kind": "<variable>",
-                  "id": 67,
+                  "id": 68,
                   "startPos": {
                     "offset": 366,
                     "line": 11,
@@ -4299,7 +4343,7 @@
               "args": [
                 {
                   "kind": "<call-expression>",
-                  "id": 74,
+                  "id": 75,
                   "startPos": {
                     "offset": 370,
                     "line": 11,
@@ -4312,7 +4356,7 @@
                   },
                   "callee": {
                     "kind": "<primary-expression>",
-                    "id": 70,
+                    "id": 71,
                     "startPos": {
                       "offset": 370,
                       "line": 11,
@@ -4325,7 +4369,7 @@
                     },
                     "expression": {
                       "kind": "<variable>",
-                      "id": 69,
+                      "id": 70,
                       "startPos": {
                         "offset": 370,
                         "line": 11,
@@ -4369,7 +4413,7 @@
                   },
                   "argumentList": {
                     "kind": "<group-expression>",
-                    "id": 73,
+                    "id": 74,
                     "startPos": {
                       "offset": 374,
                       "line": 11,
@@ -4404,7 +4448,7 @@
                     "elementList": [
                       {
                         "kind": "<primary-expression>",
-                        "id": 72,
+                        "id": 73,
                         "startPos": {
                           "offset": 375,
                           "line": 11,
@@ -4417,7 +4461,7 @@
                         },
                         "expression": {
                           "kind": "<literal>",
-                          "id": 71,
+                          "id": 72,
                           "startPos": {
                             "offset": 375,
                             "line": 11,
@@ -4516,7 +4560,7 @@
                 },
                 {
                   "kind": "<list-expression>",
-                  "id": 77,
+                  "id": 78,
                   "startPos": {
                     "offset": 380,
                     "line": 11,
@@ -4551,10 +4595,10 @@
                   "elementList": [
                     {
                       "kind": "<attribute>",
-                      "id": 76,
+                      "id": 77,
                       "name": {
                         "kind": "<identifer-stream>",
-                        "id": 75,
+                        "id": 76,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
@@ -4663,7 +4707,7 @@
               "end": 386,
               "fullStart": 362,
               "fullEnd": 388,
-              "symbol": 5
+              "symbol": 7
             }
           ],
           "blockCloseBrace": {
@@ -4718,12 +4762,12 @@
         "end": 389,
         "fullStart": 0,
         "fullEnd": 391,
-        "parentElement": 96,
+        "parentElement": 97,
         "symbol": 2
       },
       {
         "kind": "<element-declaration>",
-        "id": 95,
+        "id": 96,
         "startPos": {
           "offset": 393,
           "line": 14,
@@ -4801,7 +4845,7 @@
         },
         "name": {
           "kind": "<infix-expression>",
-          "id": 85,
+          "id": 86,
           "startPos": {
             "offset": 398,
             "line": 14,
@@ -4835,7 +4879,7 @@
           },
           "leftExpression": {
             "kind": "<primary-expression>",
-            "id": 82,
+            "id": 83,
             "startPos": {
               "offset": 398,
               "line": 14,
@@ -4848,7 +4892,7 @@
             },
             "expression": {
               "kind": "<variable>",
-              "id": 81,
+              "id": 82,
               "startPos": {
                 "offset": 398,
                 "line": 14,
@@ -4892,7 +4936,7 @@
           },
           "rightExpression": {
             "kind": "<primary-expression>",
-            "id": 84,
+            "id": 85,
             "startPos": {
               "offset": 401,
               "line": 14,
@@ -4905,7 +4949,7 @@
             },
             "expression": {
               "kind": "<variable>",
-              "id": 83,
+              "id": 84,
               "startPos": {
                 "offset": 401,
                 "line": 14,
@@ -4976,7 +5020,7 @@
         },
         "body": {
           "kind": "<block-expression>",
-          "id": 94,
+          "id": 95,
           "startPos": {
             "offset": 408,
             "line": 14,
@@ -5033,7 +5077,7 @@
           "body": [
             {
               "kind": "<primary-expression>",
-              "id": 87,
+              "id": 88,
               "startPos": {
                 "offset": 415,
                 "line": 15,
@@ -5046,7 +5090,7 @@
               },
               "expression": {
                 "kind": "<variable>",
-                "id": 86,
+                "id": 87,
                 "startPos": {
                   "offset": 415,
                   "line": 15,
@@ -5194,11 +5238,11 @@
               "end": 420,
               "fullStart": 411,
               "fullEnd": 422,
-              "symbol": 9
+              "symbol": 11
             },
             {
               "kind": "<primary-expression>",
-              "id": 89,
+              "id": 90,
               "startPos": {
                 "offset": 426,
                 "line": 16,
@@ -5211,7 +5255,7 @@
               },
               "expression": {
                 "kind": "<variable>",
-                "id": 88,
+                "id": 89,
                 "startPos": {
                   "offset": 426,
                   "line": 16,
@@ -5359,11 +5403,11 @@
               "end": 429,
               "fullStart": 422,
               "fullEnd": 431,
-              "symbol": 10
+              "symbol": 12
             },
             {
               "kind": "<primary-expression>",
-              "id": 91,
+              "id": 92,
               "startPos": {
                 "offset": 435,
                 "line": 17,
@@ -5376,7 +5420,7 @@
               },
               "expression": {
                 "kind": "<variable>",
-                "id": 90,
+                "id": 91,
                 "startPos": {
                   "offset": 435,
                   "line": 17,
@@ -5524,11 +5568,11 @@
               "end": 441,
               "fullStart": 431,
               "fullEnd": 443,
-              "symbol": 11
+              "symbol": 13
             },
             {
               "kind": "<primary-expression>",
-              "id": 93,
+              "id": 94,
               "startPos": {
                 "offset": 447,
                 "line": 18,
@@ -5541,7 +5585,7 @@
               },
               "expression": {
                 "kind": "<variable>",
-                "id": 92,
+                "id": 93,
                 "startPos": {
                   "offset": 447,
                   "line": 18,
@@ -5689,7 +5733,7 @@
               "end": 453,
               "fullStart": 443,
               "fullEnd": 455,
-              "symbol": 12
+              "symbol": 14
             }
           ],
           "blockCloseBrace": {
@@ -5722,8 +5766,8 @@
         "end": 456,
         "fullStart": 392,
         "fullEnd": 456,
-        "parentElement": 96,
-        "symbol": 8
+        "parentElement": 97,
+        "symbol": 10
       }
     ],
     "eof": {
@@ -5757,54 +5801,64 @@
           "references": [],
           "id": 2,
           "symbolTable": {
-            "Column:age": {
+            "Column:id": {
               "references": [],
               "id": 3,
-              "declaration": 47
+              "declaration": 22
+            },
+            "Column:name": {
+              "references": [],
+              "id": 4,
+              "declaration": 30
+            },
+            "Column:age": {
+              "references": [],
+              "id": 5,
+              "declaration": 48
             },
             "Column:status": {
               "references": [],
-              "id": 4,
-              "declaration": 66
+              "id": 6,
+              "declaration": 67
             },
             "Column:dob": {
               "references": [],
-              "id": 5,
-              "declaration": 78
+              "id": 7,
+              "declaration": 79
             }
           },
-          "declaration": 80
+          "declaration": 81
         },
         "Schema:v2": {
           "references": [],
-          "id": 7,
+          "id": 9,
           "symbolTable": {
             "Enum:status": {
               "references": [],
-              "id": 8,
+              "id": 10,
               "symbolTable": {
                 "Enum field:churn": {
                   "references": [],
-                  "id": 9,
-                  "declaration": 87
+                  "id": 11,
+                  "declaration": 88
                 },
                 "Enum field:new": {
                   "references": [],
-                  "id": 10,
-                  "declaration": 89
+                  "id": 12,
+                  "declaration": 90
                 },
                 "Enum field:active": {
                   "references": [],
-                  "id": 11,
-                  "declaration": 91
+                  "id": 13,
+                  "declaration": 92
                 },
                 "Enum field:tenant": {
                   "references": [],
-                  "id": 12,
-                  "declaration": 93
+                  "id": 14,
+                  "declaration": 94
                 }
               },
-              "declaration": 95
+              "declaration": 96
             }
           }
         }
@@ -6088,1131 +6142,14 @@
       "name": "CompileError"
     },
     {
-      "code": 3017,
-      "diagnostic": "A Table's column must have a name and a type",
-      "nodeOrToken": {
-        "kind": "<function-application>",
-        "id": 29,
-        "startPos": {
-          "offset": 116,
-          "line": 5,
-          "column": 4
-        },
-        "endPos": {
-          "offset": 177,
-          "line": 6,
-          "column": 26
-        },
-        "callee": {
-          "kind": "<primary-expression>",
-          "id": 16,
-          "startPos": {
-            "offset": 116,
-            "line": 5,
-            "column": 4
-          },
-          "endPos": {
-            "offset": 118,
-            "line": 5,
-            "column": 6
-          },
-          "expression": {
-            "kind": "<variable>",
-            "id": 15,
-            "startPos": {
-              "offset": 116,
-              "line": 5,
-              "column": 4
-            },
-            "endPos": {
-              "offset": 118,
-              "line": 5,
-              "column": 6
-            },
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 116,
-                "line": 5,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 118,
-                "line": 5,
-                "column": 6
-              },
-              "value": "id",
-              "leadingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 112,
-                    "line": 5,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 113,
-                    "line": 5,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 112,
-                  "end": 113
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 113,
-                    "line": 5,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 114,
-                    "line": 5,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 113,
-                  "end": 114
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 114,
-                    "line": 5,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 115,
-                    "line": 5,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 114,
-                  "end": 115
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 115,
-                    "line": 5,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 116,
-                    "line": 5,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 115,
-                  "end": 116
-                }
-              ],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 118,
-                    "line": 5,
-                    "column": 6
-                  },
-                  "endPos": {
-                    "offset": 119,
-                    "line": 5,
-                    "column": 7
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 118,
-                  "end": 119
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 116,
-              "end": 118
-            },
-            "start": 116,
-            "end": 118,
-            "fullStart": 112,
-            "fullEnd": 119
-          },
-          "start": 116,
-          "end": 118,
-          "fullStart": 112,
-          "fullEnd": 119
-        },
-        "args": [
-          {
-            "kind": "<primary-expression>",
-            "id": 18,
-            "startPos": {
-              "offset": 119,
-              "line": 5,
-              "column": 7
-            },
-            "endPos": {
-              "offset": 126,
-              "line": 5,
-              "column": 14
-            },
-            "expression": {
-              "kind": "<variable>",
-              "id": 17,
-              "startPos": {
-                "offset": 119,
-                "line": 5,
-                "column": 7
-              },
-              "endPos": {
-                "offset": 126,
-                "line": 5,
-                "column": 14
-              },
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 119,
-                  "line": 5,
-                  "column": 7
-                },
-                "endPos": {
-                  "offset": 126,
-                  "line": 5,
-                  "column": 14
-                },
-                "value": "integer",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 126,
-                      "line": 5,
-                      "column": 14
-                    },
-                    "endPos": {
-                      "offset": 127,
-                      "line": 5,
-                      "column": 15
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 126,
-                    "end": 127
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 119,
-                "end": 126
-              },
-              "start": 119,
-              "end": 126,
-              "fullStart": 119,
-              "fullEnd": 127
-            },
-            "start": 119,
-            "end": 126,
-            "fullStart": 119,
-            "fullEnd": 127
-          },
-          {
-            "kind": "<list-expression>",
-            "id": 21,
-            "startPos": {
-              "offset": 127,
-              "line": 5,
-              "column": 15
-            },
-            "endPos": {
-              "offset": 140,
-              "line": 5,
-              "column": 28
-            },
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 127,
-                "line": 5,
-                "column": 15
-              },
-              "endPos": {
-                "offset": 128,
-                "line": 5,
-                "column": 16
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 127,
-              "end": 128
-            },
-            "elementList": [
-              {
-                "kind": "<attribute>",
-                "id": 20,
-                "name": {
-                  "kind": "<identifer-stream>",
-                  "id": 19,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 128,
-                        "line": 5,
-                        "column": 16
-                      },
-                      "endPos": {
-                        "offset": 135,
-                        "line": 5,
-                        "column": 23
-                      },
-                      "value": "primary",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<space>",
-                          "startPos": {
-                            "offset": 135,
-                            "line": 5,
-                            "column": 23
-                          },
-                          "endPos": {
-                            "offset": 136,
-                            "line": 5,
-                            "column": 24
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 135,
-                          "end": 136
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 128,
-                      "end": 135
-                    },
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 136,
-                        "line": 5,
-                        "column": 24
-                      },
-                      "endPos": {
-                        "offset": 139,
-                        "line": 5,
-                        "column": 27
-                      },
-                      "value": "key",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 136,
-                      "end": 139
-                    }
-                  ],
-                  "startPos": {
-                    "offset": 128,
-                    "line": 5,
-                    "column": 16
-                  },
-                  "endPos": {
-                    "offset": 139,
-                    "line": 5,
-                    "column": 27
-                  },
-                  "start": 128,
-                  "end": 139,
-                  "fullStart": 128,
-                  "fullEnd": 139
-                },
-                "startPos": {
-                  "offset": 128,
-                  "line": 5,
-                  "column": 16
-                },
-                "endPos": {
-                  "offset": 139,
-                  "line": 5,
-                  "column": 27
-                },
-                "start": 128,
-                "end": 139,
-                "fullStart": 128,
-                "fullEnd": 139
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 139,
-                "line": 5,
-                "column": 27
-              },
-              "endPos": {
-                "offset": 140,
-                "line": 5,
-                "column": 28
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 140,
-                    "line": 5,
-                    "column": 28
-                  },
-                  "endPos": {
-                    "offset": 141,
-                    "line": 5,
-                    "column": 29
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 140,
-                  "end": 141
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 141,
-                    "line": 5,
-                    "column": 29
-                  },
-                  "endPos": {
-                    "offset": 142,
-                    "line": 5,
-                    "column": 30
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 141,
-                  "end": 142
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 142,
-                    "line": 5,
-                    "column": 30
-                  },
-                  "endPos": {
-                    "offset": 143,
-                    "line": 5,
-                    "column": 31
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 142,
-                  "end": 143
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 143,
-                    "line": 5,
-                    "column": 31
-                  },
-                  "endPos": {
-                    "offset": 144,
-                    "line": 5,
-                    "column": 32
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 143,
-                  "end": 144
-                },
-                {
-                  "kind": "<single-line-comment>",
-                  "startPos": {
-                    "offset": 144,
-                    "line": 5,
-                    "column": 32
-                  },
-                  "endPos": {
-                    "offset": 151,
-                    "line": 6,
-                    "column": 0
-                  },
-                  "value": " pk\r",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 144,
-                  "end": 151
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 151,
-                    "line": 6,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 152,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 151,
-                  "end": 152
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 152,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 153,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 152,
-                  "end": 153
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 153,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 154,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 153,
-                  "end": 154
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 154,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 155,
-                    "line": 6,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 154,
-                  "end": 155
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 139,
-              "end": 140
-            },
-            "start": 127,
-            "end": 140,
-            "fullStart": 127,
-            "fullEnd": 155
-          },
-          {
-            "kind": "<primary-expression>",
-            "id": 23,
-            "startPos": {
-              "offset": 155,
-              "line": 6,
-              "column": 4
-            },
-            "endPos": {
-              "offset": 159,
-              "line": 6,
-              "column": 8
-            },
-            "expression": {
-              "kind": "<variable>",
-              "id": 22,
-              "startPos": {
-                "offset": 155,
-                "line": 6,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 159,
-                "line": 6,
-                "column": 8
-              },
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 155,
-                  "line": 6,
-                  "column": 4
-                },
-                "endPos": {
-                  "offset": 159,
-                  "line": 6,
-                  "column": 8
-                },
-                "value": "name",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 159,
-                      "line": 6,
-                      "column": 8
-                    },
-                    "endPos": {
-                      "offset": 160,
-                      "line": 6,
-                      "column": 9
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 159,
-                    "end": 160
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 155,
-                "end": 159
-              },
-              "start": 155,
-              "end": 159,
-              "fullStart": 155,
-              "fullEnd": 160
-            },
-            "start": 155,
-            "end": 159,
-            "fullStart": 155,
-            "fullEnd": 160
-          },
-          {
-            "kind": "<primary-expression>",
-            "id": 25,
-            "startPos": {
-              "offset": 160,
-              "line": 6,
-              "column": 9
-            },
-            "endPos": {
-              "offset": 166,
-              "line": 6,
-              "column": 15
-            },
-            "expression": {
-              "kind": "<variable>",
-              "id": 24,
-              "startPos": {
-                "offset": 160,
-                "line": 6,
-                "column": 9
-              },
-              "endPos": {
-                "offset": 166,
-                "line": 6,
-                "column": 15
-              },
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 160,
-                  "line": 6,
-                  "column": 9
-                },
-                "endPos": {
-                  "offset": 166,
-                  "line": 6,
-                  "column": 15
-                },
-                "value": "string",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 166,
-                      "line": 6,
-                      "column": 15
-                    },
-                    "endPos": {
-                      "offset": 167,
-                      "line": 6,
-                      "column": 16
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 166,
-                    "end": 167
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 160,
-                "end": 166
-              },
-              "start": 160,
-              "end": 166,
-              "fullStart": 160,
-              "fullEnd": 167
-            },
-            "start": 160,
-            "end": 166,
-            "fullStart": 160,
-            "fullEnd": 167
-          },
-          {
-            "kind": "<list-expression>",
-            "id": 28,
-            "startPos": {
-              "offset": 167,
-              "line": 6,
-              "column": 16
-            },
-            "endPos": {
-              "offset": 177,
-              "line": 6,
-              "column": 26
-            },
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 167,
-                "line": 6,
-                "column": 16
-              },
-              "endPos": {
-                "offset": 168,
-                "line": 6,
-                "column": 17
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 167,
-              "end": 168
-            },
-            "elementList": [
-              {
-                "kind": "<attribute>",
-                "id": 27,
-                "name": {
-                  "kind": "<identifer-stream>",
-                  "id": 26,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 168,
-                        "line": 6,
-                        "column": 17
-                      },
-                      "endPos": {
-                        "offset": 171,
-                        "line": 6,
-                        "column": 20
-                      },
-                      "value": "not",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<space>",
-                          "startPos": {
-                            "offset": 171,
-                            "line": 6,
-                            "column": 20
-                          },
-                          "endPos": {
-                            "offset": 172,
-                            "line": 6,
-                            "column": 21
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 171,
-                          "end": 172
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 168,
-                      "end": 171
-                    },
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 172,
-                        "line": 6,
-                        "column": 21
-                      },
-                      "endPos": {
-                        "offset": 176,
-                        "line": 6,
-                        "column": 25
-                      },
-                      "value": "null",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 172,
-                      "end": 176
-                    }
-                  ],
-                  "startPos": {
-                    "offset": 168,
-                    "line": 6,
-                    "column": 17
-                  },
-                  "endPos": {
-                    "offset": 176,
-                    "line": 6,
-                    "column": 25
-                  },
-                  "start": 168,
-                  "end": 176,
-                  "fullStart": 168,
-                  "fullEnd": 176
-                },
-                "startPos": {
-                  "offset": 168,
-                  "line": 6,
-                  "column": 17
-                },
-                "endPos": {
-                  "offset": 176,
-                  "line": 6,
-                  "column": 25
-                },
-                "start": 168,
-                "end": 176,
-                "fullStart": 168,
-                "fullEnd": 176
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 176,
-                "line": 6,
-                "column": 25
-              },
-              "endPos": {
-                "offset": 177,
-                "line": 6,
-                "column": 26
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 177,
-                    "line": 6,
-                    "column": 26
-                  },
-                  "endPos": {
-                    "offset": 178,
-                    "line": 6,
-                    "column": 27
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 177,
-                  "end": 178
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 178,
-                    "line": 6,
-                    "column": 27
-                  },
-                  "endPos": {
-                    "offset": 179,
-                    "line": 6,
-                    "column": 28
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 178,
-                  "end": 179
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 179,
-                    "line": 6,
-                    "column": 28
-                  },
-                  "endPos": {
-                    "offset": 180,
-                    "line": 6,
-                    "column": 29
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 179,
-                  "end": 180
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 180,
-                    "line": 6,
-                    "column": 29
-                  },
-                  "endPos": {
-                    "offset": 181,
-                    "line": 6,
-                    "column": 30
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 180,
-                  "end": 181
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 181,
-                    "line": 6,
-                    "column": 30
-                  },
-                  "endPos": {
-                    "offset": 182,
-                    "line": 6,
-                    "column": 31
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 181,
-                  "end": 182
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 182,
-                    "line": 6,
-                    "column": 31
-                  },
-                  "endPos": {
-                    "offset": 183,
-                    "line": 6,
-                    "column": 32
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 182,
-                  "end": 183
-                },
-                {
-                  "kind": "<multiline-comment>",
-                  "startPos": {
-                    "offset": 183,
-                    "line": 6,
-                    "column": 32
-                  },
-                  "endPos": {
-                    "offset": 197,
-                    "line": 6,
-                    "column": 46
-                  },
-                  "value": " not null ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 183,
-                  "end": 197
-                },
-                {
-                  "kind": "<newline>",
-                  "startPos": {
-                    "offset": 198,
-                    "line": 6,
-                    "column": 47
-                  },
-                  "endPos": {
-                    "offset": 199,
-                    "line": 7,
-                    "column": 0
-                  },
-                  "value": "\n",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 198,
-                  "end": 199
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 176,
-              "end": 177
-            },
-            "start": 167,
-            "end": 177,
-            "fullStart": 167,
-            "fullEnd": 199
-          }
-        ],
-        "start": 116,
-        "end": 177,
-        "fullStart": 112,
-        "fullEnd": 199
-      },
-      "start": 116,
-      "end": 177,
-      "name": "CompileError"
-    },
-    {
       "code": 3022,
       "diagnostic": "Duplicate setting",
       "nodeOrToken": {
         "kind": "<attribute>",
-        "id": 45,
+        "id": 46,
         "name": {
           "kind": "<identifer-stream>",
-          "id": 42,
+          "id": 43,
           "identifiers": [
             {
               "kind": "<identifier>",
@@ -7253,7 +6190,7 @@
         },
         "value": {
           "kind": "<primary-expression>",
-          "id": 44,
+          "id": 45,
           "startPos": {
             "offset": 259,
             "line": 7,
@@ -7266,7 +6203,7 @@
           },
           "expression": {
             "kind": "<literal>",
-            "id": 43,
+            "id": 44,
             "startPos": {
               "offset": 259,
               "line": 7,


### PR DESCRIPTION
## Summary
* Single line comment was consuming newlines causing two separate lines with the first line containing a trailing comment be joined

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review