### PR TITLE
fix: missing alias was not logged in parser

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/parser.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/parser.ts
@@ -264,6 +264,8 @@ export default class Parser {
           () => (alias = this.normalExpression()),
           this.synchronizeElementDeclarationAlias,
         );
+      } else {
+        this.logError(this.peek(), CompileErrorCode.UNEXPECTED_TOKEN, 'Expect an alias');
       }
     }
 


### PR DESCRIPTION
## Summary
* Missing alias (`as` but no alias) in element header was not reported

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review