### PR TITLE
fix: bug in interpreter alias kind

### DIFF
--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/interpreter.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/interpreter.ts
@@ -108,7 +108,7 @@ export default class Interpreter {
     if (alias) {
       this.db.aliases.push({
         name: alias,
-        kind: 'Table',
+        kind: 'table',
         value: {
           tableName: name,
           schemaName,

--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/types.ts
@@ -123,7 +123,7 @@ export interface TableGroupField {
 
 export interface Alias {
   name: string;
-  kind: string;
+  kind: 'table';
   value: {
     tableName: string;
     schemaName: string | null;


### PR DESCRIPTION
## Summary
* The interpreter currently yield aliases of kind 'Table' while the Database requires 'table'.
* Refine the type of alias's kind to avoid this in the future.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review