### PR TITLE
Alternative dbml parser

### DIFF
--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "antlr4": "^4.13.1",
     "lodash": "^4.17.15",
+    "monaco-editor-core": "^0.44.0",
     "parsimmon": "^1.13.0",
     "pluralize": "^8.0.0"
   },

--- a/packages/dbml-core/src/parse/dbml/src/compiler.ts
+++ b/packages/dbml-core/src/parse/dbml/src/compiler.ts
@@ -1,0 +1,412 @@
+import _ from 'lodash';
+import { SymbolKind, destructureIndex } from './lib/analyzer/symbol/symbolIndex';
+import { generatePossibleIndexes } from './lib/analyzer/symbol/utils';
+import SymbolTable from './lib/analyzer/symbol/symbolTable';
+import { isOffsetWithinSpan } from './lib/utils';
+import { CompileError } from './lib/errors';
+import {
+  BlockExpressionNode,
+  ElementDeclarationNode,
+  FunctionApplicationNode,
+  IdentiferStreamNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  PrefixExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+  SyntaxNodeIdGenerator,
+  TupleExpressionNode,
+} from './lib/parser/nodes';
+import { NodeSymbol, NodeSymbolIdGenerator } from './lib/analyzer/symbol/symbols';
+import Report from './lib/report';
+import Lexer from './lib/lexer/lexer';
+import Parser from './lib/parser/parser';
+import Analyzer from './lib/analyzer/analyzer';
+import Interpreter from './lib/interpreter/interpreter';
+import Database from '../../../model_structure/database';
+import { SyntaxToken, SyntaxTokenKind } from './lib/lexer/tokens';
+import { getMemberChain, isInvalidToken } from './lib/parser/utils';
+
+const enum Query {
+  _Interpret,
+  Parse_Ast,
+  Parse_Errors,
+  Parse_RawDb,
+  Parse_Tokens,
+  Parse_PublicSymbolTable,
+  Token_InvalidStream,
+  Token_FlatStream,
+  Symbol_OfName,
+  Symbol_Members,
+  Container_Stack,
+  Container_Token,
+  Container_Element,
+  Container_Context,
+  Container_Scope,
+  Container_Scope_Kind,
+  /* Not correspond to a query - all meaningful queries should be placed above this */
+  TOTAL_QUERY_COUNT,
+}
+
+type Cache = Map<any, any> | any;
+
+export const enum ScopeKind {
+  TABLE,
+  ENUM,
+  TABLEGROUP,
+  INDEXES,
+  NOTE,
+  REF,
+  PROJECT,
+  CUSTOM,
+  TOPLEVEL,
+}
+
+export default class Compiler {
+  private source = '';
+  private cache: Cache[] = new Array(Query.TOTAL_QUERY_COUNT).fill(null);
+
+  private nodeIdGenerator = new SyntaxNodeIdGenerator();
+  private symbolIdGenerator = new NodeSymbolIdGenerator();
+
+  private createQuery<V>(kind: Query, queryCallback: () => V): () => V;
+  private createQuery<V, U, K>(
+    kind: Query,
+    queryCallback: (arg: U) => V,
+    toKey?: (arg: U) => K,
+  ): (arg: U) => V;
+  private createQuery<V, U, K>(
+    kind: Query,
+    queryCallback: (arg: U | undefined) => V,
+    toKey?: (arg: U) => K,
+  ): (arg: U | undefined) => V {
+    return (arg: U | undefined): V => {
+      const cacheEntry = this.cache[kind];
+      const key = arg && toKey ? toKey(arg) : arg;
+      if (cacheEntry !== null) {
+        if (!(cacheEntry instanceof Map)) {
+          return cacheEntry;
+        }
+
+        if (cacheEntry.has(key)) {
+          return cacheEntry.get(key);
+        }
+      }
+
+      const res = queryCallback(arg);
+
+      if (arg !== undefined) {
+        if (cacheEntry instanceof Map) {
+          cacheEntry.set(key, res);
+        } else {
+          this.cache[kind] = new Map();
+          this.cache[kind].set(key, res);
+        }
+      } else {
+        this.cache[kind] = res;
+      }
+
+      return res;
+    };
+  }
+
+  setSource(source: string) {
+    this.source = source;
+    this.cache = new Array(Query.TOTAL_QUERY_COUNT).fill(null);
+    this.nodeIdGenerator.reset();
+    this.symbolIdGenerator.reset();
+  }
+
+  // A namespace for token-related queries
+  readonly token = {
+    invalidStream: this.createQuery(Query.Token_InvalidStream, (): readonly SyntaxToken[] =>
+      this.parse.tokens().filter(isInvalidToken),
+    ),
+    // Valid + Invalid tokens (which are guarenteed to be non-trivials) are included in the stream
+    flatStream: this.createQuery(Query.Token_FlatStream, (): readonly SyntaxToken[] =>
+      this.parse
+        .tokens()
+        .flatMap((token) => [...token.leadingInvalid, token, ...token.trailingInvalid]),
+    ),
+  };
+
+  // A namespace for parsing-related utility
+  readonly parse = {
+    source: () => this.source as Readonly<string>,
+    _: this.createQuery(
+      Query._Interpret,
+      (): Report<
+        Readonly<{ ast: ProgramNode; tokens: SyntaxToken[]; rawDb?: Database }>,
+        CompileError
+      > => {
+        const parseRes = new Lexer(this.source)
+          .lex()
+          .chain((tokens) => {
+            const parser = new Parser(tokens as SyntaxToken[], this.nodeIdGenerator);
+
+            return parser.parse().map((ast) => ({ ast, tokens }));
+          })
+          .chain(({ ast, tokens }) => {
+            const analyzer = new Analyzer(ast, this.symbolIdGenerator);
+
+            return analyzer.analyze().map(() => ({ ast, tokens }));
+          });
+        if (parseRes.getErrors().length > 0) {
+          return parseRes;
+        }
+
+        return parseRes.chain(({ ast, tokens }) => {
+          const interpreter = new Interpreter(ast);
+
+          return interpreter
+            .interpret()
+            .map((interpretedRes) => ({ ast, tokens, rawDb: new Database(interpretedRes) }));
+        });
+      },
+    ),
+    ast: this.createQuery(
+      Query.Parse_Ast,
+      (): Readonly<ProgramNode> => this.parse._().getValue().ast,
+    ),
+    errors: this.createQuery(Query.Parse_Errors, (): readonly Readonly<CompileError>[] => {
+      const errors = [...this.parse._().getErrors()];
+      errors.sort((e1, e2) => e1.start - e2.start);
+
+      return errors;
+    }),
+    tokens: this.createQuery(
+      Query.Parse_Tokens,
+      (): Readonly<SyntaxToken>[] => this.parse._().getValue().tokens,
+    ),
+    rawDb: this.createQuery(
+      Query.Parse_RawDb,
+      (): Readonly<Database> | undefined => this.parse._().getValue().rawDb,
+    ),
+    publicSymbolTable: this.createQuery(
+      Query.Parse_PublicSymbolTable,
+      (): Readonly<SymbolTable> => this.parse._().getValue().ast.symbol!.symbolTable!,
+    ),
+  };
+
+  readonly container = {
+    stack: this.createQuery(
+      Query.Container_Stack,
+      (offset: number): readonly Readonly<SyntaxNode>[] => {
+        const tokens = this.parse.tokens();
+        let { index } = this.container.token(offset);
+        const { token } = this.container.token(offset);
+        if (index === undefined) {
+          return [this.parse.ast()];
+        }
+        while (tokens[index].isInvalid && index >= 0) {
+          index -= 1;
+        }
+        if (index === -1) {
+          return [this.parse.ast()];
+        }
+
+        const searchOffset = tokens[index].start;
+
+        let curNode: Readonly<SyntaxNode> = this.parse.ast();
+        const res: SyntaxNode[] = [curNode];
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const memberChain = getMemberChain(curNode);
+          const foundMem = memberChain.find((mem) => isOffsetWithinSpan(searchOffset, mem));
+          if (foundMem === undefined || foundMem instanceof SyntaxToken) {
+            break;
+          }
+          res.push(foundMem);
+          curNode = foundMem;
+        }
+
+        if (token?.kind === SyntaxTokenKind.COLON) {
+          return res;
+        }
+
+        while (res.length > 0) {
+          let popOnce = false;
+          const lastContainer = _.last(res)!;
+
+          if (lastContainer instanceof FunctionApplicationNode) {
+            const source = this.parse.source();
+            for (let i = lastContainer.end; i < offset; i += 1) {
+              if (source[i] === '\n') {
+                res.pop();
+                popOnce = true;
+              }
+            }
+          } else if (
+            lastContainer instanceof PrefixExpressionNode ||
+            lastContainer instanceof InfixExpressionNode
+          ) {
+            if (this.container.token(offset).token !== lastContainer.op) {
+              res.pop();
+              popOnce = true;
+            }
+          } else if (
+            lastContainer instanceof ListExpressionNode ||
+            lastContainer instanceof TupleExpressionNode ||
+            lastContainer instanceof BlockExpressionNode
+          ) {
+            if (lastContainer.end <= offset) {
+              res.pop();
+              popOnce = true;
+            }
+          } else if (!(lastContainer instanceof IdentiferStreamNode)) {
+            if (lastContainer.end < offset) {
+              res.pop();
+              popOnce = true;
+            }
+          }
+
+          if (popOnce) {
+            const maybeElement = _.last(res);
+            if (maybeElement instanceof ElementDeclarationNode && maybeElement.end <= offset) {
+              res.pop();
+            }
+          }
+          if (!popOnce) {
+            break;
+          }
+        }
+
+        return res;
+      },
+    ),
+
+    token: this.createQuery(
+      Query.Container_Token,
+      (
+        offset: number,
+      ): { token: SyntaxToken; index: number } | { token: undefined; index: undefined } => {
+        const id = this.token.flatStream().findIndex((token) => token.start >= offset);
+        if (id === undefined) {
+          return { token: undefined, index: undefined };
+        }
+
+        if (id <= 0) {
+          return { token: undefined, index: undefined };
+        }
+
+        return {
+          token: this.token.flatStream()[id - 1],
+          index: id - 1,
+        };
+      },
+    ),
+
+    element: this.createQuery(
+      Query.Container_Element,
+      (offset: number): Readonly<ElementDeclarationNode | ProgramNode> => {
+        const containers = this.container.stack(offset);
+        for (let i = containers.length - 1; i >= 0; i -= 1) {
+          if (containers[i] instanceof ElementDeclarationNode) {
+            return containers[i];
+          }
+        }
+
+        return this.parse.ast();
+      },
+    ),
+
+    scope: this.createQuery(
+      Query.Container_Scope,
+      (offset: number): Readonly<SymbolTable> | undefined =>
+        this.container.element(offset)?.symbol?.symbolTable,
+    ),
+
+    scopeKind: this.createQuery(Query.Container_Scope_Kind, (offset: number): ScopeKind => {
+      const element = this.container.element(offset);
+      if (element instanceof ProgramNode) {
+        return ScopeKind.TOPLEVEL;
+      }
+
+      switch (
+        (this.container.element(offset) as ElementDeclarationNode).type?.value.toLowerCase()
+      ) {
+        case 'table':
+          return ScopeKind.TABLE;
+        case 'enum':
+          return ScopeKind.ENUM;
+        case 'ref':
+          return ScopeKind.REF;
+        case 'tablegroup':
+          return ScopeKind.TABLEGROUP;
+        case 'indexes':
+          return ScopeKind.INDEXES;
+        case 'note':
+          return ScopeKind.NOTE;
+        case 'project':
+          return ScopeKind.PROJECT;
+        default:
+          return ScopeKind.CUSTOM;
+      }
+    }),
+  };
+
+  // A namespace for symbol-related queries
+  readonly symbol = {
+    ofName: this.createQuery(
+      Query.Symbol_OfName,
+      ({
+        nameStack,
+        owner = this.parse.ast(),
+      }: {
+        nameStack: string[];
+        owner: ElementDeclarationNode | ProgramNode;
+      }): readonly Readonly<{ symbol: NodeSymbol; kind: SymbolKind; name: string }>[] => {
+        if (nameStack.length === 0) {
+          return [];
+        }
+
+        const res: { symbol: NodeSymbol; kind: SymbolKind; name: string }[] = [];
+
+        for (
+          let currentOwner: ElementDeclarationNode | ProgramNode | undefined = owner;
+          currentOwner;
+          currentOwner =
+            currentOwner instanceof ElementDeclarationNode ? currentOwner.parent : undefined
+        ) {
+          if (!currentOwner.symbol?.symbolTable) {
+            continue;
+          }
+          const { symbolTable } = currentOwner.symbol;
+          let currentPossibleSymbolTables: SymbolTable[] = [symbolTable];
+          let currentPossibleSymbols: { symbol: NodeSymbol; kind: SymbolKind; name: string }[] = [];
+          // eslint-disable-next-line no-restricted-syntax
+          for (const name of nameStack) {
+            currentPossibleSymbols = currentPossibleSymbolTables.flatMap((st) =>
+              generatePossibleIndexes(name).flatMap((index) => {
+                const symbol = st.get(index);
+                const desRes = destructureIndex(index).unwrap_or(undefined);
+
+                return !symbol || !desRes ? [] : { ...desRes, symbol };
+              }),
+            );
+            currentPossibleSymbolTables = currentPossibleSymbols.flatMap((e) =>
+              (e.symbol.symbolTable ? e.symbol.symbolTable : []),
+            );
+          }
+
+          res.push(...currentPossibleSymbols);
+        }
+
+        return res;
+      },
+      ({ nameStack, owner }) => `${nameStack.join('.')}@${owner.id}`,
+    ),
+    members: this.createQuery(
+      Query.Symbol_Members,
+      (
+        ownerSymbol: NodeSymbol,
+      ): readonly Readonly<{ symbol: NodeSymbol; kind: SymbolKind; name: string }>[] =>
+        (ownerSymbol.symbolTable ?
+          [...ownerSymbol.symbolTable.entries()].map(([index, symbol]) => ({
+              ...destructureIndex(index).unwrap(),
+              symbol,
+            })) :
+          []),
+    ),
+  };
+}

--- a/packages/dbml-core/src/parse/dbml/src/constants.ts
+++ b/packages/dbml-core/src/parse/dbml/src/constants.ts
@@ -1,0 +1,2 @@
+export const KEYWORDS_OF_DEFAULT_SETTING = ['null', 'true', 'false'] as readonly string[];
+export const NUMERIC_LITERAL_PREFIX = ['-', '+'] as readonly string[];

--- a/packages/dbml-core/src/parse/dbml/src/index.ts
+++ b/packages/dbml-core/src/parse/dbml/src/index.ts
@@ -1,0 +1,5 @@
+import { serialize } from './lib/serialization/serialize';
+import Compiler from './compiler';
+import * as services from './services/index';
+
+export { serialize, Compiler, services };

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/analyzer.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/analyzer.ts
@@ -1,0 +1,35 @@
+import Validator from './validator/validator';
+import Binder from './binder/binder';
+import { ProgramNode } from '../parser/nodes';
+import Report from '../report';
+import { CompileError } from '../errors';
+import { NodeSymbolIdGenerator } from './symbol/symbols';
+import SymbolFactory from './symbol/factory';
+
+export default class Analyzer {
+  private ast: ProgramNode;
+  private symbolFactory: SymbolFactory;
+
+  constructor(ast: ProgramNode, symbolIdGenerator: NodeSymbolIdGenerator) {
+    this.ast = ast;
+    this.symbolFactory = new SymbolFactory(symbolIdGenerator);
+  }
+
+  // Analyzing: Invoking both the validator and binder
+  analyze(): Report<ProgramNode, CompileError> {
+    const validator = new Validator(this.ast, this.symbolFactory);
+
+    return validator.validate().chain((program) => {
+      const binder = new Binder(program);
+
+      return binder.resolve();
+    });
+  }
+
+  // For invoking the validator only
+  validate(): Report<ProgramNode, CompileError> {
+    const validator = new Validator(this.ast, this.symbolFactory);
+
+    return validator.validate().chain((program) => new Report(program, []));
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/binder.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/binder.ts
@@ -1,0 +1,29 @@
+import { CompileError } from '../../errors';
+import { ElementDeclarationNode, ProgramNode } from '../../parser/nodes';
+import { pickBinder } from './utils';
+import Report from '../../report';
+import { SyntaxToken } from '../../lexer/tokens';
+
+export default class Binder {
+  private ast: ProgramNode;
+
+  private errors: CompileError[];
+
+  constructor(ast: ProgramNode) {
+    this.ast = ast;
+    this.errors = [];
+  }
+
+  resolve(): Report<ProgramNode, CompileError> {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const element of this.ast.body) {
+      if (element.type) {
+        const _Binder = pickBinder(element as ElementDeclarationNode & { type: SyntaxToken });
+        const binder = new _Binder(element, this.errors);
+        binder.bind();
+      }
+    }
+
+    return new Report(this.ast, this.errors);
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/custom.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/custom.ts
@@ -1,0 +1,11 @@
+import ElementBinder from './elementBinder';
+
+export default class CustomBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/elementBinder.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/elementBinder.ts
@@ -1,0 +1,262 @@
+import _ from 'lodash';
+import { isTupleOfVariables } from '../../validator/utils';
+import {
+  BlockExpressionNode,
+  ElementDeclarationNode,
+  FunctionApplicationNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  PostfixExpressionNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  TupleExpressionNode,
+  VariableNode,
+} from '../../../parser/nodes';
+import {
+  extractStringFromIdentifierStream,
+  isAccessExpression,
+  isExpressionAVariableNode,
+} from '../../../parser/utils';
+import { ArgumentBinderRule, BinderRule, SettingListBinderRule } from '../types';
+import {
+  destructureMemberAccessExpression,
+  extractVarNameFromPrimaryVariable,
+  findSymbol,
+} from '../../utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+import { NodeSymbolIndex, createNodeSymbolIndex, destructureIndex } from '../../symbol/symbolIndex';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { pickBinder } from '../utils';
+
+export default abstract class ElementBinder {
+  protected abstract subfield: {
+    arg: ArgumentBinderRule;
+    settingList: SettingListBinderRule;
+  };
+  protected abstract settingList: SettingListBinderRule;
+
+  private errors: CompileError[];
+  private declarationNode: ElementDeclarationNode;
+
+  constructor(declarationNode: ElementDeclarationNode, errors: CompileError[]) {
+    this.declarationNode = declarationNode;
+    this.errors = errors;
+  }
+
+  bind() {
+    this.bindSettingList(this.declarationNode.attributeList, this.settingList);
+    this.bindBody();
+  }
+
+  private bindSettingList(
+    settingList: ListExpressionNode | undefined,
+    binderRule: SettingListBinderRule,
+  ) {
+    if (!settingList) {
+      return;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const attribute of settingList.elementList) {
+      const name = extractStringFromIdentifierStream(attribute.name).unwrap_or(undefined);
+      if (!name) {
+        continue;
+      }
+      const rule = binderRule[name.toLowerCase()];
+      if (rule?.shouldBind) {
+        this.scanAndBind(attribute.value, rule);
+      }
+    }
+  }
+
+  private bindBody() {
+    const node = this.declarationNode;
+    if (!node.body) {
+      return;
+    }
+    const { body: nodeBody } = node;
+
+    if (nodeBody instanceof BlockExpressionNode) {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const sub of nodeBody.body) {
+        if (sub instanceof ElementDeclarationNode && sub.type) {
+          const Binder = pickBinder(sub as ElementDeclarationNode & { type: SyntaxToken });
+          const binder = new Binder(sub, this.errors);
+          binder.bind();
+        } else {
+          this.bindSubfield(sub);
+        }
+      }
+    } else {
+      this.bindSubfield(nodeBody);
+    }
+  }
+
+  private bindSubfield(sub: FunctionApplicationNode | ElementDeclarationNode) {
+    if (sub instanceof ElementDeclarationNode) {
+      return;
+    }
+    const args = [sub.callee, ...sub.args];
+    const maybeSettingList = _.last(args);
+    if (maybeSettingList instanceof ListExpressionNode) {
+      args.pop();
+      this.bindSettingList(maybeSettingList, this.subfield.settingList);
+    }
+    const { argBinderRules } = this.subfield.arg;
+    for (let i = 0; i < Math.min(args.length, argBinderRules.length); i += 1) {
+      if (argBinderRules[i].shouldBind) {
+        this.scanAndBind(args[i], argBinderRules[i] as BinderRule & { shouldBind: true });
+      }
+    }
+  }
+
+  private scanAndBind(node: SyntaxNode | undefined, rule: BinderRule & { shouldBind: true }) {
+    if (!node) {
+      return;
+    }
+
+    if (node instanceof PrimaryExpressionNode) {
+      if (
+        node.expression instanceof VariableNode &&
+        rule.keywords?.includes(node.expression.variable?.value as any)
+      ) {
+        return;
+      }
+      this.bindFragments([node], rule);
+    } else if (node instanceof InfixExpressionNode) {
+      if (isAccessExpression(node)) {
+        this.bindFragments(destructureMemberAccessExpression(node).unwrap_or([]), rule);
+      } else {
+        this.scanAndBind(node.leftExpression, rule);
+        this.scanAndBind(node.rightExpression, rule);
+      }
+    } else if (node instanceof PrefixExpressionNode) {
+      this.scanAndBind(node.expression, rule);
+    } else if (node instanceof PostfixExpressionNode) {
+      this.scanAndBind(node.expression, rule);
+    } else if (node instanceof TupleExpressionNode) {
+      node.elementList.forEach((e) => this.scanAndBind(e, rule));
+    }
+
+    // The other cases are not supported as practically they shouldn't arise
+  }
+
+  private bindFragments(rawFragments: SyntaxNode[], rule: BinderRule & { shouldBind: true }) {
+    if (rawFragments.length === 0) {
+      return;
+    }
+
+    const topSubnamesSymbolKind = [...rule.topSubnamesSymbolKind!];
+    const { remainingSubnamesSymbolKind } = rule;
+
+    // Handle cases of binding an incomplete member access expression
+    const invalidIndex = rawFragments.findIndex((f) => !isExpressionAVariableNode(f));
+    const isComplexTuple = invalidIndex !== -1 && isTupleOfVariables(rawFragments[invalidIndex]);
+    // In case of a complex tuple expression, both `tuple` and `tupleVarSymbolKind` will not be `undefined`
+    const tuple = isComplexTuple ? (rawFragments[invalidIndex] as TupleExpressionNode) : undefined;
+    const tupleVarSymbolKind = invalidIndex >= 0 ? topSubnamesSymbolKind.pop() : undefined;
+
+    const fragments = rawFragments.slice(
+      0,
+      invalidIndex === -1 ? undefined : invalidIndex,
+    ) as (PrimaryExpressionNode & { expression: VariableNode })[];
+    if (fragments.length === 0) {
+      return;
+    }
+
+    const subnameStack: {
+      index: NodeSymbolIndex;
+      referrer: SyntaxNode;
+    }[] = [];
+    while (topSubnamesSymbolKind.length && fragments.length) {
+      const symbolKind = topSubnamesSymbolKind.pop()!;
+      const fragment = fragments.pop()!;
+      const varname = extractVarNameFromPrimaryVariable(fragment).unwrap();
+      subnameStack.unshift({
+        index: createNodeSymbolIndex(varname, symbolKind),
+        referrer: fragment,
+      });
+    }
+
+    while (fragments.length) {
+      const fragment = fragments.pop()!;
+      const varname = extractVarNameFromPrimaryVariable(fragment).unwrap();
+      subnameStack.unshift({
+        index: createNodeSymbolIndex(varname, remainingSubnamesSymbolKind!),
+        referrer: fragment,
+      });
+    }
+
+    return tuple ?
+      tuple.elementList.forEach((e) =>
+          this.resolveIndexStack(
+            [
+              ...subnameStack,
+              {
+                index: createNodeSymbolIndex(
+                  extractVarNameFromPrimaryVariable(e as any).unwrap(),
+                  tupleVarSymbolKind!,
+                ),
+                referrer: e,
+              },
+            ],
+            rule.ignoreNameNotFound,
+          ),
+        ) :
+      this.resolveIndexStack(subnameStack, rule.ignoreNameNotFound);
+  }
+
+  private resolveIndexStack(
+    subnameStack: { index: NodeSymbolIndex; referrer: SyntaxNode }[],
+    ignoreNameNotFound: boolean,
+  ) {
+    if (subnameStack.length === 0) {
+      throw new Error('Unreachable - An unresolved name must have at least one name component');
+    }
+    const [accessSubname, ...remainingSubnames] = subnameStack;
+    const accessSymbol = findSymbol(accessSubname.index, this.declarationNode);
+    if (accessSymbol === undefined) {
+      const { kind, name } = destructureIndex(accessSubname.index).unwrap();
+      this.logError(accessSubname.referrer, `Can not find ${kind} '${name}'`, ignoreNameNotFound);
+
+      return;
+    }
+
+    accessSymbol.references.push(accessSubname.referrer);
+    accessSubname.referrer.referee = accessSymbol;
+
+    let prevScope = accessSymbol.symbolTable!;
+    let { kind: prevKind, name: prevName } = destructureIndex(accessSubname.index).unwrap();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const subname of remainingSubnames) {
+      const { kind: curKind, name: curName } = destructureIndex(subname.index).unwrap();
+      const curSymbol = prevScope.get(subname.index);
+
+      if (!curSymbol) {
+        this.logError(
+          subname.referrer,
+          `${prevKind} '${prevName}' does not have ${curKind} '${curName}'`,
+          ignoreNameNotFound,
+        );
+
+        return;
+      }
+
+      prevKind = curKind;
+      prevName = curName;
+      subname.referrer.referee = curSymbol;
+      curSymbol.references.push(subname.referrer);
+      if (!curSymbol.symbolTable) {
+        break;
+      }
+      prevScope = curSymbol.symbolTable;
+    }
+  }
+
+  protected logError(node: SyntaxNode, message: string, ignoreError: boolean) {
+    if (!ignoreError) {
+      this.errors.push(new CompileError(CompileErrorCode.BINDING_ERROR, message, node));
+    }
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/enum.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/enum.ts
@@ -1,0 +1,11 @@
+import ElementBinder from './elementBinder';
+
+export default class EnumBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [{ shouldBind: false as const }],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/indexes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/indexes.ts
@@ -1,0 +1,19 @@
+import { SymbolKind } from '../../symbol/symbolIndex';
+import ElementBinder from './elementBinder';
+
+export default class IndexesBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [
+        {
+          shouldBind: true as const,
+          topSubnamesSymbolKind: [SymbolKind.Table, SymbolKind.Column],
+          remainingSubnamesSymbolKind: SymbolKind.Schema,
+          ignoreNameNotFound: false,
+        },
+      ],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/note.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/note.ts
@@ -1,0 +1,11 @@
+import ElementBinder from './elementBinder';
+
+export default class NoteBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [{ shouldBind: false as const }],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/project.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/project.ts
@@ -1,0 +1,11 @@
+import ElementBinder from './elementBinder';
+
+export default class ProjectBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/ref.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/ref.ts
@@ -1,0 +1,19 @@
+import { SymbolKind } from '../../symbol/symbolIndex';
+import ElementBinder from './elementBinder';
+
+export default class RefBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [
+        {
+          shouldBind: true as const,
+          topSubnamesSymbolKind: [SymbolKind.Table, SymbolKind.Column],
+          remainingSubnamesSymbolKind: SymbolKind.Schema,
+          ignoreNameNotFound: false,
+        },
+      ],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/table.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/table.ts
@@ -1,0 +1,35 @@
+import { SymbolKind } from '../../symbol/symbolIndex';
+import ElementBinder from './elementBinder';
+import { KEYWORDS_OF_DEFAULT_SETTING } from '../../../../constants';
+
+export default class TableBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [
+        { shouldBind: false as const },
+        {
+          shouldBind: true as const,
+          topSubnamesSymbolKind: [SymbolKind.Enum],
+          remainingSubnamesSymbolKind: SymbolKind.Schema,
+          ignoreNameNotFound: true,
+        },
+      ],
+    },
+    settingList: {
+      ref: {
+        shouldBind: true as const,
+        topSubnamesSymbolKind: [SymbolKind.Table, SymbolKind.Column],
+        remainingSubnamesSymbolKind: SymbolKind.Schema,
+        ignoreNameNotFound: false,
+      },
+      default: {
+        shouldBind: true as const,
+        topSubnamesSymbolKind: [SymbolKind.Enum, SymbolKind.EnumField],
+        remainingSubnamesSymbolKind: SymbolKind.Schema,
+        ignoreNameNotFound: false,
+        keywords: KEYWORDS_OF_DEFAULT_SETTING,
+      },
+    },
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/tableGroup.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/elementBinder/tableGroup.ts
@@ -1,0 +1,19 @@
+import { SymbolKind } from '../../symbol/symbolIndex';
+import ElementBinder from './elementBinder';
+
+export default class TableGroupBinder extends ElementBinder {
+  protected subfield = {
+    arg: {
+      argBinderRules: [
+        {
+          shouldBind: true as const,
+          topSubnamesSymbolKind: [SymbolKind.Table],
+          remainingSubnamesSymbolKind: SymbolKind.Schema,
+          ignoreNameNotFound: false,
+        },
+      ],
+    },
+    settingList: {},
+  };
+  protected settingList = {};
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/types.ts
@@ -1,0 +1,37 @@
+import { SymbolKind } from '../symbol/symbolIndex';
+
+export type BinderRule =
+  | {
+      // Whether the binder should run
+      shouldBind: true;
+      // The kinds of the symbols the last subnames would be bound to
+      // e.g [TableSymbol, ColumnSymbol]
+      //     In `a.b.c`, `b` would be bound to a TableSymbol
+      //                 `c` would be bound to a ColumnSymbol
+      topSubnamesSymbolKind: SymbolKind[];
+      // The kind of the symbols the ramining subnames would be bound to
+      // e.g SchemaSymbol
+      //     In the above example, `a` would be bound to a SchemaSymbol
+      remainingSubnamesSymbolKind: SymbolKind;
+      // Should the binding error be ignored
+      // Useful when trying to bind an enum name in a column type
+      // e.g
+      //    Table Emp {
+      //      status e_status // if `e_status` enum exists, it would be bound,
+      //                      // otherwise, `e_status` is just a plain type
+      //    }
+      ignoreNameNotFound: boolean;
+      // A list of keywords that, when encountered by the binder as a standalone variable, skipped
+      keywords?: readonly string[];
+    }
+  | {
+      shouldBind: false;
+    };
+
+export interface ArgumentBinderRule {
+  argBinderRules: BinderRule[];
+}
+
+export interface SettingListBinderRule {
+  [index: string]: BinderRule;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/binder/utils.ts
@@ -1,0 +1,33 @@
+import { SyntaxToken } from '../../lexer/tokens';
+import { ElementDeclarationNode } from '../../parser/nodes';
+import { ElementKind } from '../validator/types';
+import { toElementKind } from '../validator/utils';
+import CustomBinder from './elementBinder/custom';
+import EnumBinder from './elementBinder/enum';
+import IndexesBinder from './elementBinder/indexes';
+import NoteBinder from './elementBinder/note';
+import ProjectBinder from './elementBinder/project';
+import RefBinder from './elementBinder/ref';
+import TableBinder from './elementBinder/table';
+import TableGroupBinder from './elementBinder/tableGroup';
+
+export function pickBinder(element: ElementDeclarationNode & { type: SyntaxToken }) {
+  switch (toElementKind(element.type.value)) {
+    case ElementKind.ENUM:
+      return EnumBinder;
+    case ElementKind.TABLE:
+      return TableBinder;
+    case ElementKind.TABLEGROUP:
+      return TableGroupBinder;
+    case ElementKind.PROJECT:
+      return ProjectBinder;
+    case ElementKind.REF:
+      return RefBinder;
+    case ElementKind.NOTE:
+      return NoteBinder;
+    case ElementKind.INDEXES:
+      return IndexesBinder;
+    default:
+      return CustomBinder;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/factory.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/factory.ts
@@ -1,0 +1,13 @@
+import { NodeSymbol, NodeSymbolId, NodeSymbolIdGenerator } from './symbols';
+
+export default class SymbolFactory {
+  private generator: NodeSymbolIdGenerator;
+
+  constructor(generator: NodeSymbolIdGenerator) {
+    this.generator = generator;
+  }
+
+  create<T extends NodeSymbol, A>(Type: { new (args: A, id: NodeSymbolId): T }, args: A): T {
+    return new Type(args, this.generator.nextId());
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolIndex.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolIndex.ts
@@ -1,0 +1,83 @@
+import { None, Option, Some } from '../../option';
+
+// Used to index a symbol table to obtain a symbol
+export type NodeSymbolIndex = string;
+export enum SymbolKind {
+  Schema = 'Schema',
+  Table = 'Table',
+  Column = 'Column',
+  TableGroup = 'TableGroup',
+  TableGroupField = 'TableGroup field',
+  Enum = 'Enum',
+  EnumField = 'Enum field',
+}
+
+export function createSchemaSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.Schema}:${key}`;
+}
+
+export function createTableSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.Table}:${key}`;
+}
+
+export function createColumnSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.Column}:${key}`;
+}
+
+export function createEnumSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.Enum}:${key}`;
+}
+
+export function createEnumFieldSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.EnumField}:${key}`;
+}
+
+export function createTableGroupSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.TableGroup}:${key}`;
+}
+
+export function createTableGroupFieldSymbolIndex(key: string): NodeSymbolIndex {
+  return `${SymbolKind.TableGroupField}:${key}`;
+}
+
+export function createNodeSymbolIndex(key: string, symbolKind: SymbolKind): NodeSymbolIndex {
+  switch (symbolKind) {
+    case SymbolKind.Column:
+      return createColumnSymbolIndex(key);
+    case SymbolKind.Enum:
+      return createEnumSymbolIndex(key);
+    case SymbolKind.EnumField:
+      return createEnumFieldSymbolIndex(key);
+    case SymbolKind.Schema:
+      return createSchemaSymbolIndex(key);
+    case SymbolKind.Table:
+      return createTableSymbolIndex(key);
+    case SymbolKind.TableGroup:
+      return createTableGroupSymbolIndex(key);
+    case SymbolKind.TableGroupField:
+      return createTableGroupFieldSymbolIndex(key);
+    default:
+      throw new Error('Unreachable');
+  }
+}
+
+export function destructureIndex(id: NodeSymbolIndex): Option<{ name: string; kind: SymbolKind }> {
+  const [kind, name] = id.split(':');
+
+  return Object.values(SymbolKind).includes(kind as SymbolKind) ?
+    new Some({
+        name,
+        kind: kind as SymbolKind,
+      }) :
+    new None();
+}
+
+export function isPublicSchemaIndex(id: NodeSymbolIndex): boolean {
+  const res = destructureIndex(id).unwrap_or(undefined);
+  if (!res) {
+    return false;
+  }
+  const { kind, name } = res;
+
+  return kind === 'Schema' && name === 'public';
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolTable.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbolTable.ts
@@ -1,0 +1,32 @@
+import { NodeSymbolIndex } from './symbolIndex';
+import { NodeSymbol } from './symbols';
+
+export default class SymbolTable {
+  private table: Map<NodeSymbolIndex, NodeSymbol>;
+
+  constructor() {
+    this.table = new Map();
+  }
+
+  has(id: NodeSymbolIndex): boolean {
+    return this.table.has(id);
+  }
+
+  set(id: NodeSymbolIndex, value: NodeSymbol) {
+    this.table.set(id, value);
+  }
+
+  get(id: NodeSymbolIndex): NodeSymbol | undefined;
+  get(id: NodeSymbolIndex, defaultValue: NodeSymbol): NodeSymbol;
+  get(id: NodeSymbolIndex, defaultValue?: NodeSymbol): NodeSymbol | undefined {
+    return (
+      this.table.get(id) ||
+      (defaultValue !== undefined && this.set(id, defaultValue)) ||
+      defaultValue
+    );
+  }
+
+  entries(): IterableIterator<[NodeSymbolIndex, NodeSymbol]> {
+    return this.table.entries();
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbols.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/symbols.ts
@@ -1,0 +1,141 @@
+import SymbolTable from './symbolTable';
+import { SyntaxNode } from '../../parser/nodes';
+
+export type NodeSymbolId = number;
+export class NodeSymbolIdGenerator {
+  private id = 0;
+
+  reset() {
+    this.id = 0;
+  }
+
+  nextId(): NodeSymbolId {
+    return this.id++;
+  }
+}
+
+export interface NodeSymbol {
+  id: NodeSymbolId;
+  symbolTable?: SymbolTable;
+  declaration?: SyntaxNode;
+  references: SyntaxNode[];
+}
+
+// A symbol for a schema, contains the schema's symbol table
+export class SchemaSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  symbolTable: SymbolTable;
+
+  references: SyntaxNode[] = [];
+
+  constructor({ symbolTable }: { symbolTable: SymbolTable }, id: NodeSymbolId) {
+    this.id = id;
+    this.symbolTable = symbolTable;
+  }
+}
+
+// A symbol for an enum, contains the enum's symbol table
+// which is used to hold all the enum field symbols of the enum
+export class EnumSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  symbolTable: SymbolTable;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor(
+    { symbolTable, declaration }: { symbolTable: SymbolTable; declaration: SyntaxNode },
+    id: NodeSymbolId,
+  ) {
+    this.id = id;
+    this.symbolTable = symbolTable;
+    this.declaration = declaration;
+  }
+}
+
+// A symbol for an enum field
+export class EnumFieldSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor({ declaration }: { declaration: SyntaxNode }, id: NodeSymbolId) {
+    this.id = id;
+    this.declaration = declaration;
+  }
+}
+
+// A symbol for a table, contains the table's symbol table
+// which is used to hold all the column symbols of the table
+export class TableSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  symbolTable: SymbolTable;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor(
+    { symbolTable, declaration }: { symbolTable: SymbolTable; declaration: SyntaxNode },
+    id: NodeSymbolId,
+  ) {
+    this.id = id;
+    this.symbolTable = symbolTable;
+    this.declaration = declaration;
+  }
+}
+
+// A symbol for a column field
+export class ColumnSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor({ declaration }: { declaration: SyntaxNode }, id: NodeSymbolId) {
+    this.id = id;
+    this.declaration = declaration;
+  }
+}
+
+// A symbol for a tablegroup, contains the symbol table for the tablegroup
+// which is used to hold all the symbols of the table group fields
+export class TableGroupSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  symbolTable: SymbolTable;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor(
+    { symbolTable, declaration }: { symbolTable: SymbolTable; declaration: SyntaxNode },
+    id: NodeSymbolId,
+  ) {
+    this.id = id;
+    this.symbolTable = symbolTable;
+    this.declaration = declaration;
+  }
+}
+
+// A symbol for a tablegroup field
+export class TableGroupFieldSymbol implements NodeSymbol {
+  id: NodeSymbolId;
+
+  declaration: SyntaxNode;
+
+  references: SyntaxNode[] = [];
+
+  constructor({ declaration }: { declaration: SyntaxNode }, id: NodeSymbolId) {
+    this.id = id;
+    this.declaration = declaration;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/symbol/utils.ts
@@ -1,0 +1,101 @@
+import { SyntaxNode } from '../../parser/nodes';
+import { ValidatorContext } from '../validator/validatorContext';
+import SymbolFactory from './factory';
+import {
+  NodeSymbolIndex,
+  createColumnSymbolIndex,
+  createEnumFieldSymbolIndex,
+  createEnumSymbolIndex,
+  createSchemaSymbolIndex,
+  createTableGroupFieldSymbolIndex,
+  createTableGroupSymbolIndex,
+  createTableSymbolIndex,
+} from './symbolIndex';
+import SymbolTable from './symbolTable';
+import {
+  ColumnSymbol,
+  EnumFieldSymbol,
+  EnumSymbol,
+  NodeSymbol,
+  TableGroupFieldSymbol,
+  TableGroupSymbol,
+  TableSymbol,
+} from './symbols';
+
+export function createIdFromContext(
+  name: string,
+  context: ValidatorContext,
+): NodeSymbolIndex | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return createTableSymbolIndex(name);
+    case ValidatorContext.EnumContext:
+      return createEnumSymbolIndex(name);
+    case ValidatorContext.TableGroupContext:
+      return createTableGroupSymbolIndex(name);
+    default:
+      return undefined;
+  }
+}
+
+export function createSubfieldId(
+  name: string,
+  context: ValidatorContext,
+): NodeSymbolIndex | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return createColumnSymbolIndex(name);
+    case ValidatorContext.EnumContext:
+      return createEnumFieldSymbolIndex(name);
+    case ValidatorContext.TableGroupContext:
+      return createTableGroupSymbolIndex(name);
+    default:
+      return undefined;
+  }
+}
+
+export function createSymbolFromContext(
+  declaration: SyntaxNode,
+  context: ValidatorContext,
+  factory: SymbolFactory,
+): NodeSymbol | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return factory.create(TableSymbol, { symbolTable: new SymbolTable(), declaration });
+    case ValidatorContext.EnumContext:
+      return factory.create(EnumSymbol, { symbolTable: new SymbolTable(), declaration });
+    case ValidatorContext.TableGroupContext:
+      return factory.create(TableGroupSymbol, { symbolTable: new SymbolTable(), declaration });
+    default:
+      return undefined;
+  }
+}
+
+export function createSubfieldSymbol(
+  declaration: SyntaxNode,
+  context: ValidatorContext,
+  factory: SymbolFactory,
+): NodeSymbol | undefined {
+  switch (context) {
+    case ValidatorContext.TableContext:
+      return factory.create(ColumnSymbol, { declaration });
+    case ValidatorContext.EnumContext:
+      return factory.create(EnumFieldSymbol, { declaration });
+    case ValidatorContext.TableGroupContext:
+      return factory.create(TableGroupFieldSymbol, { declaration });
+    default:
+      return undefined;
+  }
+}
+
+export function generatePossibleIndexes(name: string): NodeSymbolIndex[] {
+  return [
+    createSchemaSymbolIndex,
+    createTableSymbolIndex,
+    createEnumSymbolIndex,
+    createTableGroupSymbolIndex,
+    createColumnSymbolIndex,
+    createEnumFieldSymbolIndex,
+    createTableGroupFieldSymbolIndex,
+  ].map((f) => f(name));
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/utils.ts
@@ -1,0 +1,222 @@
+import _ from 'lodash';
+import { None, Option, Some } from '../option';
+import {
+  ElementDeclarationNode,
+  FunctionExpressionNode,
+  InfixExpressionNode,
+  PrimaryExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+  TupleExpressionNode,
+  VariableNode,
+} from '../parser/nodes';
+import { isRelationshipOp, isTupleOfVariables } from './validator/utils';
+import { NodeSymbolIndex, isPublicSchemaIndex } from './symbol/symbolIndex';
+import { NodeSymbol } from './symbol/symbols';
+import {
+  isAccessExpression,
+  isExpressionAQuotedString,
+  isExpressionAVariableNode,
+} from '../parser/utils';
+import { SyntaxToken } from '../lexer/tokens';
+
+export function destructureMemberAccessExpression(node: SyntaxNode): Option<SyntaxNode[]> {
+  if (!isAccessExpression(node)) {
+    return new Some([node]);
+  }
+
+  const fragments = destructureMemberAccessExpression(node.leftExpression).unwrap_or(undefined);
+
+  if (!fragments) {
+    return new None();
+  }
+
+  fragments.push(node.rightExpression);
+
+  return new Some(fragments);
+}
+
+export function destructureComplexVariable(node?: SyntaxNode): Option<string[]> {
+  if (node === undefined) {
+    return new None();
+  }
+
+  const fragments = destructureMemberAccessExpression(node).unwrap_or(undefined);
+
+  if (!fragments) {
+    return new None();
+  }
+
+  const variables: string[] = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const fragment of fragments) {
+    const variable = extractVariableFromExpression(fragment).unwrap_or(undefined);
+    if (!variable) {
+      return new None();
+    }
+
+    variables.push(variable);
+  }
+
+  return new Some(variables);
+}
+
+export function destructureComplexTuple(
+  node?: SyntaxNode,
+): Option<{ variables: string[]; tupleElements?: string[] }> {
+  if (node === undefined) {
+    return new None();
+  }
+
+  const fragments = destructureMemberAccessExpression(node).unwrap_or(undefined);
+
+  if (!fragments || fragments.length === 0) {
+    return new None();
+  }
+
+  const variables: string[] = [];
+  let tupleElements: string[] | undefined;
+
+  if (!isExpressionAVariableNode(_.last(fragments))) {
+    const topFragment = fragments.pop()!;
+    if (isTupleOfVariables(topFragment)) {
+      tupleElements = topFragment.elementList.map((e) =>
+        extractVarNameFromPrimaryVariable(e as any).unwrap(),
+      );
+    } else {
+      return new None();
+    }
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const fragment of fragments) {
+    const variable = extractVariableFromExpression(fragment).unwrap_or(undefined);
+    if (!variable) {
+      return new None();
+    }
+
+    variables.push(variable);
+  }
+
+  return new Some({
+    variables,
+    tupleElements,
+  });
+}
+
+export function extractVariableFromExpression(node: SyntaxNode): Option<string> {
+  if (!isExpressionAVariableNode(node)) {
+    return new None();
+  }
+
+  return new Some(node.expression.variable.value);
+}
+
+export function destructureIndexNode(node: SyntaxNode): Option<{
+  functional: FunctionExpressionNode[];
+  nonFunctional: (PrimaryExpressionNode & { expression: VariableNode })[];
+}> {
+  if (isValidIndexName(node)) {
+    return node instanceof FunctionExpressionNode
+      ? new Some({ functional: [node], nonFunctional: [] })
+      : new Some({ functional: [], nonFunctional: [node] });
+  }
+
+  if (node instanceof TupleExpressionNode && node.elementList.every(isValidIndexName)) {
+    const functionalIndexName = node.elementList.filter(
+      (e) => e instanceof FunctionExpressionNode,
+    ) as FunctionExpressionNode[];
+    const nonfunctionalIndexName = node.elementList.filter(isExpressionAVariableNode);
+
+    return new Some({ functional: functionalIndexName, nonFunctional: nonfunctionalIndexName });
+  }
+
+  return new None();
+}
+
+export function extractVarNameFromPrimaryVariable(
+  node: PrimaryExpressionNode & { expression: VariableNode },
+): Option<string> {
+  const value = node.expression.variable?.value;
+
+  return value === undefined ? new None() : new Some(value);
+}
+
+export function extractQuotedStringToken(value?: SyntaxNode): Option<string> {
+  if (!isExpressionAQuotedString(value)) {
+    return new None();
+  }
+
+  if (value.expression instanceof VariableNode) {
+    return new Some(value.expression.variable!.value);
+  }
+
+  return new Some(value.expression.literal.value);
+}
+
+export function isBinaryRelationship(value?: SyntaxNode): value is InfixExpressionNode {
+  if (!(value instanceof InfixExpressionNode)) {
+    return false;
+  }
+
+  if (!isRelationshipOp(value.op?.value)) {
+    return false;
+  }
+
+  return (
+    destructureComplexTuple(value.leftExpression)
+      .and_then(() => destructureComplexTuple(value.rightExpression))
+      .unwrap_or(undefined) !== undefined
+  );
+}
+
+export function isValidIndexName(
+  value?: SyntaxNode,
+): value is (PrimaryExpressionNode & { expression: VariableNode }) | FunctionExpressionNode {
+  return (
+    (value instanceof PrimaryExpressionNode && value.expression instanceof VariableNode) ||
+    value instanceof FunctionExpressionNode
+  );
+}
+
+export function extractIndexName(
+  value:
+    | (PrimaryExpressionNode & { expression: VariableNode & { variable: SyntaxToken } })
+    | (FunctionExpressionNode & { value: SyntaxToken }),
+): string {
+  if (value instanceof PrimaryExpressionNode) {
+    return value.expression.variable.value;
+  }
+
+  return value.value.value;
+}
+
+// Starting from `startElement`
+// find the closest outer scope that contains `id`
+// and return the symbol corresponding to `id` in that scope
+export function findSymbol(
+  id: NodeSymbolIndex,
+  startElement: ElementDeclarationNode,
+): NodeSymbol | undefined {
+  let curElement: SyntaxNode | undefined = startElement;
+  const isPublicSchema = isPublicSchemaIndex(id);
+
+  while (curElement) {
+    if (curElement.symbol?.symbolTable?.has(id)) {
+      return curElement.symbol.symbolTable?.get(id);
+    }
+
+    if (curElement.symbol?.declaration instanceof ProgramNode && isPublicSchema) {
+      return curElement.symbol;
+    }
+
+    if (curElement instanceof ProgramNode) {
+      return undefined;
+    }
+
+    curElement = curElement.parent;
+  }
+
+  return undefined;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/_preset_configs.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/_preset_configs.ts
@@ -1,0 +1,213 @@
+import { CompileErrorCode } from '../../../errors';
+import {
+  UniqueElementValidatorConfig,
+  createAliasValidatorConfig,
+  createBodyValidatorConfig,
+  createNameValidatorConfig,
+  createSettingListValidatorConfig,
+  createUniqueValidatorConfig,
+} from '../types';
+
+// A wrapper for preset configs
+// so that `stopOnError` configuration by element validators is more readable
+class PartialConfig<T extends { stopOnError: boolean }> {
+  partialConfig: T;
+
+  constructor(config: T) {
+    this.partialConfig = config;
+  }
+
+  doNotStopOnError(): T {
+    this.partialConfig.stopOnError = false;
+
+    return this.partialConfig;
+  }
+
+  stopOnError(): T {
+    this.partialConfig.stopOnError = true;
+
+    return this.partialConfig;
+  }
+}
+
+// A config that allows any body form
+const anyBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: true,
+    simpleErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows only simple body
+const simpleBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: true,
+    simpleErrorCode: undefined,
+    allowComplex: false,
+    complexErrorCode: CompileErrorCode.UNEXPECTED_COMPLEX_BODY,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows only complex body
+const complexBodyConfig = new PartialConfig(
+  createBodyValidatorConfig({
+    allowSimple: false,
+    simpleErrorCode: CompileErrorCode.UNEXPECTED_SIMPLE_BODY,
+    allowComplex: true,
+    complexErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows optional alias
+const optionalAliasConfig = new PartialConfig(
+  createAliasValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: true,
+    notAllowErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that allows optional name
+const optionalNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: true,
+    notAllowErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that mandate name registration
+const registerNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: false,
+    notOptionalErrorCode: CompileErrorCode.NAME_NOT_FOUND,
+    allow: true,
+    notAllowErrorCode: undefined,
+    allowComplex: true,
+    complexErrorCode: undefined,
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_NAME,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that mandates that there are no settings
+const noSettingListConfig = new PartialConfig(
+  createSettingListValidatorConfig(
+    {},
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: false,
+      notAllowErrorCode: CompileErrorCode.UNEXPECTED_SETTINGS,
+      unknownErrorCode: undefined,
+      duplicateErrorCode: undefined,
+      invalidErrorCode: undefined,
+
+      stopOnError: false,
+    },
+  ),
+);
+
+// A config that mandates that the element must be locally unique
+export function locallyUniqueConfig(
+  errorCode: CompileErrorCode,
+): PartialConfig<UniqueElementValidatorConfig> {
+  return new PartialConfig(
+    createUniqueValidatorConfig({
+      globally: false,
+      notGloballyErrorCode: undefined,
+      locally: true,
+      notLocallyErrorCode: errorCode,
+
+      stopOnError: false,
+    }),
+  );
+}
+
+// A config that mandates that the element must be globally unique
+export function globallyUniqueConfig(
+  errorCode: CompileErrorCode,
+): PartialConfig<UniqueElementValidatorConfig> {
+  return new PartialConfig(
+    createUniqueValidatorConfig({
+      globally: true,
+      notGloballyErrorCode: errorCode,
+      locally: false,
+      notLocallyErrorCode: undefined,
+
+      stopOnError: false,
+    }),
+  );
+}
+
+// A config that does not enforce uniqueness constraint
+const noUniqueConfig = new PartialConfig(
+  createUniqueValidatorConfig({
+    globally: false,
+    notGloballyErrorCode: undefined,
+    locally: false,
+    notLocallyErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that does not allow element name
+const noNameConfig = new PartialConfig(
+  createNameValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: false,
+    notAllowErrorCode: CompileErrorCode.UNEXPECTED_NAME,
+    allowComplex: false,
+    complexErrorCode: CompileErrorCode.UNEXPECTED_NAME,
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+
+    stopOnError: false,
+  }),
+);
+
+// A config that does not allow element alias
+const noAliasConfig = new PartialConfig(
+  createAliasValidatorConfig({
+    optional: true,
+    notOptionalErrorCode: undefined,
+    allow: false,
+    notAllowErrorCode: CompileErrorCode.UNEXPECTED_ALIAS,
+    stopOnError: false,
+  }),
+);
+
+export {
+  anyBodyConfig,
+  simpleBodyConfig,
+  complexBodyConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  registerNameConfig,
+  noUniqueConfig,
+  optionalAliasConfig,
+  optionalNameConfig,
+};

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/custom.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/custom.ts
@@ -1,0 +1,74 @@
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../parser/utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  simpleBodyConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import SymbolFactory from '../../symbol/factory';
+import { transformToReturnCompileErrors } from './utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class CustomValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.CUSTOM;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.CustomContext,
+    errorCode: CompileErrorCode.INVALID_CUSTOM_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = simpleBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          isExpressionAQuotedString,
+          CompileErrorCode.INVALID_CUSTOM_ELEMENT_VALUE,
+          'This field must be a string literal',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_CUSTOM_ELEMENT_VALUE,
+    invalidArgNumberErrorMessage: 'A custom element field must be a single string literal',
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/elementValidator.ts
@@ -1,0 +1,701 @@
+import {
+  AliasValidatorConfig,
+  BodyValidatorConfig,
+  ContextValidatorConfig,
+  ElementKind,
+  NameValidatorConfig,
+  SettingListValidatorConfig,
+  SubFieldValidatorConfig,
+  UniqueElementValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { SyntaxToken } from '../../../lexer/tokens';
+import { None, Option, Some } from '../../../option';
+import {
+  ElementDeclarationNode,
+  ExpressionNode,
+  FunctionApplicationNode,
+  ListExpressionNode,
+  SyntaxNode,
+} from '../../../parser/nodes';
+import { extractStringFromIdentifierStream, extractVariableNode } from '../../../parser/utils';
+import { destructureComplexVariable } from '../../utils';
+import { ContextStack, canBeNestedWithin } from '../validatorContext';
+import {
+  hasComplexBody,
+  hasSimpleBody,
+  isSimpleName,
+  isValidAlias,
+  isValidName,
+  isValidSettingList,
+  pickValidator,
+  registerSchemaStack,
+} from '../utils';
+import { NodeSymbol, SchemaSymbol } from '../../symbol/symbols';
+import {
+  createIdFromContext,
+  createSubfieldId,
+  createSubfieldSymbol,
+  createSymbolFromContext,
+} from '../../symbol/utils';
+import SymbolFactory from '../../symbol/factory';
+import { getSubfieldKind, isCustomElement } from './utils';
+
+export default abstract class ElementValidator {
+  protected abstract elementKind: ElementKind;
+
+  protected abstract context: ContextValidatorConfig;
+  protected abstract unique: UniqueElementValidatorConfig;
+  protected abstract name: NameValidatorConfig;
+  protected abstract alias: AliasValidatorConfig;
+  protected abstract body: BodyValidatorConfig;
+  protected abstract settingList: SettingListValidatorConfig;
+  protected abstract subfield: SubFieldValidatorConfig;
+
+  protected declarationNode: ElementDeclarationNode & { type: SyntaxToken };
+  protected publicSchemaSymbol: SchemaSymbol;
+  protected contextStack: ContextStack;
+  protected errors: CompileError[];
+  protected kindsGloballyFound: Set<ElementKind>;
+  protected kindsLocallyFound: Set<ElementKind>;
+  protected symbolFactory: SymbolFactory;
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    this.declarationNode = declarationNode;
+    this.publicSchemaSymbol = publicSchemaSymbol;
+    this.contextStack = contextStack;
+    this.errors = errors;
+    this.kindsGloballyFound = kindsGloballyFound;
+    this.kindsLocallyFound = kindsLocallyFound;
+    this.symbolFactory = symbolFactory;
+  }
+
+  validate(): boolean {
+    this.contextStack.push(this.context.name);
+    const res =
+      this.validateContext() &&
+      this.validateUnique() &&
+      this.validateName() &&
+      this.validateAlias() &&
+      this.validateSettingList() &&
+      this.validateBodyForm() &&
+      this.validateBodyContent();
+
+    this.contextStack.pop();
+
+    return res;
+  }
+
+  /* Validate uniqueness according to config `this.unique` */
+
+  private validateUnique(): boolean {
+    return (
+      (this.validateGloballyUnique() && this.validateLocallyUnique()) || !this.unique.stopOnError
+    );
+  }
+
+  private validateLocallyUnique(): boolean {
+    if (!this.unique.locally) {
+      return true;
+    }
+
+    if (this.kindsLocallyFound.has(this.elementKind)) {
+      this.logError(
+        this.declarationNode.type,
+        this.unique.notLocallyErrorCode,
+        `A(n) ${this.elementKind} has already been defined in this scope`,
+      );
+
+      return false;
+    }
+
+    this.kindsLocallyFound.add(this.elementKind);
+
+    return true;
+  }
+
+  private validateGloballyUnique(): boolean {
+    if (!this.unique.globally) {
+      return true;
+    }
+
+    if (this.kindsGloballyFound.has(this.elementKind)) {
+      this.logError(
+        this.declarationNode.type,
+        this.unique.notGloballyErrorCode,
+        `A(n) ${this.elementKind} has already been defined in this file`,
+      );
+
+      return false;
+    }
+
+    this.kindsGloballyFound.add(this.elementKind);
+
+    return true;
+  }
+
+  /* Validate context according to config `this.context` */
+
+  private validateContext(): boolean {
+    if (!canBeNestedWithin(this.contextStack.parent(), this.contextStack.top())) {
+      this.logError(
+        this.declarationNode.type,
+        this.context.errorCode,
+        isCustomElement(this.elementKind) ?
+          'Unknown element type' :
+          `A(n) ${this.elementKind} can not appear here`,
+      );
+
+      return !this.context.stopOnError;
+    }
+
+    return true;
+  }
+
+  /* Validate and register name according to config `this.name` */
+
+  private validateName(): boolean {
+    // Default symbol in case one of the check fails which cause registerName to not be called
+    this.declarationNode.symbol = createSymbolFromContext(
+      this.declarationNode,
+      this.context.name,
+      this.symbolFactory,
+    );
+
+    return (
+      (this.checkNameInValidForm() &&
+        this.checkNameAllowed() &&
+        this.checkNameOptional() &&
+        this.checkNameComplex() &&
+        // Short-circuting prevents registerName to be called if a previous check fails
+        this.registerName()) ||
+      !this.name.stopOnError
+    );
+  }
+
+  private checkNameInValidForm(): boolean {
+    const { name } = this.declarationNode;
+    if (name && !isValidName(name)) {
+      this.logError(name, CompileErrorCode.INVALID_NAME, 'Invalid element name');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameAllowed(): boolean {
+    if (!this.name.allow && this.declarationNode.name) {
+      this.logError(
+        this.declarationNode.name,
+        this.name.notAllowErrorCode,
+        `A(n) ${this.elementKind} shouldn't have a name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameOptional(): boolean {
+    if (!this.name.optional && !this.declarationNode.name) {
+      this.logError(
+        this.declarationNode.type,
+        this.name.notOptionalErrorCode,
+        `A(n) ${this.elementKind} must have a name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkNameComplex(): boolean {
+    const { name } = this.declarationNode;
+    if (!this.name.allowComplex && name && !isSimpleName(name)) {
+      this.logError(
+        name,
+        this.name.complexErrorCode,
+        `A(n) ${this.elementKind} must have a double-quoted string or an identifier name`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private registerName(): boolean {
+    if (this.declarationNode.name && this.name.shouldRegister) {
+      const { registeredSymbol, ok } = this.registerElement(this.declarationNode.name);
+      this.declarationNode.symbol = registeredSymbol;
+
+      return ok;
+    }
+
+    return true;
+  }
+
+  /* Validate and register alias according to config `this.alias` */
+
+  private validateAlias(): boolean {
+    return (
+      (this.checkAliasInValidForm() &&
+        this.checkAliasAllow() &&
+        this.checkAliasOptional() &&
+        // Short-circuting prevents registerAlias to be called if a previous check fails
+        this.registerAlias()) ||
+      !this.alias.stopOnError
+    );
+  }
+
+  private checkAliasInValidForm() {
+    const { alias } = this.declarationNode;
+    if (alias && !isValidAlias(alias)) {
+      this.logError(alias, CompileErrorCode.INVALID_ALIAS, 'Invalid element alias');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkAliasAllow(): boolean {
+    const { alias } = this.declarationNode;
+
+    if (!this.alias.allow && alias) {
+      this.logError(
+        alias,
+        this.alias.notAllowErrorCode,
+        `A(n) ${this.elementKind} shouldn't have an alias`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkAliasOptional(): boolean {
+    const { alias } = this.declarationNode;
+
+    if (!this.alias.optional && !alias) {
+      this.logError(
+        this.declarationNode.type,
+        this.alias.notOptionalErrorCode,
+        `A(n) ${this.elementKind} must have an alias`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private registerAlias(): boolean {
+    const { alias } = this.declarationNode;
+    if (alias && this.name.shouldRegister) {
+      const { ok } = this.registerElement(alias, this.declarationNode.symbol);
+
+      return ok;
+    }
+
+    return true;
+  }
+
+  // Register a name extracted from `nameNode` into the `public` schema
+  // Also check for duplicated name
+  // If `defaultSymbol` is undefined, create the symbol anew corresponding to the name
+  // If `defaultSymbol` is given, the symbol (and its symbol table) is reused
+  private registerElement(
+    nameNode: SyntaxNode,
+    defaultSymbol?: NodeSymbol,
+  ): { registeredSymbol: NodeSymbol; ok: boolean } {
+    const variables = destructureComplexVariable(nameNode).unwrap_or(undefined);
+    if (!variables) {
+      throw new Error(`${this.elementKind} must be a valid complex variable`);
+    }
+    const name = variables.pop();
+    if (!name) {
+      throw new Error(`${this.elementKind} name shouldn't be empty`);
+    }
+
+    const id = createIdFromContext(name, this.context.name);
+
+    if (variables[0] === 'public') {
+      variables.shift();
+    }
+
+    const registerSchema = registerSchemaStack(
+      variables,
+      this.publicSchemaSymbol.symbolTable,
+      this.symbolFactory,
+    );
+    if (!id) {
+      throw new Error(`${this.elementKind} fails to create id to register in the symbol table`);
+    }
+
+    const newSymbol = createSymbolFromContext(
+      this.declarationNode,
+      this.context.name,
+      this.symbolFactory,
+    );
+    if (!newSymbol) {
+      throw new Error(
+        `${this.elementKind} fails to create a symbol to register in the symbol table`,
+      );
+    }
+
+    if (registerSchema.has(id)) {
+      this.logError(
+        nameNode,
+        this.name.duplicateErrorCode,
+        `${this.elementKind} "${name}" has been defined`,
+      );
+
+      return { registeredSymbol: defaultSymbol || newSymbol, ok: false };
+    }
+    registerSchema.set(id, defaultSymbol || newSymbol);
+
+    return { registeredSymbol: defaultSymbol || newSymbol, ok: true };
+  }
+
+  /* Validate element according to config `this.settingList` */
+
+  private validateSettingList(): boolean {
+    return (
+      (this.checkSettingListInValidForm() &&
+        this.checkSettingListAllow() &&
+        this.checkSettingListOptional() &&
+        (!this.declarationNode.attributeList ||
+          this.validateSettingListContent(this.declarationNode.attributeList, this.settingList))) ||
+      !this.settingList.stopOnError
+    );
+  }
+
+  private checkSettingListInValidForm(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (attributeList && !isValidSettingList(attributeList)) {
+      this.logError(attributeList, CompileErrorCode.INVALID_SETTINGS, 'SettingList must be a list');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkSettingListAllow(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (!this.settingList.allow && attributeList) {
+      this.logError(
+        attributeList,
+        this.settingList.notAllowErrorCode,
+        `A(n) ${this.elementKind} shouldn't have a setting list`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkSettingListOptional(): boolean {
+    const { attributeList } = this.declarationNode;
+    if (!this.settingList.optional && !attributeList) {
+      this.logError(
+        this.declarationNode.type,
+        this.settingList.notOptionalErrorCode,
+        `A(n) ${this.elementKind} must have a setting list`,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  /* Validate body format according to config `this.body` */
+
+  private validateBodyForm(): boolean {
+    const node = this.declarationNode;
+    if (!node.body) {
+      return false;
+    }
+
+    let hasError = false;
+
+    if (!this.body.allowComplex && hasComplexBody(node)) {
+      this.logError(
+        node.body,
+        this.body.complexErrorCode,
+        `A(n) ${this.elementKind} should not have a complex body`,
+      );
+      hasError = true;
+    }
+
+    if (!this.body.allowSimple && hasSimpleBody(node)) {
+      this.logError(
+        node.body,
+        this.body.simpleErrorCode,
+        `A(n) ${this.elementKind} should not have a simple body`,
+      );
+      hasError = true;
+    }
+
+    return !hasError || !this.body.stopOnError;
+  }
+
+  /* Validate the body content */
+
+  protected validateBodyContent(): boolean {
+    const node = this.declarationNode;
+    if (!node.body) {
+      return false;
+    }
+
+    if (hasComplexBody(node)) {
+      if (!this.body.allowComplex) {
+        return false;
+      }
+
+      const kindsFoundInScope = new Set<ElementKind>();
+      let hasError = false;
+      let ith = -1;
+      hasError =
+        !node.body.body
+          .map((sub) => {
+            if (sub instanceof ElementDeclarationNode) {
+              return !sub.type || this.validateNestedElementDeclaration(sub, kindsFoundInScope);
+            }
+            ith += 1;
+
+            return (
+              !sub.callee ||
+              this.validateSubField(sub as FunctionApplicationNode & { callee: SyntaxNode }, ith)
+            );
+          })
+          .every((v) => !!v === true) || hasError;
+
+      return !hasError;
+    }
+
+    if (node.body instanceof FunctionApplicationNode && node.body.callee) {
+      return this.validateSubField(
+        node.body as FunctionApplicationNode & { callee: SyntaxNode },
+        0,
+      );
+    }
+
+    this.logError(
+      node.body,
+      CompileErrorCode.INVALID_ELEMENT_IN_SIMPLE_BODY,
+      "An element's simple body can not contain an element declaration",
+    );
+
+    return false;
+  }
+
+  protected validateNestedElementDeclaration(
+    sub: ElementDeclarationNode,
+    kindsFoundInScope: Set<ElementKind>,
+  ): boolean {
+    // eslint-disable-next-line no-param-reassign
+    sub.parent = this.declarationNode;
+    if (!sub.type) {
+      return false;
+    }
+    const _sub = sub as ElementDeclarationNode & { type: SyntaxToken };
+
+    const Val = pickValidator(_sub);
+
+    const validatorObject = new Val(
+      _sub,
+      this.publicSchemaSymbol,
+      this.contextStack,
+      this.errors,
+      this.kindsGloballyFound,
+      kindsFoundInScope,
+      this.symbolFactory,
+    );
+
+    return validatorObject.validate();
+  }
+
+  /* Validate and register subfield according to config `this.subfield` */
+
+  protected validateSubField(
+    sub: FunctionApplicationNode & { callee: SyntaxNode },
+    ith: number,
+  ): boolean {
+    const _args = [sub.callee, ...sub.args];
+
+    const args = _args as ExpressionNode[];
+
+    if (args.length === 0) {
+      throw new Error('A function application node always has at least 1 callee');
+    }
+
+    const maybeSettingList = args[args.length - 1];
+    this.validateSubFieldSettingList(maybeSettingList);
+    if (maybeSettingList instanceof ListExpressionNode) {
+      args.pop();
+    }
+
+    if (args.length !== this.subfield.argValidators.length) {
+      this.logError(
+        sub,
+        this.subfield.invalidArgNumberErrorCode,
+        this.subfield.invalidArgNumberErrorMessage!,
+      );
+
+      return false;
+    }
+
+    let hasError = false;
+
+    for (let i = 0; i < args.length; i += 1) {
+      const errors = this.subfield.argValidators[i].validateArg(args[i], ith);
+      if (errors.length > 0) {
+        this.errors.push(...errors);
+        hasError = true;
+      }
+    }
+
+    if (this.subfield.shouldRegister && !hasError) {
+      const symbol = this.registerSubField(sub, args[0]).unwrap_or(undefined);
+      hasError = symbol === undefined || hasError;
+      // eslint-disable-next-line no-param-reassign
+      sub.symbol = symbol;
+    }
+
+    return !hasError;
+  }
+
+  private registerSubField(declarationNode: SyntaxNode, nameNode: SyntaxNode): Option<NodeSymbol> {
+    if (!this.declarationNode.symbol || !this.declarationNode.symbol.symbolTable) {
+      throw new Error('If an element allows registering subfields, it must own a symbol table');
+    }
+
+    if (!isSimpleName(nameNode)) {
+      throw new Error('If an element allows registering subfields, their name must be simple');
+    }
+    const name = extractVariableNode(nameNode).unwrap().value;
+    const { symbolTable } = this.declarationNode.symbol;
+    if (!name) {
+      throw new Error(`${this.elementKind} subfield's name shouldn't be empty`);
+    }
+
+    const id = createSubfieldId(name, this.context.name);
+    if (!id) {
+      throw new Error(
+        `${this.elementKind} fails to create subfield id to register in the symbol table`,
+      );
+    }
+    if (symbolTable.has(id)) {
+      this.logError(
+        nameNode,
+        this.subfield.duplicateErrorCode,
+        `${this.elementKind} ${getSubfieldKind(this.elementKind)} "${name}" has been defined`,
+      );
+
+      return new None();
+    }
+    const symbol = createSubfieldSymbol(declarationNode, this.context.name, this.symbolFactory);
+    if (!symbol) {
+      throw new Error(
+        `${this.elementKind} fails to create subfield symbol to register in the symbol table`,
+      );
+    }
+
+    return new Some(symbolTable.get(id, symbol));
+  }
+
+  protected validateSubFieldSettingList(maybeSettingList: ExpressionNode): boolean {
+    if (!(maybeSettingList instanceof ListExpressionNode) && !this.subfield.settingList.optional) {
+      this.logError(
+        maybeSettingList,
+        this.subfield.settingList.notOptionalErrorCode,
+        `A(n) ${this.elementKind} ${getSubfieldKind(this.elementKind)} must have a setting list`,
+      );
+
+      return false;
+    }
+
+    if (maybeSettingList instanceof ListExpressionNode && !this.subfield.settingList.allow) {
+      this.logError(
+        maybeSettingList,
+        this.subfield.settingList.notAllowErrorCode,
+        `A(n) ${this.elementKind} ${getSubfieldKind(
+          this.elementKind,
+        )}  should not have a setting list`,
+      );
+
+      return false;
+    }
+
+    if (!(maybeSettingList instanceof ListExpressionNode)) {
+      return true;
+    }
+
+    return this.validateSettingListContent(maybeSettingList, this.subfield.settingList);
+  }
+
+  private validateSettingListContent(
+    settingListNode: ListExpressionNode,
+    config: SettingListValidatorConfig,
+  ): boolean {
+    const settingListSet = new Set<string>();
+    let hasError = false;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const setting of settingListNode.elementList) {
+      const name = extractStringFromIdentifierStream(setting.name)
+        .unwrap_or(undefined)
+        ?.toLowerCase();
+      const { value } = setting;
+
+      if (name === undefined) {
+        continue;
+      }
+
+      if (!config.isValid(name, value).isOk()) {
+        this.logError(setting, config.unknownErrorCode, 'Unknown setting');
+        hasError = true;
+      } else if (settingListSet.has(name) && !config.allowDuplicate(name).unwrap()) {
+        this.logError(setting, config.duplicateErrorCode, 'Duplicate setting');
+        hasError = true;
+      } else {
+        settingListSet.add(name);
+        const isValid = config.isValid(name, value).unwrap();
+        if (!isValid) {
+          this.logError(setting, config.invalidErrorCode, 'Invalid value for this setting');
+          hasError = true;
+        }
+      }
+    }
+
+    return !hasError;
+  }
+
+  protected logError(
+    nodeOrToken: SyntaxNode | SyntaxToken,
+    code: CompileErrorCode | undefined,
+    message: string,
+  ) {
+    if (code === undefined) {
+      throw Error(`This error shouldn't exist. Maybe a validator is misconfigured
+       Error message: ${message}`);
+    }
+    // eslint-disable-next-line no-unused-expressions
+    this.errors.push(new CompileError(code, message, nodeOrToken));
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/enum.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/enum.ts
@@ -1,0 +1,99 @@
+import SymbolFactory from '../../symbol/factory';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { isExpressionAVariableNode, isExpressionAQuotedString } from '../../../parser/utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  registerNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { transformToReturnCompileErrors } from './utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class EnumValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.ENUM;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.EnumContext,
+    errorCode: CompileErrorCode.INVALID_ENUM_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          isExpressionAVariableNode,
+          CompileErrorCode.INVALID_ENUM_ELEMENT_NAME,
+          'This field must be a simple variable',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_ENUM_ELEMENT,
+    invalidArgNumberErrorMessage: "An enum's field must be a simple variable",
+    settingList: enumFieldSettingList(),
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_ENUM_ELEMENT_NAME,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}
+
+const enumFieldSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: true,
+        isValid: isExpressionAQuotedString,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_ENUM_ELEMENT_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_ENUM_ELEMENT_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_ENUM_ELEMENT_SETTING,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/indexes.ts
@@ -1,0 +1,133 @@
+import SymbolFactory from '../../symbol/factory';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import {
+  ElementDeclarationNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  VariableNode,
+} from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../parser/utils';
+import { destructureIndexNode } from '../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { isVoid } from '../utils';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { transformToReturnCompileErrors } from './utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class IndexesValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.INDEXES;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.IndexesContext,
+    errorCode: CompileErrorCode.INVALID_INDEXES_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          (node) => destructureIndexNode(node).unwrap_or(undefined) !== undefined,
+          CompileErrorCode.INVALID_INDEX,
+          'This field must be a function expression, a column name or a tuple of such',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_INDEX,
+    invalidArgNumberErrorMessage:
+      'An Indexes field must be a function expression, a column name or a tuple of such',
+    settingList: indexSettingList(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}
+
+export function isValidIndexesType(value?: SyntaxNode): boolean {
+  if (!(value instanceof PrimaryExpressionNode) || !(value.expression instanceof VariableNode)) {
+    return false;
+  }
+
+  const str = value.expression.variable?.value;
+
+  return str === 'btree' || str === 'hash';
+}
+
+const indexSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      name: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      type: {
+        allowDuplicate: false,
+        isValid: isValidIndexesType,
+      },
+      unique: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      pk: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_INDEX_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_INDEX_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_INDEX_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/note.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/note.ts
@@ -1,0 +1,90 @@
+import SymbolFactory from '../../symbol/factory';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode, SyntaxNode } from '../../../parser/nodes';
+import { isExpressionAQuotedString } from '../../../parser/utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  anyBodyConfig,
+  locallyUniqueConfig,
+  noAliasConfig,
+  noNameConfig,
+  noSettingListConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class NoteValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.NOTE;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.NoteContext,
+    errorCode: CompileErrorCode.INVALID_NOTE_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = locallyUniqueConfig(CompileErrorCode.NOTE_REDEFINED).doNotStopOnError();
+
+  protected name = noNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = anyBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: (node: SyntaxNode, ith: number) => {
+          if (ith > 0) {
+            return [
+              new CompileError(
+                CompileErrorCode.NOTE_CONTENT_REDEFINED,
+                'Only one note content can be defined',
+                node,
+              ),
+            ];
+          }
+          if (isExpressionAQuotedString(node)) {
+            return [];
+          }
+
+          return [
+            new CompileError(
+              CompileErrorCode.INVALID_NOTE,
+              "A note's content must be doubly or singly quoted string",
+              node,
+            ),
+          ];
+        },
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_NOTE,
+    invalidArgNumberErrorMessage: 'A note content must be a doubly or singly quoted string',
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/project.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/project.ts
@@ -1,0 +1,64 @@
+import SymbolFactory from '../../symbol/factory';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  complexBodyConfig,
+  globallyUniqueConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  optionalNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class ProjectValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.PROJECT;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.ProjectContext,
+    errorCode: CompileErrorCode.INVALID_PROJECT_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = globallyUniqueConfig(CompileErrorCode.PROJECT_REDEFINED).doNotStopOnError();
+
+  protected name = optionalNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_PROJECT_FIELD,
+    invalidArgNumberErrorMessage: 'A Project cannot have a subfield',
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -1,0 +1,141 @@
+import { SyntaxToken, SyntaxTokenKind } from '../../../lexer/tokens';
+import SymbolFactory from '../../symbol/factory';
+import { transformToReturnCompileErrors } from './utils';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode, IdentiferStreamNode, SyntaxNode } from '../../../parser/nodes';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { isBinaryRelationship } from '../utils';
+import {
+  anyBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  optionalNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import {
+  extractStringFromIdentifierStream,
+  isExpressionAVariableNode,
+} from '../../../parser/utils';
+
+export default class RefValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.REF;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.RefContext,
+    errorCode: CompileErrorCode.INVALID_REF_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = optionalNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = anyBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          isBinaryRelationship,
+          CompileErrorCode.INVALID_REF_RELATIONSHIP,
+          'This field must be a valid binary relationship',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_REF_FIELD,
+    invalidArgNumberErrorMessage: "A ref's field must be a single valid binary relationship",
+    settingList: refFieldSettings(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}
+
+function isValidPolicy(value?: SyntaxNode): boolean {
+  if (
+    !(
+      isExpressionAVariableNode(value) &&
+      value.expression.variable.kind !== SyntaxTokenKind.QUOTED_STRING
+    ) &&
+    !(value instanceof IdentiferStreamNode)
+  ) {
+    return false;
+  }
+
+  let extractedString: string | undefined;
+  if (value instanceof IdentiferStreamNode) {
+    extractedString = extractStringFromIdentifierStream(value).unwrap_or('');
+  } else {
+    extractedString = value.expression.variable.value;
+  }
+
+  if (extractedString) {
+    switch (extractedString.toLowerCase()) {
+      case 'cascade':
+      case 'no action':
+      case 'set null':
+      case 'set default':
+      case 'restrict':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  return false; // unreachable
+}
+
+const refFieldSettings = () =>
+  createSettingListValidatorConfig(
+    {
+      delete: {
+        allowDuplicate: false,
+        isValid: isValidPolicy,
+      },
+      update: {
+        allowDuplicate: false,
+        isValid: isValidPolicy,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_REF_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_REF_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_REF_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/table.ts
@@ -1,0 +1,205 @@
+import SymbolFactory from '../../symbol/factory';
+import {
+  ElementKind,
+  createContextValidatorConfig,
+  createSettingListValidatorConfig,
+  createSubFieldValidatorConfig,
+} from '../types';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import {
+  CallExpressionNode,
+  ElementDeclarationNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+} from '../../../parser/nodes';
+import { destructureComplexVariable } from '../../utils';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import {
+  isExpressionANumber,
+  isUnaryRelationship,
+  isValidColor,
+  isValidDefaultValue,
+  isVoid,
+} from '../utils';
+import {
+  registerNameConfig,
+  optionalAliasConfig,
+  complexBodyConfig,
+  noUniqueConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { createEnumSymbolIndex, createSchemaSymbolIndex } from '../../symbol/symbolIndex';
+import { transformToReturnCompileErrors } from './utils';
+import {
+  isAccessExpression,
+  isExpressionAQuotedString,
+  isExpressionAVariableNode,
+} from '../../../parser/utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class TableValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.TABLE;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.TableContext,
+    errorCode: CompileErrorCode.INVALID_TABLE_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = optionalAliasConfig.doNotStopOnError();
+
+  protected settingList = createSettingListValidatorConfig(
+    {
+      headercolor: {
+        allowDuplicate: false,
+        isValid: isValidColor,
+      },
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.INVALID_TABLE_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_TABLE_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_TABLE_SETTING,
+      stopOnError: false,
+    },
+  );
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          isExpressionAVariableNode,
+          CompileErrorCode.INVALID_COLUMN_NAME,
+          'This field must be a valid column name',
+        ),
+      },
+      {
+        validateArg: transformToReturnCompileErrors(
+          isValidColumnType,
+          CompileErrorCode.INVALID_COLUMN_TYPE,
+          'This field must be a valid column type',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_COLUMN,
+    invalidArgNumberErrorMessage: "A Table's column must have a name and a type",
+    settingList: columnSettingList(),
+    shouldRegister: true,
+    duplicateErrorCode: CompileErrorCode.DUPLICATE_COLUMN_NAME,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}
+
+function isValidColumnType(type: SyntaxNode): boolean {
+  if (
+    !(
+      type instanceof CallExpressionNode ||
+      isAccessExpression(type) ||
+      type instanceof PrimaryExpressionNode
+    )
+  ) {
+    return false;
+  }
+
+  if (type instanceof CallExpressionNode) {
+    if (type.callee === undefined || type.argumentList?.elementList.every((e) => e !== undefined)) {
+      return true;
+    }
+
+    if (!type.argumentList?.elementList.every(isExpressionANumber)) {
+      return false;
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    type = type.callee;
+  }
+
+  const variables = destructureComplexVariable(type).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+const columnSettingList = () =>
+  createSettingListValidatorConfig(
+    {
+      note: {
+        allowDuplicate: false,
+        isValid: isExpressionAQuotedString,
+      },
+      ref: {
+        allowDuplicate: true,
+        isValid: isUnaryRelationship,
+      },
+      'primary key': {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      default: {
+        allowDuplicate: false,
+        isValid: isValidDefaultValue,
+      },
+      increment: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      'not null': {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      null: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      pk: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+      unique: {
+        allowDuplicate: false,
+        isValid: isVoid,
+      },
+    },
+    {
+      optional: true,
+      notOptionalErrorCode: undefined,
+      allow: true,
+      notAllowErrorCode: undefined,
+      unknownErrorCode: CompileErrorCode.UNKNOWN_COLUMN_SETTING,
+      duplicateErrorCode: CompileErrorCode.DUPLICATE_COLUMN_SETTING,
+      invalidErrorCode: CompileErrorCode.INVALID_COLUMN_SETTING_VALUE,
+      stopOnError: false,
+    },
+  );

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/tableGroup.ts
@@ -1,0 +1,74 @@
+import SymbolFactory from '../../symbol/factory';
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { ElementDeclarationNode } from '../../../parser/nodes';
+import { ContextStack, ValidatorContext } from '../validatorContext';
+import ElementValidator from './elementValidator';
+import { ElementKind, createContextValidatorConfig, createSubFieldValidatorConfig } from '../types';
+import {
+  complexBodyConfig,
+  noAliasConfig,
+  noSettingListConfig,
+  noUniqueConfig,
+  registerNameConfig,
+} from './_preset_configs';
+import { SchemaSymbol } from '../../symbol/symbols';
+import { isValidName } from '../utils';
+import { transformToReturnCompileErrors } from './utils';
+import { SyntaxToken } from '../../../lexer/tokens';
+
+export default class TableGroupValidator extends ElementValidator {
+  protected elementKind: ElementKind = ElementKind.TABLEGROUP;
+
+  protected context = createContextValidatorConfig({
+    name: ValidatorContext.TableGroupContext,
+    errorCode: CompileErrorCode.INVALID_TABLEGROUP_CONTEXT,
+    stopOnError: false,
+  });
+
+  protected unique = noUniqueConfig.doNotStopOnError();
+
+  protected name = registerNameConfig.doNotStopOnError();
+
+  protected alias = noAliasConfig.doNotStopOnError();
+
+  protected settingList = noSettingListConfig.doNotStopOnError();
+
+  protected body = complexBodyConfig.doNotStopOnError();
+
+  protected subfield = createSubFieldValidatorConfig({
+    argValidators: [
+      {
+        validateArg: transformToReturnCompileErrors(
+          isValidName,
+          CompileErrorCode.INVALID_TABLEGROUP_ELEMENT_NAME,
+          'This field must be a valid table name',
+        ),
+      },
+    ],
+    invalidArgNumberErrorCode: CompileErrorCode.INVALID_TABLEGROUP_FIELD,
+    invalidArgNumberErrorMessage: 'A TableGroup field must be a single valid table name',
+    settingList: noSettingListConfig.doNotStopOnError(),
+    shouldRegister: false,
+    duplicateErrorCode: undefined,
+  });
+
+  constructor(
+    declarationNode: ElementDeclarationNode & { type: SyntaxToken },
+    publicSchemaSymbol: SchemaSymbol,
+    contextStack: ContextStack,
+    errors: CompileError[],
+    kindsGloballyFound: Set<ElementKind>,
+    kindsLocallyFound: Set<ElementKind>,
+    symbolFactory: SymbolFactory,
+  ) {
+    super(
+      declarationNode,
+      publicSchemaSymbol,
+      contextStack,
+      errors,
+      kindsGloballyFound,
+      kindsLocallyFound,
+      symbolFactory,
+    );
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/elementValidators/utils.ts
@@ -1,0 +1,34 @@
+import { CompileError, CompileErrorCode } from '../../../errors';
+import { SyntaxNode } from '../../../parser/nodes';
+import { ElementKind } from '../types';
+
+export function isCustomElement(kind: ElementKind): kind is ElementKind.CUSTOM {
+  return kind === ElementKind.CUSTOM;
+}
+
+export function getSubfieldKind(kind: ElementKind): string {
+  switch (kind) {
+    case ElementKind.TABLE:
+      return 'column';
+    case ElementKind.ENUM:
+      return 'field';
+    case ElementKind.TABLEGROUP:
+      return 'table';
+    default:
+      return 'subfield';
+  }
+}
+
+export function transformToReturnCompileErrors(
+  validator: (node: SyntaxNode, ith: number) => boolean,
+  errorCode: CompileErrorCode,
+  errorMessage: string,
+): (node: SyntaxNode, ith: number) => CompileError[] {
+  return (node: SyntaxNode, ith: number) => {
+    if (validator(node, ith)) {
+      return [];
+    }
+
+    return [new CompileError(errorCode, errorMessage, node)];
+  };
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/types.ts
@@ -1,0 +1,347 @@
+import { ElementDeclarationNode, SyntaxNode } from '../../parser/nodes';
+import { CompileError, CompileErrorCode } from '../../errors';
+import { None, Option, Some } from '../../option';
+import { ValidatorContext } from './validatorContext';
+
+// Each element has its own element kind
+// Except for custom elements, which all fall under one kind
+// e.g
+// Project {
+//   project_name: 'My project' // custom element
+//   version: '1.0.0' // custom element
+// }
+export enum ElementKind {
+  TABLE = 'Table',
+  ENUM = 'Enum',
+  INDEXES = 'Indexes',
+  NOTE = 'Note',
+  PROJECT = 'Project',
+  REF = 'Ref',
+  TABLEGROUP = 'TableGroup',
+  CUSTOM = 'custom element',
+}
+
+// An object that can validate a certain setting
+// e.g Table [headercolor: #123]
+//   -> headercolor has its own SettingValidator
+export interface SettingValidator {
+  // Whether the setting is allowed to appear more than once
+  // e.g id integer [ref: > Products.uid, ref: ...]
+  //  -> ref can be duplicated
+  // e.g Table [note: 'this is a note']
+  //  -> note can not be duplicated
+  allowDuplicate: boolean;
+
+  // A callback that validates whether `value` is valid for the setting
+  isValid: (value?: SyntaxNode) => boolean;
+}
+
+// An object that can validates a term in an element's subfield
+// By definition, an element's subfield is a single primary expression
+// or a function application, which can have many arguments
+// The callee is also treated as an argument
+// e.g
+// Table Users {
+//   id integer [pk] // 'id' and 'integer' have their own validator
+//                   // '[pk]' is validated by the Table's subfield setting validator
+// }
+//
+export interface ArgumentValidator {
+  // Validator whether the node is a valid argument
+  // `ith` is a number representing the order of the subfield in the element
+  //   This parameter can be useful in cases
+  //   for example, where the first subfield has a different semantics from the rests
+  validateArg(node: SyntaxNode, ith: number): CompileError[];
+}
+
+// A configuration object
+// that dictates whether an element can appear within a certain `context`
+// e.g
+//   A Table can not appear inside a RefContext
+export interface ContextValidatorConfig {
+  // Which context is associated with this configuration?
+  name: Readonly<ValidatorContext>;
+  errorCode: Readonly<CompileErrorCode>;
+
+  // Should the validation stops immediately upon context checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates whether an element must be unique globally or locally in the current scope
+// e.g
+//   There can only be one Project -> globally unique
+//   There can not be more than one Notes in a Table -> locally unique
+export interface UniqueElementValidatorConfig {
+  globally: Readonly<boolean>;
+  notGloballyErrorCode?: Readonly<CompileErrorCode>;
+
+  locally: Readonly<boolean>;
+  notLocallyErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stops immediately upon uniqueness checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of an element's name
+// e.g
+//   A Table name is not optional, can be complex (v2.Users) and must be registrated
+//   A Ref name is optional, can be complex and is not registrated (no uniqueness constraint)
+export interface NameValidatorConfig {
+  // Is the name optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have a name
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to be complex
+  allowComplex: Readonly<boolean>;
+  complexErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should it be registered
+  shouldRegister: Readonly<boolean>;
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stops immediately upon name checking failure?
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of an element's alias
+// e.g
+//   Only Tables are allowed to have aliases
+export interface AliasValidatorConfig {
+  // Is the alias optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have an alias
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon alias checking failure
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the settings allowed on an element or a subfield
+export interface SettingListValidatorConfig {
+  // Is the settingList optional
+  optional: Readonly<boolean>;
+  notOptionalErrorCode?: Readonly<CompileErrorCode>;
+
+  // Is it allowed to have settingList
+  allow: Readonly<boolean>;
+  notAllowErrorCode?: Readonly<CompileErrorCode>;
+
+  // Error Code for unknown setting name
+  unknownErrorCode?: Readonly<CompileErrorCode>;
+  // Error Code for duplicate setting name (if the setting is not allowed to have duplicate)
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+  // Error Code for unknown setting name
+  invalidErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon setting list checking failure
+  stopOnError: Readonly<boolean>;
+
+  // A function that determines whether a specific value is allowed for a specific setting
+  // Return `Some(true)` if it's allowed
+  //        `Some(false)` if it's not allowed
+  //        `None` if the setting name is unknown
+  isValid(name: string, value?: SyntaxNode): Option<boolean>;
+
+  // A function that determines whether a specific setting is allowed to be duplicated
+  // Return value is similar to `isValid`
+  allowDuplicate(name: string): Option<boolean>;
+}
+
+// A configuration object
+// that dictates the format of an element body
+export interface BodyValidatorConfig {
+  // Can the body be simple
+  // e.g Ref: Users.id < Products.uid
+  allowSimple: Readonly<boolean>;
+  simpleErrorCode?: Readonly<CompileErrorCode>;
+
+  // Can the body be complex
+  // e.g Table Users {
+  //
+  // }
+  allowComplex: Readonly<boolean>;
+  complexErrorCode?: Readonly<CompileErrorCode>;
+
+  // Should the validation process stop immediately upon body checking failure
+  stopOnError: Readonly<boolean>;
+}
+
+// A configuration object
+// that dictates the format of a subfield
+// e.g A Table subfield (column) must have 2 args, including the callee,
+//     but excluding the setting list (optional)
+export interface SubFieldValidatorConfig {
+  // The list of validators for each argument
+  argValidators: Readonly<ArgumentValidator[]>;
+  invalidArgNumberErrorCode: Readonly<CompileErrorCode>;
+  invalidArgNumberErrorMessage: Readonly<string>;
+
+  // The setting list configuration of the subfield
+  settingList: Readonly<SettingListValidatorConfig>;
+
+  // Should a subfield's callee be registered
+  // For example, a Table's column name can not be duplicated
+  shouldRegister: Readonly<boolean>;
+  duplicateErrorCode?: Readonly<CompileErrorCode>;
+}
+
+export function createContextValidatorConfig(
+  config: ContextValidatorConfig,
+): ContextValidatorConfig {
+  return config;
+}
+
+export function createUniqueValidatorConfig(
+  config: UniqueElementValidatorConfig,
+): UniqueElementValidatorConfig {
+  if (config.globally && !config.notGloballyErrorCode) {
+    throw new Error(
+      'Misconfigurartion: If an element is globally unique, notGloballyErrorCode must be set',
+    );
+  }
+
+  if (config.locally && !config.notLocallyErrorCode) {
+    throw new Error(
+      'Misconfigurartion: If an element is locally unique, notLocallyErrorCode must be set',
+    );
+  }
+
+  return config;
+}
+
+export function createNameValidatorConfig(config: NameValidatorConfig): NameValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If name is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error('Misconfiguration: If name is not allowed, notAllowErrorCode must be present');
+  }
+
+  if (config.shouldRegister && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If name should be registered, duplicateErrorCode must be present',
+    );
+  }
+
+  return config;
+}
+
+export function createAliasValidatorConfig(config: AliasValidatorConfig): AliasValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If alias is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error('Misconfiguration: If alias is not allowed, notAllowErrorCode must be present');
+  }
+
+  return config;
+}
+
+export function createSettingListValidatorConfig(
+  validatorMap: { [settingName: string]: SettingValidator },
+  config: {
+    optional: boolean;
+    notOptionalErrorCode?: CompileErrorCode;
+    allow: boolean;
+    notAllowErrorCode?: CompileErrorCode;
+    unknownErrorCode?: CompileErrorCode;
+    duplicateErrorCode?: CompileErrorCode;
+    invalidErrorCode?: CompileErrorCode;
+    stopOnError: boolean;
+  },
+): SettingListValidatorConfig {
+  if (!config.optional && !config.notOptionalErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is not optional, notOptionalErrorCode must be present',
+    );
+  }
+
+  if (!config.allow && !config.notAllowErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is not allowed, notAllowErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.unknownErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, unknownErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, duplicateErrorCode must be present',
+    );
+  }
+
+  if (config.allow && !config.invalidErrorCode) {
+    throw new Error(
+      'Misconfiguration: If settingList is allowed, notAllowErrorCode must be present',
+    );
+  }
+
+  return {
+    ...config,
+
+    isValid(name: string, value?: SyntaxNode): Option<boolean> {
+      const validator = validatorMap[name];
+      if (!validator) {
+        return new None();
+      }
+
+      return new Some(validator.isValid(value));
+    },
+
+    allowDuplicate(name: string): Option<boolean> {
+      const validator = validatorMap[name];
+      if (!validator) {
+        return new None();
+      }
+
+      return new Some(validator.allowDuplicate);
+    },
+  };
+}
+
+export function createBodyValidatorConfig(config: BodyValidatorConfig): BodyValidatorConfig {
+  if (!config.allowSimple && !config.simpleErrorCode) {
+    throw new Error('Misconfiguration: If simple body is not allowed, simpleErrorCode must be set');
+  }
+
+  if (!config.allowComplex && !config.complexErrorCode) {
+    throw new Error(
+      'Misconfiguration: If complex body is not allowed, complexErrorCode must be set',
+    );
+  }
+
+  return config;
+}
+
+export function createSubFieldValidatorConfig(
+  config: SubFieldValidatorConfig,
+): SubFieldValidatorConfig {
+  if (config.shouldRegister && !config.duplicateErrorCode) {
+    throw new Error(
+      'Misconfiguration: If subfield should be registered, duplicateErrorCode must be present',
+    );
+  }
+
+  return config;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/utils.ts
@@ -1,0 +1,246 @@
+import { SyntaxToken, SyntaxTokenKind } from '../../lexer/tokens';
+import {
+  BlockExpressionNode,
+  ElementDeclarationNode,
+  FunctionExpressionNode,
+  ListExpressionNode,
+  LiteralNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  TupleExpressionNode,
+  VariableNode,
+} from '../../parser/nodes';
+import { isHexChar } from '../../utils';
+import { destructureComplexVariable, isBinaryRelationship } from '../utils';
+import CustomValidator from './elementValidators/custom';
+import EnumValidator from './elementValidators/enum';
+import IndexesValidator from './elementValidators/indexes';
+import NoteValidator from './elementValidators/note';
+import ProjectValidator from './elementValidators/project';
+import RefValidator from './elementValidators/ref';
+import TableValidator from './elementValidators/table';
+import TableGroupValidator from './elementValidators/tableGroup';
+import { createSchemaSymbolIndex } from '../symbol/symbolIndex';
+import { SchemaSymbol } from '../symbol/symbols';
+import SymbolTable from '../symbol/symbolTable';
+import SymbolFactory from '../symbol/factory';
+import { isAccessExpression, isExpressionAVariableNode } from '../../parser/utils';
+import { ElementKind } from './types';
+import { NUMERIC_LITERAL_PREFIX } from '../../../constants';
+
+// Pick a validator suitable for `element`
+export function toElementKind(str: string): ElementKind {
+  switch (str.toLowerCase()) {
+    case 'enum':
+      return ElementKind.ENUM;
+    case 'table':
+      return ElementKind.TABLE;
+    case 'tablegroup':
+      return ElementKind.TABLEGROUP;
+    case 'project':
+      return ElementKind.PROJECT;
+    case 'ref':
+      return ElementKind.REF;
+    case 'note':
+      return ElementKind.NOTE;
+    case 'indexes':
+      return ElementKind.INDEXES;
+    default:
+      return ElementKind.CUSTOM;
+  }
+}
+
+export function pickValidator(element: ElementDeclarationNode & { type: SyntaxToken }) {
+  switch (toElementKind(element.type.value)) {
+    case ElementKind.ENUM:
+      return EnumValidator;
+    case ElementKind.TABLE:
+      return TableValidator;
+    case ElementKind.TABLEGROUP:
+      return TableGroupValidator;
+    case ElementKind.PROJECT:
+      return ProjectValidator;
+    case ElementKind.REF:
+      return RefValidator;
+    case ElementKind.NOTE:
+      return NoteValidator;
+    case ElementKind.INDEXES:
+      return IndexesValidator;
+    default:
+      return CustomValidator;
+  }
+}
+
+// Is the name valid (either simple or complex)
+export function isValidName(nameNode: SyntaxNode): boolean {
+  return !!destructureComplexVariable(nameNode).unwrap_or(false);
+}
+
+// Is the alias valid (only simple name is allowed)
+export function isValidAlias(
+  aliasNode: SyntaxNode,
+): aliasNode is PrimaryExpressionNode & { expression: VariableNode } {
+  return isSimpleName(aliasNode);
+}
+
+// Is the name valid and simple
+export function isSimpleName(
+  nameNode: SyntaxNode,
+): nameNode is PrimaryExpressionNode & { expression: VariableNode } {
+  return nameNode instanceof PrimaryExpressionNode && nameNode.expression instanceof VariableNode;
+}
+
+// Is the argument a ListExpression
+export function isValidSettingList(
+  settingListNode: SyntaxNode,
+): settingListNode is ListExpressionNode {
+  return settingListNode instanceof ListExpressionNode;
+}
+
+// Does the element has complex body
+export function hasComplexBody(
+  node: ElementDeclarationNode,
+): node is ElementDeclarationNode & { body: BlockExpressionNode; bodyColon: undefined } {
+  return node.body instanceof BlockExpressionNode && !node.bodyColon;
+}
+
+// Does the element has simple body
+export function hasSimpleBody(
+  node: ElementDeclarationNode,
+): node is ElementDeclarationNode & { bodyColon: SyntaxToken } {
+  return !!node.bodyColon;
+}
+
+// Register the `variables` array as a stack of schema, the following nested within the former
+// `initialSchema` is the schema in which the first variable of `variables` is nested within
+export function registerSchemaStack(
+  variables: string[],
+  initialSchema: SymbolTable,
+  symbolFactory: SymbolFactory,
+): SymbolTable {
+  let prevSchema = initialSchema;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const curName of variables) {
+    let curSchema: SymbolTable | undefined;
+    const curId = createSchemaSymbolIndex(curName);
+
+    if (!prevSchema.has(curId)) {
+      curSchema = new SymbolTable();
+      const curSymbol = symbolFactory.create(SchemaSymbol, { symbolTable: curSchema });
+      prevSchema.set(curId, curSymbol);
+    } else {
+      curSchema = prevSchema.get(curId)?.symbolTable;
+      if (!curSchema) {
+        throw new Error('Expect a symbol table in a schema symbol');
+      }
+    }
+    prevSchema = curSchema;
+  }
+
+  return prevSchema;
+}
+
+export function isRelationshipOp(op?: string): boolean {
+  return op === '-' || op === '<>' || op === '>' || op === '<';
+}
+
+export function isValidColor(value?: SyntaxNode): boolean {
+  if (
+    !(value instanceof PrimaryExpressionNode) ||
+    !(value.expression instanceof LiteralNode) ||
+    !(value.expression.literal?.kind === SyntaxTokenKind.COLOR_LITERAL)
+  ) {
+    return false;
+  }
+
+  const color = value.expression.literal.value;
+
+  // e.g. #fff or #0abcde
+  if (color.length !== 4 && color.length !== 7) {
+    return false;
+  }
+
+  if (color[0] !== '#') {
+    return false;
+  }
+
+  for (let i = 1; i < color.length; i += 1) {
+    if (!isHexChar(color[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Is the value non-existent
+export function isVoid(value?: SyntaxNode): boolean {
+  return (
+    value === undefined ||
+    (!Array.isArray(value) && value.end === -1 && value.start === -1) ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
+// Is the `value` a valid value for a column's `default` setting
+// It's a valid only if it's a literal or a complex variable (potentially an enum member)
+export function isValidDefaultValue(value?: SyntaxNode): boolean {
+  if (
+    value instanceof PrimaryExpressionNode &&
+    (value.expression instanceof LiteralNode || value.expression instanceof VariableNode)
+  ) {
+    return true;
+  }
+  if (
+    value instanceof PrefixExpressionNode &&
+    NUMERIC_LITERAL_PREFIX.includes(value.op?.value as any) &&
+    isExpressionANumber(value.expression)
+  ) {
+    return true;
+  }
+
+  if (value instanceof FunctionExpressionNode) {
+    return true;
+  }
+
+  if (!value || Array.isArray(value) || !isAccessExpression(value)) {
+    return false;
+  }
+
+  const variables = destructureComplexVariable(value).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+export function isExpressionANumber(value?: SyntaxNode): value is PrimaryExpressionNode & {
+  expression: LiteralNode & { literal: { kind: SyntaxTokenKind.NUMERIC_LITERAL } };
+} {
+  return (
+    value instanceof PrimaryExpressionNode &&
+    value.expression instanceof LiteralNode &&
+    value.expression.literal?.kind === SyntaxTokenKind.NUMERIC_LITERAL
+  );
+}
+
+export function isUnaryRelationship(value?: SyntaxNode): value is PrefixExpressionNode {
+  if (!(value instanceof PrefixExpressionNode)) {
+    return false;
+  }
+
+  if (!isRelationshipOp(value.op?.value)) {
+    return false;
+  }
+
+  const variables = destructureComplexVariable(value.expression).unwrap_or(undefined);
+
+  return variables !== undefined && variables.length > 0;
+}
+
+export function isTupleOfVariables(value?: SyntaxNode): value is TupleExpressionNode & {
+  elementList: (PrimaryExpressionNode & { expression: VariableNode })[];
+} {
+  return value instanceof TupleExpressionNode && value.elementList.every(isExpressionAVariableNode);
+}
+
+export { isBinaryRelationship };

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validator.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validator.ts
@@ -1,0 +1,65 @@
+import Report from '../../report';
+import { CompileError } from '../../errors';
+import { ElementDeclarationNode, ProgramNode } from '../../parser/nodes';
+import { ContextStack } from './validatorContext';
+import { SchemaSymbol } from '../symbol/symbols';
+import SymbolFactory from '../symbol/factory';
+import { pickValidator } from './utils';
+import { ElementKind } from './types';
+import SymbolTable from '../symbol/symbolTable';
+import { SyntaxToken } from '../../lexer/tokens';
+
+export default class Validator {
+  private ast: ProgramNode;
+
+  private publicSchemaSymbol: SchemaSymbol;
+
+  private contextStack: ContextStack;
+
+  private kindsGloballyFound: Set<ElementKind>;
+  private kindsLocallyFound: Set<ElementKind>;
+
+  private errors: CompileError[];
+
+  private symbolFactory: SymbolFactory;
+
+  constructor(ast: ProgramNode, symbolFactory: SymbolFactory) {
+    this.ast = ast;
+    this.contextStack = new ContextStack();
+    this.errors = [];
+    this.symbolFactory = symbolFactory;
+    this.publicSchemaSymbol = this.symbolFactory.create(SchemaSymbol, {
+      symbolTable: new SymbolTable(),
+    });
+    this.kindsGloballyFound = new Set();
+    this.kindsLocallyFound = new Set();
+
+    this.ast.symbol = this.publicSchemaSymbol;
+    this.ast.symbol.declaration = this.ast;
+  }
+
+  validate(): Report<ProgramNode, CompileError> {
+    this.ast.body.forEach((_element) => {
+      // eslint-disable-next-line no-param-reassign
+      _element.parent = this.ast;
+      if (_element.type === undefined) {
+        return;
+      }
+      const element = _element as ElementDeclarationNode & { type: SyntaxToken };
+
+      const Val = pickValidator(element);
+      const validatorObject = new Val(
+        element,
+        this.publicSchemaSymbol,
+        this.contextStack,
+        this.errors,
+        this.kindsGloballyFound,
+        this.kindsLocallyFound,
+        this.symbolFactory,
+      );
+      validatorObject.validate();
+    });
+
+    return new Report(this.ast, this.errors);
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validatorContext.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/analyzer/validator/validatorContext.ts
@@ -1,0 +1,88 @@
+export const enum ValidatorContext {
+  TopLevelContext,
+  ProjectContext,
+  TableContext,
+  TableGroupContext,
+  EnumContext,
+  RefContext,
+  IndexesContext,
+  NoteContext,
+  CustomContext,
+}
+
+export function canBeNestedWithin(
+  container: ValidatorContext,
+  containee: ValidatorContext,
+): boolean {
+  switch (container) {
+    case ValidatorContext.TopLevelContext:
+      return (
+        containee === ValidatorContext.ProjectContext ||
+        containee === ValidatorContext.TableContext ||
+        containee === ValidatorContext.TableGroupContext ||
+        containee === ValidatorContext.EnumContext ||
+        containee === ValidatorContext.RefContext
+      );
+    case ValidatorContext.ProjectContext:
+      return (
+        containee === ValidatorContext.TableContext ||
+        containee === ValidatorContext.TableGroupContext ||
+        containee === ValidatorContext.EnumContext ||
+        containee === ValidatorContext.NoteContext ||
+        containee === ValidatorContext.RefContext ||
+        containee === ValidatorContext.CustomContext
+      );
+    case ValidatorContext.TableContext:
+      return (
+        containee === ValidatorContext.IndexesContext ||
+        containee === ValidatorContext.NoteContext ||
+        containee === ValidatorContext.RefContext
+      );
+    default:
+      return false;
+  }
+}
+
+export function canContainField(container: ValidatorContext, fieldName: string) {
+  // eslint-disable-next-line
+  const _fieldName = fieldName.toLowerCase();
+
+  switch (container) {
+    case ValidatorContext.ProjectContext:
+      return true;
+    case ValidatorContext.TableContext:
+      return _fieldName === 'note' || _fieldName === 'ref';
+    default:
+      return false;
+  }
+}
+
+export class ContextStack {
+  private stack: ValidatorContext[] = [ValidatorContext.TopLevelContext];
+
+  push(ctx: ValidatorContext) {
+    this.stack.push(ctx);
+  }
+
+  pop(): ValidatorContext {
+    return this.stack.length === 1 ? this.stack[0] : this.stack.pop()!;
+  }
+
+  top(): ValidatorContext {
+    return this.stack[this.stack.length - 1];
+  }
+
+  parent(): ValidatorContext {
+    return this.stack.length === 1 ? this.stack[0] : this.stack[this.stack.length - 2];
+  }
+
+  isWithinContext(ctx: ValidatorContext): boolean {
+    for (let i = this.stack.length - 1; i >= 0; i -= 1) {
+      if (this.stack[i] === ctx) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/errors.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/errors.ts
@@ -1,0 +1,121 @@
+import { SyntaxToken } from './lexer/tokens';
+import { SyntaxNode } from './parser/nodes';
+
+export enum CompileErrorCode {
+  UNKNOWN_SYMBOL = 1000,
+
+  UNEXPECTED_SYMBOL,
+  UNEXPECTED_EOF,
+  UNEXPECTED_NEWLINE,
+
+  UNKNOWN_TOKEN,
+  UNEXPECTED_TOKEN,
+  MISPLACED_LIST_NODE,
+  MISSING_SPACES,
+  UNKNOWN_PREFIX_OP,
+  INVALID_OPERAND,
+  EMPTY_ATTRIBUTE_NAME,
+
+  INVALID_NAME = 3000,
+  UNEXPECTED_NAME,
+  NAME_NOT_FOUND,
+  DUPLICATE_NAME,
+  INVALID_ALIAS,
+  UNEXPECTED_ALIAS,
+  UNEXPECTED_SETTINGS,
+  INVALID_SETTINGS,
+  UNEXPECTED_SIMPLE_BODY,
+  UNEXPECTED_COMPLEX_BODY,
+
+  INVALID_TABLE_CONTEXT,
+  INVALID_TABLE_SETTING,
+  DUPLICATE_TABLE_SETTING,
+
+  INVALID_TABLEGROUP_CONTEXT,
+  INVALID_TABLEGROUP_ELEMENT_NAME,
+  DUPLICATE_TABLEGROUP_ELEMENT_NAME,
+  INVALID_TABLEGROUP_FIELD,
+
+  INVALID_COLUMN,
+  INVALID_COLUMN_NAME,
+  UNKNOWN_COLUMN_SETTING,
+  INVALID_COLUMN_TYPE,
+  DUPLICATE_COLUMN_NAME,
+  DUPLICATE_COLUMN_SETTING,
+  INVALID_COLUMN_SETTING_VALUE,
+
+  INVALID_ENUM_CONTEXT,
+  INVALID_ENUM_ELEMENT_NAME,
+  INVALID_ENUM_ELEMENT,
+  DUPLICATE_ENUM_ELEMENT_NAME,
+  UNKNOWN_ENUM_ELEMENT_SETTING,
+  DUPLICATE_ENUM_ELEMENT_SETTING,
+  INVALID_ENUM_ELEMENT_SETTING,
+
+  INVALID_REF_CONTEXT,
+  UNKNOWN_REF_SETTING,
+  DUPLICATE_REF_SETTING,
+  INVALID_REF_SETTING_VALUE,
+  INVALID_REF_RELATIONSHIP,
+  INVALID_REF_FIELD,
+
+  INVALID_NOTE_CONTEXT,
+  INVALID_NOTE,
+  NOTE_REDEFINED,
+  NOTE_CONTENT_REDEFINED,
+
+  INVALID_INDEXES_CONTEXT,
+  INVALID_INDEXES_FIELD,
+  INVALID_INDEX,
+  UNKNOWN_INDEX_SETTING,
+  DUPLICATE_INDEX_SETTING,
+  UNEXPECTED_INDEX_SETTING_VALUE,
+  INVALID_INDEX_SETTING_VALUE,
+
+  INVALID_PROJECT_CONTEXT,
+  PROJECT_REDEFINED,
+  INVALID_PROJECT_FIELD,
+
+  INVALID_CUSTOM_CONTEXT,
+  INVALID_CUSTOM_ELEMENT_VALUE,
+
+  INVALID_ELEMENT_IN_SIMPLE_BODY,
+  BINDING_ERROR = 4000,
+
+  UNSUPPORTED = 5000,
+  CIRCULAR_REF,
+  SAME_ENDPOINT,
+  UNEQUAL_FIELDS_BINARY_REF,
+  CONFLICTING_SETTING,
+}
+
+export class CompileError extends Error {
+  code: Readonly<CompileErrorCode>;
+
+  diagnostic: Readonly<string>;
+
+  nodeOrToken: Readonly<SyntaxNode | SyntaxToken>; // The node or token that causes the error
+
+  start: Readonly<number>;
+
+  end: Readonly<number>;
+
+  constructor(code: number, message: string, nodeOrToken: SyntaxNode | SyntaxToken) {
+    super(message);
+    this.code = code;
+    this.diagnostic = message;
+    this.nodeOrToken = nodeOrToken;
+    this.start = nodeOrToken.start;
+    this.end = nodeOrToken.end;
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, CompileError.prototype);
+  }
+
+  isTokenError(): this is CompileError & { nodeOrToken: SyntaxToken } {
+    return this.nodeOrToken instanceof SyntaxToken;
+  }
+
+  isNodeError(): this is CompileError & { nodeOrToken: SyntaxNode } {
+    return !(this.nodeOrToken instanceof SyntaxToken);
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/attributeCollector.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/attributeCollector.ts
@@ -1,0 +1,321 @@
+/* A utility module to ease the attribute processing in the main `interpreter` module */
+
+import { KEYWORDS_OF_DEFAULT_SETTING, NUMERIC_LITERAL_PREFIX } from '../../constants';
+import {
+  AttributeNode,
+  FunctionExpressionNode,
+  IdentiferStreamNode,
+  ListExpressionNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  SyntaxNode,
+  VariableNode,
+} from '../parser/nodes';
+import { extractQuotedStringToken } from '../analyzer/utils';
+import { CompileError, CompileErrorCode } from '../errors';
+import { isExpressionANumber } from '../analyzer/validator/utils';
+import { extractStringFromIdentifierStream, isExpressionAQuotedString } from '../parser/utils';
+import { InlineRef } from './types';
+import { ColumnSymbol } from '../analyzer/symbol/symbols';
+import {
+  extractTokenForInterpreter,
+  getColumnSymbolsOfRefOperand,
+  normalizeNoteContent,
+  processRelOperand,
+} from './utils';
+
+class AttributeMap {
+  private map: Map<string, AttributeNode[]> = new Map();
+
+  insert(name: string, attribute: AttributeNode) {
+    const curEntry = this.map.get(name);
+    if (curEntry === undefined) {
+      this.map.set(name, [attribute]);
+    } else {
+      curEntry.push(attribute);
+    }
+  }
+
+  getValue(name: string): SyntaxNode | SyntaxNode[] | boolean | undefined {
+    const entry = this.map.get(name);
+    if (entry === undefined) {
+      return undefined;
+    }
+    if (entry[0].value === undefined) {
+      return true;
+    }
+    if (entry.length >= 2) {
+      return entry.map((e) => e.value!);
+    }
+
+    return entry[0].value!;
+  }
+
+  getAttributeNode(name: string): AttributeNode | AttributeNode[] | undefined {
+    const entry = this.map.get(name);
+    if (entry === undefined) {
+      return undefined;
+    }
+    if (entry.length >= 2) {
+      return entry;
+    }
+
+    return entry[0];
+  }
+}
+
+export default function collectAttribute(
+  settingNode: ListExpressionNode | undefined,
+  errors: CompileError[],
+): AttributeCollector {
+  const attrMap = new AttributeMap();
+
+  if (!settingNode) {
+    return new AttributeCollector(attrMap, errors);
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const attribute of settingNode.elementList) {
+    const attrName = extractStringFromIdentifierStream(attribute.name).unwrap_or('').toLowerCase();
+    attrMap.insert(attrName, attribute);
+  }
+
+  return new AttributeCollector(attrMap, errors);
+}
+
+class AttributeCollector {
+  settingMap: AttributeMap;
+  errors: CompileError[];
+
+  constructor(attrMap: AttributeMap, errors: CompileError[]) {
+    this.settingMap = attrMap;
+    this.errors = errors;
+  }
+
+  extractNote(): string | undefined {
+    const note = this.settingMap.getValue('note');
+
+    return note !== undefined ?
+      normalizeNoteContent(extractQuotedStringToken(note as SyntaxNode | undefined).unwrap()) :
+      undefined;
+  }
+
+  extractDefault():
+    | { type: 'number' | 'string' | 'expression' | 'boolean'; value: number | string }
+    | undefined {
+    const deflt = this.settingMap.getValue('default');
+
+    if (deflt === undefined) {
+      return undefined;
+    }
+
+    // eslint-disable-next-line no-underscore-dangle
+    const _deflt = deflt as SyntaxNode;
+
+    if (
+      _deflt instanceof PrimaryExpressionNode &&
+      _deflt.expression instanceof VariableNode &&
+      KEYWORDS_OF_DEFAULT_SETTING.includes(_deflt.expression.variable?.value as any)
+    ) {
+      return {
+        type: 'boolean',
+        value: _deflt.expression.variable!.value,
+      };
+    }
+
+    if (isExpressionANumber(_deflt)) {
+      return {
+        type: 'number',
+        value: Number(_deflt.expression.literal.value),
+      };
+    }
+
+    if (
+      _deflt instanceof PrefixExpressionNode &&
+      NUMERIC_LITERAL_PREFIX.includes(_deflt.op?.value as any) &&
+      isExpressionANumber(_deflt.expression)
+    ) {
+      return {
+        type: 'number',
+        value:
+          Number(_deflt.expression.expression.literal.value) * (_deflt.op?.value === '+' ? 1 : -1),
+      };
+    }
+
+    if (isExpressionAQuotedString(_deflt)) {
+      return {
+        value: extractQuotedStringToken(_deflt as SyntaxNode).unwrap(),
+        type: 'string',
+      };
+    }
+
+    if (_deflt instanceof FunctionExpressionNode) {
+      return {
+        value: _deflt.value!.value,
+        type: 'expression',
+      };
+    }
+
+    // `value` must be a complex variable now
+    // as allowed by the validator
+    // to potentially support enum default value
+    // e.g
+    // Enum status {
+    //   new
+    //   churn
+    // }
+    // Table Users {
+    //   status public.status [default: status.new]
+    // }
+    // currently the interpreter doesn't support this
+    this.errors.push(
+      new CompileError(CompileErrorCode.UNSUPPORTED, 'Unsupported default value', _deflt),
+    );
+
+    return undefined;
+  }
+
+  extractRef(
+    ownerTableName: string,
+    ownerSchemaName: string | null,
+  ): (InlineRef & { referee: ColumnSymbol; node: SyntaxNode })[] {
+    const refs = this.settingMap.getValue('ref');
+    if (refs === undefined) {
+      return [];
+    }
+    const refList = Array.isArray(refs) ? refs : [refs as SyntaxNode];
+    const res: (InlineRef & { referee: ColumnSymbol; node: SyntaxNode })[] = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const ref of refList) {
+      const operand = (ref as PrefixExpressionNode).expression;
+      const maybeName = processRelOperand(operand!, ownerTableName, ownerSchemaName);
+      if (maybeName instanceof CompileError) {
+        this.errors.push(maybeName);
+      } else {
+        const { columnNames, tableName, schemaName } = maybeName;
+        const relation = (ref as PrefixExpressionNode).op!.value as any;
+        res.push({
+          schemaName,
+          tableName,
+          fieldNames: columnNames,
+          relation,
+          token: extractTokenForInterpreter(ref),
+          referee: getColumnSymbolsOfRefOperand(
+            (ref as PrefixExpressionNode).expression!,
+          ).unwrap()[0],
+          node: ref,
+        });
+      }
+    }
+
+    return res;
+  }
+
+  extractHeaderColor(): string | undefined {
+    const headerColor = this.settingMap.getValue('headercolor');
+
+    if (headerColor === undefined) {
+      return undefined;
+    }
+
+    return (headerColor as any).expression.literal.value;
+  }
+
+  extractUpdate(): string | undefined {
+    const update = this.settingMap.getValue('update');
+
+    if (update === undefined) {
+      return undefined;
+    }
+
+    if (update instanceof IdentiferStreamNode) {
+      return extractStringFromIdentifierStream(update).unwrap_or('');
+    }
+
+    return (update as any).expression.variable.value;
+  }
+
+  extractDelete(): string | undefined {
+    const del = this.settingMap.getValue('delete');
+
+    if (del === undefined) {
+      return undefined;
+    }
+
+    if (del instanceof IdentiferStreamNode) {
+      return extractStringFromIdentifierStream(del).unwrap_or('');
+    }
+
+    return (del as any).expression.variable.value;
+  }
+
+  extractIndexType(): string | undefined {
+    const idxType = this.settingMap.getValue('type');
+
+    if (idxType === undefined) {
+      return undefined;
+    }
+
+    return (idxType as any).expression.variable.value;
+  }
+
+  extractPk(): boolean | undefined {
+    const pk = this.settingMap.getValue('pk') || this.settingMap.getValue('primary key');
+
+    if (pk === undefined) {
+      return undefined;
+    }
+
+    return true;
+  }
+
+  extractUnique(): boolean | undefined {
+    const uniq = this.settingMap.getValue('unique');
+
+    if (uniq === undefined) {
+      return undefined;
+    }
+
+    return true;
+  }
+
+  extractIncrement(): boolean | undefined {
+    const increment = this.settingMap.getValue('increment');
+
+    if (increment === undefined) {
+      return undefined;
+    }
+
+    return true;
+  }
+
+  extractNotNull(): boolean | undefined {
+    const notNull = this.settingMap.getValue('not null');
+    const isNull = this.settingMap.getValue('null');
+    if (notNull === undefined && isNull === undefined) {
+      return undefined;
+    }
+    if (notNull && isNull) {
+      this.errors.push(
+        new CompileError(
+          CompileErrorCode.CONFLICTING_SETTING,
+          'null and not null can not be set at the same time',
+          this.settingMap.getAttributeNode('not null') as AttributeNode,
+        ),
+      );
+
+      return undefined;
+    }
+
+    return !!notNull;
+  }
+
+  extractIdxName(): string | undefined {
+    const idxName = this.settingMap.getValue('name');
+
+    if (idxName === undefined) {
+      return undefined;
+    }
+
+    return extractQuotedStringToken(idxName as SyntaxNode).unwrap();
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/interpreter.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/interpreter.ts
@@ -1,0 +1,681 @@
+import { CompileError, CompileErrorCode } from '../errors';
+import {
+  AttributeNode,
+  BlockExpressionNode,
+  CallExpressionNode,
+  ElementDeclarationNode,
+  FunctionApplicationNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+} from '../parser/nodes';
+import {
+  Column,
+  Database,
+  Enum,
+  EnumField,
+  Index,
+  InlineRef,
+  Project,
+  Ref,
+  RefEndpoint,
+  Table,
+  TableGroup,
+  TableGroupField,
+  TokenPosition,
+} from './types';
+import Report from '../report';
+import {
+  destructureComplexVariable,
+  destructureIndexNode,
+  extractQuotedStringToken,
+  extractVarNameFromPrimaryVariable,
+} from '../analyzer/utils';
+import collectAttribute from './attributeCollector';
+import { ColumnSymbol } from '../analyzer/symbol/symbols';
+import {
+  convertRelationOpToCardinalities,
+  extractTokenForInterpreter,
+  getColumnSymbolsOfRefOperand,
+  isCircular,
+  isSameEndpoint,
+  normalizeNoteContent,
+  processRelOperand,
+} from './utils';
+import { None, Option, Some } from '../option';
+
+// The interpreted format follows the old parser
+export default class Interpreter {
+  ast: ProgramNode;
+  errors: CompileError[];
+  db: Database;
+  endpointPairSet: Set<string>;
+
+  constructor(ast: ProgramNode) {
+    this.ast = ast;
+    this.db = {
+      schemas: [],
+      tables: [],
+      refs: [],
+      enums: [],
+      tableGroups: [],
+      aliases: [],
+      project: {},
+    };
+    this.endpointPairSet = new Set();
+    this.errors = [];
+  }
+
+  interpret(): Report<Database, CompileError> {
+    this.ast.body.forEach((element) => {
+      switch (element.type!.value.toLowerCase()) {
+        case 'table':
+          tryPush(this.table(element), this.db.tables);
+          break;
+        case 'ref':
+          this.db.refs.push(...this.ref(element, null, null));
+          break;
+        case 'tablegroup':
+          tryPush(this.tableGroup(element), this.db.tableGroups);
+          break;
+        case 'enum':
+          tryPush(this.enum(element), this.db.enums);
+          break;
+        case 'project':
+          this.db.project = this.project(element);
+          if (this.db.project) {
+            this.db.tables.push(...this.db.project.tables);
+            this.db.enums.push(...this.db.project.enums);
+            this.db.tableGroups.push(...this.db.project.tableGroups);
+          }
+          break;
+        default:
+          throw new Error('Unreachable - unknown element type');
+      }
+    });
+
+    return new Report(this.db, this.errors);
+  }
+
+  private table(element: ElementDeclarationNode): Table | undefined {
+    const maybeName = this.extractElementName(element.name!);
+    if (!maybeName.isOk()) {
+      return undefined;
+    }
+    const { name, schemaName } = maybeName.unwrap();
+    const alias = element.alias ?
+      extractVarNameFromPrimaryVariable(element.alias as any).unwrap_or(null) :
+      null;
+    if (alias) {
+      this.db.aliases.push({
+        name: alias,
+        kind: 'table',
+        value: {
+          tableName: name,
+          schemaName,
+        },
+      });
+    }
+
+    const collector = collectAttribute(element.attributeList, this.errors);
+    const headerColor = collector.extractHeaderColor();
+    const headerNote = collector.extractNote();
+    let bodyNote: { value: string; token: TokenPosition } | undefined;
+    const noteNode = collector.settingMap.getAttributeNode('note') as AttributeNode | undefined;
+    const fields: Column[] = [];
+    const indexes: Index[] = [];
+    (element.body as BlockExpressionNode).body.forEach((sub) => {
+      if (sub instanceof FunctionApplicationNode) {
+        tryPush(this.column(sub, name, schemaName), fields);
+      } else if (sub instanceof ElementDeclarationNode) {
+        switch (sub.type!.value.toLowerCase()) {
+          case 'ref':
+            this.db.refs.push(...this.ref(sub, name, schemaName));
+            break;
+          case 'indexes':
+            indexes.push(...this.indexes(sub));
+            break;
+          case 'note':
+            if (headerNote !== undefined) {
+              this.logError(
+                sub,
+                CompileErrorCode.NOTE_REDEFINED,
+                'Note already appears as a setting of the table',
+              );
+            } else {
+              bodyNote = this.note(sub);
+            }
+            break;
+        }
+      }
+    });
+
+    return {
+      name,
+      schemaName,
+      alias,
+      fields,
+      token: extractTokenForInterpreter(element),
+      indexes,
+      headerColor,
+      note:
+        headerNote === undefined ?
+          bodyNote :
+          {
+              value: headerNote,
+              token: extractTokenForInterpreter(noteNode!),
+            },
+    };
+  }
+
+  private column(
+    field: FunctionApplicationNode,
+    tableName: string,
+    schemaName: string | null,
+  ): Column | undefined {
+    const name = extractVarNameFromPrimaryVariable(field.callee as any);
+    let typeNode = field.args[0];
+    let typeArgs: string | null = null;
+    if (typeNode instanceof CallExpressionNode) {
+      typeArgs = typeNode
+        .argumentList!.elementList.map((e) => (e as any).expression.literal.value)
+        .join(',');
+      typeNode = typeNode.callee!;
+    }
+
+    const maybeName = this.extractElementName(typeNode);
+    if (!maybeName.isOk()) {
+      return undefined;
+    }
+    const { name: typeName, schemaName: typeSchemaName } = maybeName.unwrap();
+
+    let pk: boolean | undefined;
+    let increment: boolean | undefined;
+    let unique: boolean | undefined;
+    let notNull: boolean | undefined;
+    let note: string | undefined;
+    let noteNode: AttributeNode | undefined;
+    let dbdefault:
+      | {
+          type: 'number' | 'string' | 'boolean' | 'expression';
+          value: number | string;
+        }
+      | undefined;
+    let inlineRefs: (InlineRef & { referee: ColumnSymbol; node: SyntaxNode })[] = [];
+    // eslint-disable-next-line no-underscore-dangle
+    const _inlineRefs: InlineRef[] = [];
+    if (field.args.length === 2) {
+      const collector = collectAttribute(field.args[1] as ListExpressionNode, this.errors);
+      pk = collector.extractPk();
+      increment = collector.extractIncrement();
+      unique = collector.extractUnique();
+      notNull = collector.extractNotNull();
+      dbdefault = collector.extractDefault();
+      note = collector.extractNote();
+      noteNode = collector.settingMap.getAttributeNode('note') as AttributeNode | undefined;
+      inlineRefs = collector.extractRef(tableName, schemaName);
+      inlineRefs.forEach((ref) => {
+        if (!this.logIfSameEndpoint(ref.node, [field.symbol as ColumnSymbol], [ref.referee])) {
+          return;
+        }
+        if (!this.logIfCircularRefError(ref.node, [field.symbol as ColumnSymbol], [ref.referee])) {
+          return;
+        }
+        _inlineRefs.push({
+          schemaName: ref.schemaName,
+          tableName: ref.tableName,
+          fieldNames: ref.fieldNames,
+          relation: ref.relation,
+          token: ref.token,
+        });
+        this.registerInlineRefEndpoints(ref, field, tableName, schemaName);
+      });
+    }
+
+    return {
+      name: name.unwrap(),
+      type: {
+        schemaName: typeSchemaName,
+        type_name: `${typeName}${typeArgs === null ? '' : `(${typeArgs})`}`,
+        args: typeArgs,
+      },
+      token: extractTokenForInterpreter(field),
+      inline_refs: _inlineRefs,
+      pk,
+      unique,
+      not_null: notNull,
+      dbdefault,
+      increment,
+      note:
+        note === undefined ?
+          undefined :
+          {
+              value: note,
+              token: extractTokenForInterpreter(noteNode!),
+            },
+    };
+  }
+
+  private registerInlineRefEndpoints(
+    inlRef: InlineRef,
+    columnNode: FunctionApplicationNode,
+    tableName: string,
+    schemaName: string | null,
+  ) {
+    const [left, right] = convertRelationOpToCardinalities(inlRef.relation);
+    const ref: Ref = {
+      schemaName: null,
+      name: null,
+      endpoints: [
+        {
+          schemaName,
+          tableName,
+          fieldNames: [extractVarNameFromPrimaryVariable(columnNode.callee as any).unwrap()],
+          relation: left,
+          token: extractTokenForInterpreter(columnNode),
+        },
+        {
+          schemaName: inlRef.schemaName,
+          tableName: inlRef.tableName,
+          fieldNames: inlRef.fieldNames,
+          relation: right,
+          token: inlRef.token,
+        },
+      ],
+      token: inlRef.token,
+    };
+    this.db.refs.push(ref);
+  }
+
+  private ref(
+    element: ElementDeclarationNode,
+    ownerTableName: string | null,
+    ownerSchemaName: string | null,
+  ): Ref[] {
+    let schemaName: string | null = null;
+    let name: string | null = null;
+    if (element.name) {
+      const maybeName = this.extractElementName(element.name);
+      if (!maybeName.isOk()) {
+        return [];
+      }
+      schemaName = maybeName.unwrap().schemaName;
+      name = maybeName.unwrap().name;
+    }
+
+    if (!(element.body instanceof BlockExpressionNode)) {
+      const maybeRef = this.refField(
+        element.body! as FunctionApplicationNode,
+        schemaName,
+        name,
+        ownerTableName,
+        ownerSchemaName,
+      );
+
+      return maybeRef ? [maybeRef] : [];
+    }
+
+    const res: Ref[] = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const field of element.body.body) {
+      const maybeRef = this.refField(
+        field as FunctionApplicationNode,
+        schemaName,
+        name,
+        ownerTableName,
+        ownerSchemaName,
+      );
+      if (maybeRef) {
+        res.push(maybeRef);
+      }
+    }
+
+    return res;
+  }
+
+  private refField(
+    field: FunctionApplicationNode,
+    refSchemaName: string | null,
+    refName: string | null,
+    ownerTableName: string | null,
+    ownerSchemaName: string | null,
+  ): Ref | undefined {
+    const args = [field.callee, ...field.args];
+    const rel = args[0] as InfixExpressionNode;
+    const [leftCardinality, rightCardinality] = convertRelationOpToCardinalities(rel.op!.value);
+    const leftReferees = getColumnSymbolsOfRefOperand(rel.leftExpression!).unwrap();
+    const rightReferees = getColumnSymbolsOfRefOperand(rel.rightExpression!).unwrap();
+    if (!this.logIfUnequalFields(rel, leftReferees, rightReferees)) {
+      return undefined;
+    }
+    if (!this.logIfSameEndpoint(rel, leftReferees, rightReferees)) {
+      return undefined;
+    }
+    if (!this.logIfCircularRefError(rel, leftReferees, rightReferees)) {
+      return undefined;
+    }
+    const left = processRelOperand(rel.leftExpression!, ownerTableName, ownerSchemaName);
+    const right = processRelOperand(rel.rightExpression!, ownerTableName, ownerSchemaName);
+    if (left instanceof CompileError) {
+      this.errors.push(left);
+    }
+    if (right instanceof CompileError) {
+      this.errors.push(right);
+    }
+    if (left instanceof CompileError || right instanceof CompileError) {
+      return undefined;
+    }
+
+    const leftEndpoint: RefEndpoint = {
+      schemaName: left.schemaName,
+      tableName: left.tableName,
+      fieldNames: left.columnNames,
+      relation: leftCardinality,
+      token: extractTokenForInterpreter(rel.leftExpression!),
+    };
+    const rightEndpoint: RefEndpoint = {
+      schemaName: right.schemaName,
+      tableName: right.tableName,
+      fieldNames: right.columnNames,
+      relation: rightCardinality,
+      token: extractTokenForInterpreter(rel.rightExpression!),
+    };
+    let del: string | undefined;
+    let update: string | undefined;
+    if (args.length === 2) {
+      const collector = collectAttribute(args[1] as ListExpressionNode, this.errors);
+      del = collector.extractDelete();
+      update = collector.extractUpdate();
+    }
+
+    return {
+      name: refName,
+      endpoints: [leftEndpoint, rightEndpoint],
+      onDelete: del as any,
+      onUpdate: update as any,
+      token: extractTokenForInterpreter(rel),
+      schemaName: refSchemaName,
+    };
+  }
+
+  private enum(element: ElementDeclarationNode): Enum | undefined {
+    const maybeName = this.extractElementName(element.name!);
+    if (!maybeName.isOk()) {
+      return undefined;
+    }
+    const { name, schemaName } = maybeName.unwrap();
+    const values = (element.body as BlockExpressionNode).body.map((sub) =>
+      this.enumField(sub as FunctionApplicationNode),
+    );
+
+    return {
+      name,
+      schemaName,
+      token: extractTokenForInterpreter(element),
+      values,
+    };
+  }
+
+  private enumField(field: FunctionApplicationNode): EnumField {
+    const args = [field.callee, ...field.args];
+    let note: string | undefined;
+    let noteNode: AttributeNode | undefined;
+    if (args.length === 2) {
+      const collector = collectAttribute(args[1] as ListExpressionNode, this.errors);
+      note = collector.extractNote();
+      noteNode = collector.settingMap.getAttributeNode('note') as AttributeNode | undefined;
+    }
+
+    return {
+      name: extractVarNameFromPrimaryVariable(args[0] as any).unwrap(),
+      token: extractTokenForInterpreter(field),
+      note:
+        note === undefined ?
+          undefined :
+          {
+              value: note,
+              token: extractTokenForInterpreter(noteNode!),
+            },
+    };
+  }
+
+  private project(element: ElementDeclarationNode): Project {
+    const proj: Project = {
+      name:
+        (element.name && extractVarNameFromPrimaryVariable(element.name as any))?.unwrap() || null,
+      tables: [],
+      refs: [],
+      enums: [],
+      tableGroups: [],
+      note: undefined,
+    };
+
+    (element.body as BlockExpressionNode).body.forEach((sub) => {
+      // eslint-disable-next-line no-underscore-dangle
+      const _sub = sub as ElementDeclarationNode;
+      const type = _sub.type!.value.toLowerCase();
+      switch (type) {
+        case 'table':
+          tryPush(this.table(_sub), proj.tables);
+          break;
+        case 'ref':
+          proj.refs.push(...this.ref(_sub, null, null));
+          break;
+        case 'tablegroup':
+          tryPush(this.tableGroup(_sub), proj.tableGroups);
+          break;
+        case 'enum':
+          tryPush(this.enum(_sub), proj.enums);
+          break;
+        case 'note':
+          proj.note = this.note(_sub);
+          break;
+        default:
+          proj[type as any] = this.custom(_sub);
+          break;
+      }
+    });
+
+    return proj;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private custom(element: ElementDeclarationNode): string {
+    return extractQuotedStringToken((element.body as FunctionApplicationNode).callee).unwrap_or('');
+  }
+
+  private tableGroup(element: ElementDeclarationNode): TableGroup | undefined {
+    const maybeName = this.extractElementName(element.name!);
+    if (!maybeName.isOk()) {
+      return undefined;
+    }
+    const { name, schemaName } = maybeName.unwrap();
+    const tables: TableGroupField[] = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const field of (element.body as BlockExpressionNode).body) {
+      const maybeTableGroupField = this.tableGroupField(field as FunctionApplicationNode);
+      if (maybeTableGroupField) {
+        tables.push(maybeTableGroupField);
+      }
+    }
+
+    return {
+      name,
+      schemaName,
+      tables,
+      token: extractTokenForInterpreter(element),
+    };
+  }
+
+  private tableGroupField(field: FunctionApplicationNode): TableGroupField | undefined {
+    const maybeName = this.extractElementName(field.callee!);
+    if (!maybeName.isOk()) {
+      return undefined;
+    }
+    const { name, schemaName } = maybeName.unwrap();
+
+    return {
+      name,
+      schemaName,
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private note(
+    element: ElementDeclarationNode,
+  ): { value: string; token: TokenPosition } | undefined {
+    const content =
+      element.body instanceof BlockExpressionNode ?
+        extractQuotedStringToken(
+            ((element.body as BlockExpressionNode).body[0] as FunctionApplicationNode).callee,
+          ) :
+        extractQuotedStringToken((element.body as FunctionApplicationNode).callee);
+
+    return {
+      value: normalizeNoteContent(content.unwrap()),
+      token: extractTokenForInterpreter(element),
+    };
+  }
+
+  private indexes(element: ElementDeclarationNode): Index[] {
+    const res: Index[] = [];
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const sub of (element.body as BlockExpressionNode).body) {
+      const maybeIndexField = this.indexField(sub as FunctionApplicationNode);
+      if (maybeIndexField) {
+        res.push(maybeIndexField);
+      }
+    }
+
+    return res;
+  }
+
+  private indexField(field: FunctionApplicationNode): Index {
+    const args = [field.callee, ...field.args];
+
+    const { functional, nonFunctional } = destructureIndexNode(args[0]!).unwrap();
+    let pk: boolean | undefined;
+    let unique: boolean | undefined;
+    let name: string | undefined;
+    let note: string | undefined;
+    let noteNode: AttributeNode | undefined;
+    let type: string | undefined;
+    if (args.length === 2) {
+      const collector = collectAttribute(args[1] as ListExpressionNode, this.errors);
+      pk = collector.extractPk();
+      unique = collector.extractUnique();
+      name = collector.extractIdxName();
+      note = collector.extractNote();
+      noteNode = collector.settingMap.getAttributeNode('note') as AttributeNode | undefined;
+      type = collector.extractIndexType();
+    }
+
+    return {
+      columns: [
+        ...functional.map((s) => ({
+          value: s.value!.value,
+          type: 'expression',
+        })),
+        ...nonFunctional.map((s) => ({
+          value: extractVarNameFromPrimaryVariable(s).unwrap(),
+          type: 'column',
+        })),
+      ],
+      token: extractTokenForInterpreter(field),
+      type,
+      pk,
+      unique,
+      name,
+      note:
+        note === undefined ?
+          undefined :
+          {
+              value: note,
+              token: extractTokenForInterpreter(noteNode!),
+            },
+    };
+  }
+
+  private extractElementName(
+    nameNode: SyntaxNode,
+  ): Option<{ schemaName: string | null; name: string }> {
+    const fragments = destructureComplexVariable(nameNode).unwrap();
+    const name = fragments.pop()!;
+    const schemaName = fragments.pop();
+    if (fragments.length > 0) {
+      this.logError(
+        nameNode,
+        CompileErrorCode.UNSUPPORTED,
+        'Nested schemas are currently not allowed',
+      );
+
+      return new None();
+    }
+
+    return new Some({
+      name,
+      // eslint-disable-next-line no-unneeded-ternary
+      schemaName: schemaName ? schemaName : null,
+    });
+  }
+
+  private logIfUnequalFields(
+    node: SyntaxNode,
+    firstColumnSymbols: ColumnSymbol[],
+    secondColumnSymbols: ColumnSymbol[],
+  ): boolean {
+    if (firstColumnSymbols.length !== secondColumnSymbols.length) {
+      this.logError(node, CompileErrorCode.UNEQUAL_FIELDS_BINARY_REF, 'Two endpoints have unequal number of fields');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private logIfSameEndpoint(
+    node: SyntaxNode,
+    firstColumnSymbols: ColumnSymbol[],
+    secondColumnSymbols: ColumnSymbol[],
+  ): boolean {
+    if (isSameEndpoint(firstColumnSymbols, secondColumnSymbols)) {
+      this.logError(node, CompileErrorCode.SAME_ENDPOINT, 'Two endpoints are the same');
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private logIfCircularRefError(
+    node: SyntaxNode,
+    firstColumnSymbols: ColumnSymbol[],
+    secondColumnSymbols: ColumnSymbol[],
+  ): boolean {
+    if (isCircular(firstColumnSymbols, secondColumnSymbols, this.endpointPairSet)) {
+      this.logError(
+        node,
+        CompileErrorCode.UNSUPPORTED,
+        'Reference with the same endpoints already exists',
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private logError(node: SyntaxNode, code: CompileErrorCode, message: string) {
+    this.errors.push(new CompileError(code, message, node));
+  }
+}
+
+function tryPush<T>(element: T | undefined, list: T[]) {
+  if (element === undefined) {
+    return;
+  }
+
+  list.push(element);
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/types.ts
@@ -1,0 +1,154 @@
+import { Position } from '../types';
+
+export interface TokenPosition {
+  start: Position;
+  end: Position;
+}
+
+export interface Database {
+  schemas: [];
+  tables: Table[];
+  refs: Ref[];
+  enums: Enum[];
+  tableGroups: TableGroup[];
+  aliases: Alias[];
+  project: Project;
+}
+
+export interface Table {
+  name: string;
+  schemaName: null | string;
+  alias: string | null;
+  fields: Column[];
+  token: TokenPosition;
+  indexes: Index[];
+  headerColor?: string;
+  note?: {
+    value: string;
+    token: TokenPosition;
+  };
+}
+
+export interface ColumnType {
+  schemaName: string | null;
+  type_name: string;
+  args: string | null;
+}
+
+export interface Column {
+  name: string;
+  type: ColumnType;
+  token: TokenPosition;
+  inline_refs: InlineRef[];
+  pk?: boolean;
+  dbdefault?: {
+    type: 'number' | 'string' | 'boolean' | 'expression';
+    value: number | string;
+  };
+  increment?: boolean;
+  unique?: boolean;
+  not_null?: boolean;
+  note?: {
+    value: string;
+    token: TokenPosition;
+  };
+}
+
+export interface Index {
+  columns: {
+    value: string;
+    type: string;
+  }[];
+  token: TokenPosition;
+  unique?: boolean;
+  pk?: boolean;
+  name?: string;
+  note?: {
+    value: string;
+    token: TokenPosition;
+  };
+  type?: string;
+}
+
+export interface InlineRef {
+  schemaName: string | null;
+  tableName: string;
+  fieldNames: string[];
+  relation: '>' | '<' | '-' | '<>';
+  token: TokenPosition;
+}
+
+export interface Ref {
+  schemaName: string | null;
+  name: string | null;
+  endpoints: RefEndpointPair;
+  onDelete?: 'cascade' | 'no action' | 'restrict' | 'set default' | 'set null';
+  onUpdate?: 'cascade' | 'no action' | 'restrict' | 'set default' | 'set null';
+  token: TokenPosition;
+}
+
+export type RefEndpointPair = [RefEndpoint, RefEndpoint];
+
+export interface RefEndpoint {
+  schemaName: string | null;
+  tableName: string;
+  fieldNames: string[];
+  relation: RelationCardinality;
+  token: TokenPosition;
+}
+
+export type RelationCardinality = '1' | '*';
+
+export interface Enum {
+  name: string;
+  schemaName: string | null;
+  token: TokenPosition;
+  values: EnumField[];
+}
+
+export interface EnumField {
+  name: string;
+  token: TokenPosition;
+  note?: {
+    value: string;
+    token: TokenPosition;
+  };
+}
+
+export interface TableGroup {
+  name: string | null;
+  schemaName: string | null;
+  tables: TableGroupField[];
+  token: TokenPosition;
+}
+
+export interface TableGroupField {
+  name: string;
+  schemaName: string | null;
+}
+
+export interface Alias {
+  name: string;
+  kind: 'table';
+  value: {
+    tableName: string;
+    schemaName: string | null;
+  };
+}
+
+export type Project =
+  | Record<string, never>
+  | {
+      name: string | null;
+      tables: Table[];
+      refs: Ref[];
+      enums: Enum[];
+      tableGroups: TableGroup[];
+      note?: {
+        value: string;
+        token: TokenPosition;
+      },
+      [
+        index: string & Omit<any, 'name' | 'tables' | 'refs' | 'enums' | 'tableGroups' | 'note'>
+      ]: string;
+    };

--- a/packages/dbml-core/src/parse/dbml/src/lib/interpreter/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/interpreter/utils.ts
@@ -1,0 +1,119 @@
+import _ from 'lodash';
+import { None, Option, Some } from '../option';
+import { ColumnSymbol } from '../analyzer/symbol/symbols';
+import {
+  destructureComplexTuple,
+  destructureMemberAccessExpression,
+} from '../analyzer/utils';
+import { CompileError, CompileErrorCode } from '../errors';
+import { SyntaxNode, TupleExpressionNode } from '../parser/nodes';
+import { RelationCardinality, TokenPosition } from './types';
+
+export function isCircular(
+  firstColumnSymbols: ColumnSymbol[],
+  secondColumnSymbols: ColumnSymbol[],
+  endpointPairSet: Set<string>,
+): boolean {
+  const firstIds = firstColumnSymbols.map((s) => s.id);
+  const secondIds = secondColumnSymbols.map((s) => s.id);
+
+  const endpointPairId =
+    firstIds[0] < secondIds[0] ?
+      `${firstIds.join(',')}_${secondIds.join(',')}` :
+      `${secondIds.join(',')}_${firstIds.join(',')}`;
+  if (endpointPairSet.has(endpointPairId)) {
+    return true;
+  }
+  endpointPairSet.add(endpointPairId);
+
+  return false;
+}
+
+export function isSameEndpoint(
+  firstColumnSymbols: ColumnSymbol[],
+  secondColumnSymbols: ColumnSymbol[],
+): boolean {
+  return _.zip(firstColumnSymbols, secondColumnSymbols).every(([f, s]) => f?.id === s?.id);
+}
+
+export function convertRelationOpToCardinalities(
+  op: string,
+): [RelationCardinality, RelationCardinality] {
+  switch (op) {
+    case '<':
+      return ['1', '*'];
+    case '<>':
+      return ['*', '*'];
+    case '>':
+      return ['*', '1'];
+    case '-':
+      return ['1', '1'];
+  }
+  throw new Error('Invalid relation op');
+}
+
+export function processRelOperand(
+  operand: SyntaxNode,
+  ownerTableName: string | null,
+  ownerSchemaName: string | null,
+):
+  | {
+      columnNames: string[];
+      tableName: string;
+      schemaName: string | null;
+    }
+  | CompileError {
+  const { tupleElements, variables } = destructureComplexTuple(operand).unwrap();
+  const columnNames = tupleElements || [variables.pop()!];
+  const tableName = variables.pop();
+  const schemaName = variables.pop();
+  if (variables.length > 0) {
+    return new CompileError(
+      CompileErrorCode.UNSUPPORTED,
+      'Nested schemas are currently not allowed',
+      operand,
+    );
+  }
+
+  if (tableName === undefined && ownerTableName === null) {
+    throw new Error("A rel operand's table name must be defined");
+  }
+
+  return {
+    columnNames,
+    // if tableName is undefined, the columnName must be relative to the owner
+    tableName: tableName || (ownerTableName as string),
+    schemaName: tableName ? schemaName || null : ownerSchemaName,
+  };
+}
+
+export function extractTokenForInterpreter(node: SyntaxNode): TokenPosition {
+  return {
+    start: {
+      offset: node.startPos.offset,
+      line: node.startPos.line + 1,
+      column: node.startPos.column + 1,
+    },
+    end: { offset: node.endPos.offset, line: node.endPos.line + 1, column: node.endPos.column + 1 },
+  };
+}
+
+export function getColumnSymbolsOfRefOperand(ref: SyntaxNode): Option<ColumnSymbol[]> {
+  const colNode = destructureMemberAccessExpression(ref).unwrap_or(undefined)?.pop();
+  if (colNode instanceof TupleExpressionNode) {
+    if (!colNode.elementList.every((e) => !!e.referee)) {
+      return new None();
+    }
+
+    return new Some(colNode.elementList.map((e) => e.referee as ColumnSymbol));
+  }
+  if (!(colNode?.referee instanceof ColumnSymbol)) {
+    return new None();
+  }
+
+  return new Some([colNode.referee]);
+}
+
+export function normalizeNoteContent(content: string): string {
+  return content.split('\n').map((s) => s.trim()).join('\n');
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/lexer/lexer.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/lexer/lexer.ts
@@ -1,0 +1,465 @@
+import { CompileError, CompileErrorCode } from '../errors';
+import Report from '../report';
+import { isAlphaOrUnderscore, isAlphaNumeric, isDigit } from '../utils';
+import {
+ SyntaxToken, SyntaxTokenKind, isOp, isTriviaToken,
+} from './tokens';
+import { Position } from '../types';
+import { isInvalidToken } from '../parser/utils';
+
+export default class Lexer {
+  private start: Position = {
+    offset: 0,
+    line: 0,
+    column: 0,
+  };
+
+  private current: Position = {
+    offset: 0,
+    line: 0,
+    column: 0,
+  };
+
+  private text: string;
+
+  private tokens: SyntaxToken[] = []; // list of lexed tokens, not including invalid tokens
+
+  private errors: CompileError[] = []; // list of errors during lexing
+
+  constructor(text: string) {
+    this.text = text;
+  }
+
+  private isAtEnd(): boolean {
+    return this.current.offset >= this.text.length;
+  }
+
+  private advance(): string {
+    const c = this.peek();
+    this.current = { ...this.current };
+    if (c === '\n') {
+      this.current.line += 1;
+      this.current.column = 0;
+    } else {
+      this.current.column += 1;
+    }
+    this.current.offset += 1;
+
+    return c!;
+  }
+
+  private peek(lookahead: number = 0): string | undefined {
+    if (this.current.offset + lookahead >= this.text.length) {
+      return undefined;
+    }
+
+    return this.text[this.current.offset + lookahead];
+  }
+
+  // Check if the sequence ahead matches `sequence`
+  check(sequence: string): boolean {
+    for (let i = 0; i < sequence.length; i += 1) {
+      if (sequence[i] !== this.peek(i)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // If the sequence ahead matches `sequence`, move `current` past `sequence`
+  match(sequence: string): boolean {
+    if (!this.check(sequence)) {
+      return false;
+    }
+
+    sequence.split('').forEach(() => this.advance());
+
+    return true;
+  }
+
+  private addToken(kind: SyntaxTokenKind, isInvalid: boolean = false) {
+    this.tokens.push(this.createToken(kind, isInvalid));
+  }
+
+  private createToken(kind: SyntaxTokenKind, isInvalid: boolean = false): SyntaxToken {
+    return SyntaxToken.create(
+      kind,
+      this.start,
+      this.current,
+      this.text.substring(this.start.offset, this.current.offset),
+      isInvalid,
+    );
+  }
+
+  lex(): Report<SyntaxToken[], CompileError> {
+    this.scanTokens();
+    this.tokens.push(SyntaxToken.create(SyntaxTokenKind.EOF, this.start, this.current, '', false));
+    this.gatherTrivia();
+    this.gatherInvalid();
+
+    return new Report(this.tokens, this.errors);
+  }
+
+  scanTokens() {
+    while (!this.isAtEnd()) {
+      const c = this.advance();
+      switch (c) {
+        case ' ':
+          this.addToken(SyntaxTokenKind.SPACE);
+          break;
+        case '\r':
+          break;
+        case '\n':
+          this.addToken(SyntaxTokenKind.NEWLINE);
+          break;
+        case '\t':
+          this.addToken(SyntaxTokenKind.TAB);
+          break;
+        case ',':
+          this.addToken(SyntaxTokenKind.COMMA);
+          break;
+        case '(':
+          this.addToken(SyntaxTokenKind.LPAREN);
+          break;
+        case ')':
+          this.addToken(SyntaxTokenKind.RPAREN);
+          break;
+        case '[':
+          this.addToken(SyntaxTokenKind.LBRACKET);
+          break;
+        case ']':
+          this.addToken(SyntaxTokenKind.RBRACKET);
+          break;
+        case '{':
+          this.addToken(SyntaxTokenKind.LBRACE);
+          break;
+        case '}':
+          this.addToken(SyntaxTokenKind.RBRACE);
+          break;
+        case ';':
+          this.addToken(SyntaxTokenKind.SEMICOLON);
+          break;
+        case ':':
+          this.addToken(SyntaxTokenKind.COLON);
+          break;
+        case "'":
+          if (this.match("''")) {
+            this.multilineStringLiteral();
+          } else {
+            this.singleLineStringLiteral();
+          }
+          break;
+        case '"':
+          this.quotedVariable();
+          break;
+        case '`':
+          this.functionExpression();
+          break;
+        case '#':
+          this.colorLiteral();
+          break;
+        case '/':
+          if (this.match('/')) {
+            this.singleLineComment();
+          } else if (this.match('*')) {
+            this.multilineComment();
+          } else {
+            this.operator();
+          }
+          break;
+        default:
+          if (isOp(c)) {
+            this.operator();
+            break;
+          }
+          if (isAlphaOrUnderscore(c)) {
+            this.identifier();
+            break;
+          }
+          if (isDigit(c)) {
+            this.numericLiteral();
+            break;
+          }
+          this.addToken(SyntaxTokenKind.OP, true);
+          this.errors.push(
+            new CompileError(
+              CompileErrorCode.UNKNOWN_SYMBOL,
+              `Unexpected token '${c}'`,
+              this.createToken(SyntaxTokenKind.OP, true),
+            ),
+          );
+          break;
+      }
+      this.start = { ...this.current };
+    }
+  }
+
+  gatherTrivia() {
+    let startOfLine = true;
+    let triviaList: SyntaxToken[] = [];
+    let lastNonTrivia: SyntaxToken | undefined;
+    const newTokenList: SyntaxToken[] = [];
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const token of this.tokens) {
+      if (isTriviaToken(token)) {
+        triviaList.push(token);
+        // If a newline token is encountered and there are any non-trivias in the line,
+        // then `triviaList` belongs to its `trailingTrivia`
+        if (token.kind === SyntaxTokenKind.NEWLINE && lastNonTrivia) {
+          lastNonTrivia.trailingTrivia = triviaList;
+          startOfLine = true;
+          lastNonTrivia = undefined;
+          triviaList = [];
+        }
+      } else {
+        // The first non-trivia is encountered
+
+        // If at start of line
+        // then `triviaList` belongs to that non-trivia as `leadingTrivia`
+        // eslint-disable-next-line no-unused-expressions
+        startOfLine ?
+          (token.leadingTrivia = triviaList) :
+          (lastNonTrivia!.trailingTrivia = triviaList);
+        newTokenList.push(token);
+        triviaList = [];
+        lastNonTrivia = token;
+        startOfLine = false;
+      }
+    }
+
+    this.tokens = newTokenList;
+  }
+
+  gatherInvalid() {
+    let i;
+    const newTokenList: SyntaxToken[] = [];
+
+    const leadingInvalidList: SyntaxToken[] = [];
+    for (i = 0; i < this.tokens.length && isInvalidToken(this.tokens[i]); i += 1) {
+      leadingInvalidList.push(this.tokens[i]);
+    }
+
+    let prevValidToken = this.tokens[i];
+    prevValidToken.leadingInvalid = [...leadingInvalidList, ...prevValidToken.leadingInvalid];
+
+    for (; i < this.tokens.length; i += 1) {
+      const token = this.tokens[i];
+      if (token.isInvalid) {
+        prevValidToken.trailingInvalid.push(token);
+      } else {
+        prevValidToken = token;
+        newTokenList.push(token);
+      }
+    }
+
+    this.tokens = newTokenList;
+  }
+
+  // Consuming characters until the `stopSequence` is encountered
+  consumeUntil(
+    tokenKind: SyntaxTokenKind,
+    stopSequence: string,
+    {
+      allowNewline, // Whether newline is allowed
+      allowEof, // Whether EOF is allowed
+      raw, // Whether to interpret '\' as a backlash
+      consumeStopSequence = true,
+    }: { allowNewline: boolean; allowEof: boolean; raw: boolean; consumeStopSequence?: boolean },
+  ) {
+    let string = '';
+
+    while (!this.isAtEnd() && (allowNewline || !this.check('\n')) && !this.check(stopSequence)) {
+      if (this.peek() === '\\' && !raw) {
+        this.advance();
+        string += this.escapedString();
+      } else {
+        string += this.advance();
+      }
+    }
+
+    if (this.isAtEnd() && !allowEof) {
+      const token = this.createToken(tokenKind, true);
+      this.tokens.push(token);
+      this.errors.push(
+        new CompileError(CompileErrorCode.UNEXPECTED_EOF, 'EOF reached while parsing', token),
+      );
+
+      return;
+    }
+
+    if (this.check('\n') && !allowNewline) {
+      const token = this.createToken(tokenKind, true);
+      this.tokens.push(token);
+      this.errors.push(
+        new CompileError(
+          CompileErrorCode.UNEXPECTED_NEWLINE,
+          'Invalid newline encountered while parsing',
+          token,
+        ),
+      );
+
+      return;
+    }
+
+    if (consumeStopSequence) {
+      this.match(stopSequence);
+    }
+    this.tokens.push(SyntaxToken.create(tokenKind, this.start, this.current, string, false));
+  }
+
+  singleLineStringLiteral() {
+    this.consumeUntil(SyntaxTokenKind.STRING_LITERAL, "'", {
+      allowNewline: false,
+      allowEof: false,
+      raw: false,
+    });
+  }
+
+  multilineStringLiteral() {
+    this.consumeUntil(SyntaxTokenKind.STRING_LITERAL, "'''", {
+      allowNewline: true,
+      allowEof: false,
+      raw: false,
+    });
+  }
+
+  functionExpression() {
+    this.consumeUntil(SyntaxTokenKind.FUNCTION_EXPRESSION, '`', {
+      allowNewline: false,
+      allowEof: false,
+      raw: true,
+    });
+  }
+
+  quotedVariable() {
+    this.consumeUntil(SyntaxTokenKind.QUOTED_STRING, '"', {
+      allowNewline: false,
+      allowEof: false,
+      raw: false,
+    });
+  }
+
+  singleLineComment() {
+    this.consumeUntil(SyntaxTokenKind.SINGLE_LINE_COMMENT, '\n', {
+      allowNewline: true,
+      allowEof: true,
+      raw: true,
+      consumeStopSequence: false,
+    });
+  }
+
+  multilineComment() {
+    this.consumeUntil(SyntaxTokenKind.MULTILINE_COMMENT, '*/', {
+      allowNewline: true,
+      allowEof: false,
+      raw: true,
+    });
+  }
+
+  identifier() {
+    while (!this.isAtEnd() && isAlphaNumeric(this.peek()!)) {
+      this.advance();
+    }
+    this.addToken(SyntaxTokenKind.IDENTIFIER);
+  }
+
+  operator() {
+    while (isOp(this.peek())) {
+      this.advance();
+    }
+    this.addToken(SyntaxTokenKind.OP);
+  }
+
+  numericLiteral() {
+    let nDots = 0;
+    if (this.isAtEnd()) {
+      return this.addToken(SyntaxTokenKind.NUMERIC_LITERAL);
+    }
+    while (!this.isAtEnd()) {
+      const isDot = this.check('.');
+      nDots += isDot ? 1 : 0;
+      if (nDots > 1) {
+        break;
+      }
+
+      // The first way to return a numeric literal without error:
+      // a digit is encountered as the last character
+      if (!isDot && this.current.offset === this.text.length - 1) {
+        this.advance();
+
+        return this.addToken(SyntaxTokenKind.NUMERIC_LITERAL);
+      }
+
+      // The second way to return a numeric literal without error:
+      // a non alpha-numeric and non-dot character is encountered
+      if (!isDot && !isAlphaNumeric(this.peek()!)) {
+        return this.addToken(SyntaxTokenKind.NUMERIC_LITERAL);
+      }
+
+      if (!isDot && !isDigit(this.peek()!)) {
+        break;
+      }
+
+      this.advance();
+    }
+    // if control reaches here, an invalid number has been encountered
+    // consume all alphanumeric characters or . of the invalid number
+    while (!this.isAtEnd() && (this.check('.') || isAlphaNumeric(this.peek()!))) {
+      this.advance();
+    }
+
+    const token = this.createToken(SyntaxTokenKind.NUMERIC_LITERAL, true);
+    this.tokens.push(token);
+    this.errors.push(new CompileError(CompileErrorCode.UNKNOWN_TOKEN, 'Invalid number', token));
+  }
+
+  colorLiteral() {
+    while (!this.isAtEnd() && isAlphaNumeric(this.peek()!)) {
+      this.advance();
+    }
+    this.addToken(SyntaxTokenKind.COLOR_LITERAL);
+  }
+
+  escapedString(): string {
+    if (this.isAtEnd()) {
+      return '\\';
+    }
+    switch (this.advance()) {
+      case 't':
+        return '\t';
+      case 'n':
+        return '\n';
+      case '\\':
+        return '\\';
+      case 'r':
+        return '\r';
+      case "'":
+        return "'";
+      case '"':
+        return '"';
+      case '0':
+        return '\0';
+      case 'b':
+        return '\b';
+      case 'v':
+        return '\v';
+      case 'f':
+        return '\f';
+      case 'u': {
+        let hex = '';
+        for (let i = 0; i <= 3; i += 1) {
+          if (this.isAtEnd() || !isAlphaNumeric(this.peek()!)) {
+            return `\\u${hex}`;
+          }
+          hex += this.advance();
+        }
+
+        return String.fromCharCode(parseInt(hex, 16));
+      }
+      default:
+        return `\\${this.tokens[this.current.offset - 1]}`;
+    }
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/lexer/tokens.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/lexer/tokens.ts
@@ -1,0 +1,129 @@
+import { Position } from '../types';
+
+export enum SyntaxTokenKind {
+  SPACE = '<space>',
+  TAB = '<tab>',
+  NEWLINE = '<newline>',
+
+  COMMA = '<comma>',
+  LPAREN = '<lparen>',
+  RPAREN = '<rparen>',
+  LBRACE = '<lbrace>',
+  RBRACE = '<rbrace>',
+  LBRACKET = '<lbracket>',
+  RBRACKET = '<rbracket>',
+  LANGLE = '<langle>',
+  RANGLE = '<rangle>',
+
+  OP = '<op>',
+  EOF = '<eof>',
+  NUMERIC_LITERAL = '<number>',
+  STRING_LITERAL = '<string>',
+  COLOR_LITERAL = '<color>',
+  FUNCTION_EXPRESSION = '<function-expression>',
+
+  QUOTED_STRING = '<variable>',
+  IDENTIFIER = '<identifier>',
+
+  SEMICOLON = '<semicolon>',
+  COLON = '<colon>',
+
+  SINGLE_LINE_COMMENT = '<single-line-comment>',
+  MULTILINE_COMMENT = '<multiline-comment>',
+}
+
+export function isTriviaToken(token: SyntaxToken): boolean {
+  switch (token.kind) {
+    case SyntaxTokenKind.NEWLINE:
+    case SyntaxTokenKind.SPACE:
+    case SyntaxTokenKind.TAB:
+    case SyntaxTokenKind.SINGLE_LINE_COMMENT:
+    case SyntaxTokenKind.MULTILINE_COMMENT:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isOp(c?: string): boolean {
+  if (!c) {
+    return false;
+  }
+
+  switch (c) {
+    case '+':
+    case '-':
+    case '*':
+    case '/':
+    case '%':
+    case '<':
+    case '>':
+    case '=':
+    case '!':
+    case '.':
+    case '&':
+    case '|':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isOpToken(token?: SyntaxToken): boolean {
+  return token !== undefined && token.kind === SyntaxTokenKind.OP;
+}
+
+export class SyntaxToken {
+  kind: SyntaxTokenKind;
+
+  value: string;
+
+  leadingTrivia: SyntaxToken[];
+
+  trailingTrivia: SyntaxToken[];
+
+  leadingInvalid: SyntaxToken[];
+
+  trailingInvalid: SyntaxToken[];
+
+  startPos: Readonly<Position>;
+
+  start: Readonly<number>;
+
+  endPos: Readonly<Position>;
+
+  end: Readonly<number>;
+
+  isInvalid: boolean;
+
+  protected constructor(
+    kind: SyntaxTokenKind,
+    startPos: Position,
+    endPos: Position,
+    value: string,
+    isInvalid: boolean,
+  ) {
+    this.kind = kind;
+    this.startPos = startPos;
+    this.endPos = endPos;
+    this.value = value;
+    this.leadingTrivia = [];
+    this.trailingTrivia = [];
+    this.leadingInvalid = [];
+    this.trailingInvalid = [];
+    this.isInvalid = isInvalid;
+
+    this.start = startPos.offset;
+    this.end = endPos.offset;
+  }
+
+  static create(
+    kind: SyntaxTokenKind,
+    startPos: Position,
+    endPos: Position,
+    value: string,
+    isInvalid: boolean,
+  ) {
+    return new SyntaxToken(kind, startPos, endPos, value, isInvalid);
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/lexer/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/lexer/utils.ts
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import { SyntaxToken, SyntaxTokenKind } from './tokens';
+
+export function hasTrailingNewLines(token: SyntaxToken): boolean {
+  return token.trailingTrivia.find(({ kind }) => kind === SyntaxTokenKind.NEWLINE) !== undefined;
+}
+
+export function isAtStartOfLine(previous: SyntaxToken, token: SyntaxToken): boolean {
+  const hasLeadingNewLines =
+    token.leadingTrivia.find(({ kind }) => kind === SyntaxTokenKind.NEWLINE) !== undefined;
+
+  return hasLeadingNewLines || hasTrailingNewLines(previous);
+}
+
+export function hasTrailingSpaces(token: SyntaxToken): boolean {
+  return token.trailingTrivia.find(({ kind }) => kind === SyntaxTokenKind.SPACE) !== undefined;
+}
+
+export function getTokenFullEnd(token: SyntaxToken): number {
+  return token.trailingTrivia.length === 0 ?
+    token.end :
+    getTokenFullEnd(_.last(token.trailingTrivia)!);
+}
+
+export function getTokenFullStart(token: SyntaxToken): number {
+  return token.leadingTrivia.length === 0 ? token.start : getTokenFullStart(token.leadingTrivia[0]);
+}
+
+export function isComment(token: SyntaxToken): boolean {
+  return [SyntaxTokenKind.SINGLE_LINE_COMMENT, SyntaxTokenKind.MULTILINE_COMMENT].includes(
+    token.kind,
+  );
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/option.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/option.ts
@@ -1,0 +1,58 @@
+export type Option<T> = Some<T> | None<T>;
+
+export class Some<T> {
+  value: T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
+
+  unwrap(): T {
+    return this.value;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  unwrap_or<S>(orValue: S): S | T {
+    return this.value;
+  }
+
+  and_then<S>(callback: (_: T) => Option<S>): Option<S> {
+    return callback(this.value);
+  }
+
+  map<S>(callback: (_: T) => S): Option<S> {
+    return new Some(callback(this.value));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  isOk(): boolean {
+    return true;
+  }
+}
+
+export class None<T> {
+  // eslint-disable-next-line class-methods-use-this
+  unwrap(): T {
+    throw new Error('Trying to unwrap a None value');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  unwrap_or<S>(orValue: S): S | T {
+    return orValue;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
+  and_then<S>(callback: (_: T) => Option<S>): Option<S> {
+    return new None();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
+  map<S>(callback: (_: T) => S): Option<S> {
+    return new None();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  isOk(): boolean {
+    return false;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/contextStack.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/contextStack.ts
@@ -1,0 +1,124 @@
+import _ from 'lodash';
+import { SyntaxToken, SyntaxTokenKind } from '../lexer/tokens';
+
+export const enum ParsingContext {
+  ListExpression,
+  GroupExpression,
+  BlockExpression,
+}
+
+export class ParsingContextStack {
+  private stack: ParsingContext[] = [];
+
+  private numberOfNestedLParens = 0;
+
+  private numberOfNestedLBrackets = 0;
+
+  private numberOfNestedLBraces = 0;
+
+  push(ctx: ParsingContext) {
+    this.stack.push(ctx);
+    if (ctx === ParsingContext.ListExpression) {
+      this.numberOfNestedLBrackets += 1;
+    }
+    if (ctx === ParsingContext.GroupExpression) {
+      this.numberOfNestedLParens += 1;
+    }
+    if (ctx === ParsingContext.BlockExpression) {
+      this.numberOfNestedLBraces += 1;
+    }
+  }
+
+  pop(): ParsingContext | undefined {
+    const top = this.stack.pop();
+    if (top === ParsingContext.ListExpression) {
+      this.numberOfNestedLBrackets -= 1;
+    }
+    if (top === ParsingContext.GroupExpression) {
+      this.numberOfNestedLParens -= 1;
+    }
+    if (top === ParsingContext.BlockExpression) {
+      this.numberOfNestedLBraces -= 1;
+    }
+
+    return top;
+  }
+
+  top(): ParsingContext | undefined {
+    return _.last(this.stack);
+  }
+
+  isWithinGroupExpressionContext(): boolean {
+    return this.numberOfNestedLParens > 0;
+  }
+
+  isWithinListExpressionContext(): boolean {
+    return this.numberOfNestedLBrackets > 0;
+  }
+
+  isWithinBlockExpressionContext(): boolean {
+    return this.numberOfNestedLBraces > 0;
+  }
+
+  // Call the passed in callback
+  // with the guarantee that the passed in context will be pushed and popped properly
+  // even in cases of exceptions
+  withContextDo<T>(context: ParsingContext, callback: () => T): () => T {
+    return () => {
+      this.push(context);
+
+      try {
+        const res = callback();
+
+        return res;
+      } finally {
+        this.pop();
+      }
+    };
+  }
+
+  // Return the type of the handler context currently in the context stack to handle `token`
+  findHandlerContext(tokens: SyntaxToken[], curTokenId: number): ParsingContext | null {
+    if (
+      this.numberOfNestedLBraces <= 0 &&
+      this.numberOfNestedLBrackets <= 0 &&
+      this.numberOfNestedLParens <= 0
+    ) {
+      return null;
+    }
+
+    for (let tokenId = curTokenId; tokenId < tokens.length - 1; tokenId += 1) {
+      const token = tokens[tokenId];
+      switch (token.kind) {
+        case SyntaxTokenKind.COMMA:
+          if (this.isWithinGroupExpressionContext() || this.isWithinListExpressionContext()) {
+            return [...this.stack]
+              .reverse()
+              .find((c) =>
+                [ParsingContext.GroupExpression, ParsingContext.ListExpression].includes(c),
+              )!;
+          }
+          break;
+        case SyntaxTokenKind.RPAREN:
+          if (this.isWithinGroupExpressionContext()) {
+            return ParsingContext.GroupExpression;
+          }
+          break;
+        case SyntaxTokenKind.RBRACE:
+          if (this.isWithinBlockExpressionContext()) {
+            return ParsingContext.BlockExpression;
+          }
+          break;
+        case SyntaxTokenKind.RBRACKET:
+          if (this.isWithinListExpressionContext()) {
+            return ParsingContext.ListExpression;
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/factory.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/factory.ts
@@ -1,0 +1,13 @@
+import { SyntaxNode, SyntaxNodeId, SyntaxNodeIdGenerator } from './nodes';
+
+export default class NodeFactory {
+  private generator: SyntaxNodeIdGenerator;
+
+  constructor(generator: SyntaxNodeIdGenerator) {
+    this.generator = generator;
+  }
+
+  create<T extends SyntaxNode, A>(Type: { new (args: A, id: SyntaxNodeId): T }, args: A): T {
+    return new Type(args, this.generator.nextId());
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/nodes.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/nodes.ts
@@ -1,0 +1,505 @@
+import _ from 'lodash';
+import { SyntaxToken } from '../lexer/tokens';
+import { NodeSymbol } from '../analyzer/symbol/symbols';
+import { Position } from '../types';
+import { getTokenFullEnd, getTokenFullStart } from '../lexer/utils';
+
+export type SyntaxNodeId = number;
+export class SyntaxNodeIdGenerator {
+  private id = 0;
+
+  reset() {
+    this.id = 0;
+  }
+
+  nextId(): SyntaxNodeId {
+    // eslint-disable-next-line no-plusplus
+    return this.id++;
+  }
+}
+
+export class SyntaxNode {
+  id: Readonly<SyntaxNodeId>;
+  kind: SyntaxNodeKind;
+  startPos: Readonly<Position>;
+  start: Readonly<number>;
+  fullStart: Readonly<number>; // Start offset with trivias counted
+  endPos: Readonly<Position>;
+  end: Readonly<number>;
+  fullEnd: Readonly<number>; // End offset with trivias counted
+  symbol?: NodeSymbol;
+  referee?: NodeSymbol; // The symbol that this syntax node refers to
+  parent?: ElementDeclarationNode | ProgramNode; // The enclosing element/program
+
+  // args must be passed in order of appearance in the node
+  constructor(
+    id: SyntaxNodeId,
+    kind: SyntaxNodeKind,
+    args: Readonly<SyntaxToken | SyntaxNode | undefined>[],
+  ) {
+    this.id = id;
+    this.kind = kind;
+
+    const firstValid = args.find((sub) => sub !== undefined && !Number.isNaN(sub.start));
+    if (!firstValid) {
+      this.startPos = {
+        offset: NaN,
+        column: NaN,
+        line: NaN,
+      };
+      this.fullStart = NaN;
+    } else {
+      this.startPos = firstValid.startPos;
+      this.fullStart =
+        firstValid instanceof SyntaxToken ?
+          getTokenFullStart(firstValid) :
+          (firstValid as SyntaxNode).fullStart;
+    }
+
+    const lastValid = [...args]
+      .reverse()
+      .find((sub) => sub !== undefined && !Number.isNaN(sub.end));
+    if (!lastValid) {
+      this.endPos = {
+        offset: NaN,
+        column: NaN,
+        line: NaN,
+      };
+      this.fullEnd = NaN;
+    } else {
+      this.endPos = lastValid.endPos;
+      this.fullEnd =
+        lastValid instanceof SyntaxToken ?
+          getTokenFullEnd(lastValid) :
+          (lastValid as SyntaxNode).fullEnd;
+    }
+
+    this.start = this.startPos.offset;
+    this.end = this.endPos.offset;
+  }
+}
+
+export enum SyntaxNodeKind {
+  PROGRAM = '<program>',
+  ELEMENT_DECLARATION = '<element-declaration>',
+  ATTRIBUTE = '<attribute>',
+  // A node that represents a contiguous stream of identifiers
+  // Attribute name or value may use this
+  // e.g [primary key] -> 'primary' 'key'
+  // e.g [update: no action] -> 'no' 'action'
+  IDENTIFIER_STREAM = '<identifer-stream>',
+
+  LITERAL = '<literal>',
+  VARIABLE = '<variable>',
+  PREFIX_EXPRESSION = '<prefix-expression>',
+  INFIX_EXPRESSION = '<infix-expression>',
+  POSTFIX_EXPRESSION = '<postfix-expression>',
+  FUNCTION_EXPRESSION = '<function-expression>',
+  FUNCTION_APPLICATION = '<function-application>',
+  BLOCK_EXPRESSION = '<block-expression>',
+  LIST_EXPRESSION = '<list-expression>',
+  TUPLE_EXPRESSION = '<tuple-expression>',
+  CALL_EXPRESSION = '<call-expression>',
+  PRIMARY_EXPRESSION = '<primary-expression>',
+  GROUP_EXPRESSION = '<group-expression>',
+}
+
+export class ProgramNode extends SyntaxNode {
+  body: ElementDeclarationNode[];
+
+  eof?: SyntaxToken;
+
+  constructor(
+    { body = [], eof }: { body?: ElementDeclarationNode[]; eof?: SyntaxToken },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.PROGRAM, [...body, eof]);
+    this.body = body;
+    this.eof = eof;
+  }
+}
+
+export class ElementDeclarationNode extends SyntaxNode {
+  type?: SyntaxToken;
+
+  name?: NormalExpressionNode;
+
+  as?: SyntaxToken;
+
+  alias?: NormalExpressionNode;
+
+  attributeList?: ListExpressionNode;
+
+  bodyColon?: SyntaxToken;
+
+  // if simple body, `body` must be a FunctionApplicationNode or ElementDeclarationNode
+  body?: FunctionApplicationNode | ElementDeclarationNode | BlockExpressionNode;
+
+  constructor(
+    {
+      type,
+      name,
+      as,
+      alias,
+      attributeList,
+      bodyColon,
+      body,
+    }: {
+      type?: SyntaxToken;
+      name?: NormalExpressionNode;
+      as?: SyntaxToken;
+      alias?: NormalExpressionNode;
+      attributeList?: ListExpressionNode;
+      bodyColon?: SyntaxToken;
+      body?: BlockExpressionNode | FunctionApplicationNode | ElementDeclarationNode;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.ELEMENT_DECLARATION, [
+      type,
+      name,
+      as,
+      alias,
+      attributeList,
+      bodyColon,
+      body,
+    ]);
+
+    if (
+      bodyColon &&
+      !(body instanceof FunctionApplicationNode || body instanceof ElementDeclarationNode)
+    ) {
+      throw new Error('If an element has a simple body, it must be a function application node');
+    }
+
+    this.type = type;
+    this.name = name;
+    this.as = as;
+    this.alias = alias;
+    this.attributeList = attributeList;
+    this.bodyColon = bodyColon;
+    this.body = body;
+  }
+}
+
+export class IdentiferStreamNode extends SyntaxNode {
+  identifiers: SyntaxToken[];
+
+  constructor({ identifiers = [] }: { identifiers?: SyntaxToken[] }, id: SyntaxNodeId) {
+    super(id, SyntaxNodeKind.IDENTIFIER_STREAM, identifiers || []);
+    this.identifiers = identifiers;
+  }
+}
+
+export class AttributeNode extends SyntaxNode {
+  name?: IdentiferStreamNode;
+
+  colon?: SyntaxToken;
+
+  value?: NormalExpressionNode | IdentiferStreamNode;
+
+  constructor(
+    {
+      name,
+      colon,
+      value,
+    }: {
+      name?: IdentiferStreamNode;
+      colon?: SyntaxToken;
+      value?: NormalExpressionNode | IdentiferStreamNode;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.ATTRIBUTE, [name, colon, value]);
+    this.name = name;
+    this.value = value;
+    this.colon = colon;
+  }
+}
+
+// A normal form expression is the regular expression we encounter in most programming languages
+// ex. 1 + 2, 1 * 2, (1 / 3) - 4, a.b
+// Function application and literal element expressions are not considered one
+export type NormalExpressionNode =
+  | PrefixExpressionNode
+  | InfixExpressionNode
+  | PostfixExpressionNode
+  | BlockExpressionNode
+  | ListExpressionNode
+  | TupleExpressionNode
+  | CallExpressionNode
+  | PrimaryExpressionNode
+  | FunctionExpressionNode;
+
+export type ExpressionNode =
+  | ElementDeclarationNode
+  | NormalExpressionNode
+  | FunctionApplicationNode;
+
+export class PrefixExpressionNode extends SyntaxNode {
+  op?: SyntaxToken;
+
+  expression?: NormalExpressionNode;
+
+  constructor(
+    { op, expression }: { op?: SyntaxToken; expression?: NormalExpressionNode },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.PREFIX_EXPRESSION, [op, expression]);
+    this.op = op;
+    this.expression = expression;
+  }
+}
+
+export class InfixExpressionNode extends SyntaxNode {
+  op?: SyntaxToken;
+
+  leftExpression?: NormalExpressionNode;
+
+  rightExpression?: NormalExpressionNode;
+
+  constructor(
+    {
+      op,
+      leftExpression,
+      rightExpression,
+    }: {
+      op?: SyntaxToken;
+      leftExpression?: NormalExpressionNode;
+      rightExpression?: NormalExpressionNode;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.INFIX_EXPRESSION, [leftExpression, op, rightExpression]);
+    this.op = op;
+    this.leftExpression = leftExpression;
+    this.rightExpression = rightExpression;
+  }
+}
+
+export class PostfixExpressionNode extends SyntaxNode {
+  op?: SyntaxToken;
+
+  expression?: NormalExpressionNode;
+
+  constructor(
+    { op, expression }: { op?: SyntaxToken; expression?: NormalExpressionNode },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.POSTFIX_EXPRESSION, [expression, op]);
+    this.op = op;
+    this.expression = expression;
+  }
+}
+
+export class FunctionExpressionNode extends SyntaxNode {
+  value?: SyntaxToken;
+
+  constructor({ value }: { value?: SyntaxToken }, id: SyntaxNodeId) {
+    super(id, SyntaxNodeKind.FUNCTION_EXPRESSION, [value]);
+    this.value = value;
+  }
+}
+
+export class FunctionApplicationNode extends SyntaxNode {
+  callee?: ExpressionNode;
+
+  args: ExpressionNode[];
+
+  constructor(
+    { callee, args = [] }: { callee?: ExpressionNode; args?: ExpressionNode[] },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.FUNCTION_APPLICATION, [callee, ...args]);
+    this.callee = callee;
+    this.args = args;
+  }
+}
+
+export class BlockExpressionNode extends SyntaxNode {
+  blockOpenBrace?: SyntaxToken;
+
+  body: (ElementDeclarationNode | FunctionApplicationNode)[];
+
+  blockCloseBrace?: SyntaxToken;
+
+  constructor(
+    {
+      blockOpenBrace,
+      body = [],
+      blockCloseBrace,
+    }: {
+      blockOpenBrace?: SyntaxToken;
+      body?: (ElementDeclarationNode | FunctionApplicationNode)[];
+      blockCloseBrace?: SyntaxToken;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.BLOCK_EXPRESSION, [blockOpenBrace, ...body, blockCloseBrace]);
+    this.blockOpenBrace = blockOpenBrace;
+    this.body = body;
+    this.blockCloseBrace = blockCloseBrace;
+  }
+}
+
+export class ListExpressionNode extends SyntaxNode {
+  listOpenBracket?: SyntaxToken;
+
+  elementList: AttributeNode[];
+
+  commaList: SyntaxToken[];
+
+  listCloseBracket?: SyntaxToken;
+
+  constructor(
+    {
+      listOpenBracket,
+      elementList = [],
+      commaList = [],
+      listCloseBracket,
+    }: {
+      listOpenBracket?: SyntaxToken;
+      elementList?: AttributeNode[];
+      commaList?: SyntaxToken[];
+      listCloseBracket?: SyntaxToken;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.LIST_EXPRESSION, [
+      listOpenBracket,
+      ...interleave(elementList, commaList),
+      listCloseBracket,
+    ]);
+    this.listOpenBracket = listOpenBracket;
+    this.elementList = elementList;
+    this.commaList = commaList;
+    this.listCloseBracket = listCloseBracket;
+  }
+}
+
+export class TupleExpressionNode extends SyntaxNode {
+  tupleOpenParen?: SyntaxToken;
+
+  elementList: NormalExpressionNode[];
+
+  commaList: SyntaxToken[];
+
+  tupleCloseParen?: SyntaxToken;
+
+  constructor(
+    {
+      tupleOpenParen,
+      elementList = [],
+      commaList = [],
+      tupleCloseParen,
+    }: {
+      tupleOpenParen?: SyntaxToken;
+      elementList?: NormalExpressionNode[];
+      commaList?: SyntaxToken[];
+      tupleCloseParen?: SyntaxToken;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.TUPLE_EXPRESSION, [
+      tupleOpenParen,
+      ...interleave(elementList, commaList),
+      tupleCloseParen,
+    ]);
+    this.tupleOpenParen = tupleOpenParen;
+    this.elementList = elementList;
+    this.commaList = commaList;
+    this.tupleCloseParen = tupleCloseParen;
+  }
+}
+
+export class GroupExpressionNode extends TupleExpressionNode {
+  constructor(
+    {
+      groupOpenParen,
+      expression,
+      groupCloseParen,
+    }: {
+      groupOpenParen?: SyntaxToken;
+      expression?: NormalExpressionNode;
+      groupCloseParen?: SyntaxToken;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(
+      {
+        tupleOpenParen: groupOpenParen,
+        elementList: expression && [expression],
+        commaList: [],
+        tupleCloseParen: groupCloseParen,
+      },
+      id,
+    );
+    this.kind = SyntaxNodeKind.GROUP_EXPRESSION;
+  }
+}
+
+export class CallExpressionNode extends SyntaxNode {
+  callee?: NormalExpressionNode;
+
+  argumentList?: TupleExpressionNode;
+
+  constructor(
+    {
+      callee,
+      argumentList,
+    }: {
+      callee?: NormalExpressionNode;
+      argumentList?: TupleExpressionNode;
+    },
+    id: SyntaxNodeId,
+  ) {
+    super(id, SyntaxNodeKind.CALL_EXPRESSION, [callee, argumentList]);
+    this.callee = callee;
+    this.argumentList = argumentList;
+  }
+}
+
+export class LiteralNode extends SyntaxNode {
+  literal?: SyntaxToken;
+
+  constructor({ literal }: { literal?: SyntaxToken }, id: SyntaxNodeId) {
+    super(id, SyntaxNodeKind.LITERAL, [literal]);
+    this.literal = literal;
+  }
+}
+
+export class VariableNode extends SyntaxNode {
+  variable?: SyntaxToken;
+
+  constructor({ variable }: { variable?: SyntaxToken }, id: SyntaxNodeId) {
+    super(id, SyntaxNodeKind.VARIABLE, [variable]);
+    this.variable = variable;
+  }
+}
+
+export class PrimaryExpressionNode extends SyntaxNode {
+  expression?: LiteralNode | VariableNode;
+
+  constructor({ expression }: { expression?: LiteralNode | VariableNode }, id: SyntaxNodeId) {
+    super(id, SyntaxNodeKind.PRIMARY_EXPRESSION, [expression]);
+    this.expression = expression;
+  }
+}
+
+function interleave(
+  arr1: (SyntaxNode | SyntaxToken)[] | undefined,
+  arr2: (SyntaxNode | SyntaxToken)[] | undefined,
+): (SyntaxNode | SyntaxToken)[] {
+  if (!arr1 || arr1.length === 0) {
+    return arr2 || [];
+  }
+  if (!arr2 || arr2.length === 0) {
+    return arr1 || [];
+  }
+  const [e1] = arr1;
+  const [e2] = arr2;
+
+  return (e1.start < e2.start ? _.flatten(_.zip(arr1, arr2)) : _.flatten(_.zip(arr2, arr1))).filter(
+    (e) => e !== null,
+  ) as (SyntaxNode | SyntaxToken)[];
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/parser.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/parser.ts
@@ -1,0 +1,1102 @@
+import _ from 'lodash';
+import {
+  convertFuncAppToElem,
+  createDummyOperand,
+  isAsKeyword,
+  isDummyOperand,
+  markInvalid,
+} from './utils';
+import { CompileError, CompileErrorCode } from '../errors';
+import { SyntaxToken, SyntaxTokenKind, isOpToken } from '../lexer/tokens';
+import Report from '../report';
+import { ParsingContext, ParsingContextStack } from './contextStack';
+import {
+  AttributeNode,
+  BlockExpressionNode,
+  CallExpressionNode,
+  ElementDeclarationNode,
+  FunctionApplicationNode,
+  FunctionExpressionNode,
+  GroupExpressionNode,
+  IdentiferStreamNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  LiteralNode,
+  NormalExpressionNode,
+  PostfixExpressionNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+  SyntaxNodeIdGenerator,
+  TupleExpressionNode,
+  VariableNode,
+} from './nodes';
+import NodeFactory from './factory';
+import { hasTrailingNewLines, hasTrailingSpaces, isAtStartOfLine } from '../lexer/utils';
+
+/* eslint-disable no-loop-func */
+
+// A class of errors that represent a parsing failure and contain the node that was partially parsed
+class PartialParsingError<T extends SyntaxNode | undefined> {
+  partialNode: T;
+  token: Readonly<SyntaxToken>;
+  handlerContext: null | ParsingContext;
+
+  constructor(token: Readonly<SyntaxToken>, partialNode: T, handlerContext: null | ParsingContext) {
+    this.token = token;
+    this.partialNode = partialNode;
+    this.handlerContext = handlerContext;
+  }
+}
+
+export default class Parser {
+  private tokens: SyntaxToken[];
+
+  private current: number = 0;
+
+  private errors: CompileError[] = []; // A list of errors during parsing
+
+  // Keep track of which context we're parsing in
+  private contextStack: ParsingContextStack = new ParsingContextStack();
+
+  private nodeFactory: NodeFactory;
+
+  constructor(tokens: SyntaxToken[], nodeIdGenerator: SyntaxNodeIdGenerator) {
+    this.tokens = tokens;
+    this.nodeFactory = new NodeFactory(nodeIdGenerator);
+  }
+
+  private isAtEnd(): boolean {
+    return (
+      this.current >= this.tokens.length || this.tokens[this.current].kind === SyntaxTokenKind.EOF
+    );
+  }
+
+  private advance(): SyntaxToken {
+    if (this.isAtEnd()) {
+      return _.last(this.tokens)!; // The EOF
+    }
+
+    // eslint-disable-next-line no-plusplus
+    return this.tokens[this.current++];
+  }
+
+  private peek(lookahead: number = 0): SyntaxToken {
+    if (lookahead + this.current >= this.tokens.length) {
+      return _.last(this.tokens)!; // The EOF
+    }
+
+    return this.tokens[this.current + lookahead];
+  }
+
+  private match(...kind: SyntaxTokenKind[]): boolean {
+    const res = this.check(...kind);
+    if (res) {
+      this.advance();
+    }
+
+    return res;
+  }
+
+  private check(...kind: SyntaxTokenKind[]): boolean {
+    const currentToken = this.peek();
+
+    return kind.includes(currentToken.kind);
+  }
+
+  private previous(): SyntaxToken {
+    return this.tokens[this.current - 1];
+  }
+
+  private canHandle<T extends SyntaxNode>(e: PartialParsingError<T>): boolean {
+    return e.handlerContext === null || e.handlerContext === this.contextStack.top();
+  }
+
+  private consume(message: string, ...kind: SyntaxTokenKind[]) {
+    if (!this.match(...kind)) {
+      this.logError(this.peek(), CompileErrorCode.UNEXPECTED_TOKEN, message);
+      throw new PartialParsingError(
+        this.peek(),
+        undefined,
+        this.contextStack.findHandlerContext(this.tokens, this.current),
+      );
+    }
+  }
+
+  private consumeReturn(message: string, ...kind: SyntaxTokenKind[]): SyntaxToken {
+    this.consume(message, ...kind);
+
+    return this.previous();
+  }
+
+  // Discard tokens until one of `kind` is found
+  // If any tokens are discarded, the error message is logged
+  // Return whether the token of one of the listed kinds are eventually reached
+  private discardUntil(message: string, ...kind: SyntaxTokenKind[]): boolean {
+    if (this.isAtEnd() || !this.check(...kind)) {
+      markInvalid(this.peek());
+      this.logError(this.advance(), CompileErrorCode.UNEXPECTED_TOKEN, message);
+      while (!this.isAtEnd() && !this.check(...kind)) {
+        markInvalid(this.advance());
+      }
+
+      return !this.isAtEnd();
+    }
+
+    return true;
+  }
+
+  private gatherInvalid() {
+    const tokens: SyntaxToken[] = [];
+
+    const firstInvalidList: SyntaxToken[] = [];
+    let curValid: SyntaxToken | undefined;
+    let i = 0;
+    for (; i < this.tokens.length; i += 1) {
+      if (this.tokens[i].isInvalid) {
+        firstInvalidList.push(this.tokens[i]);
+      } else {
+        break;
+      }
+    }
+
+    curValid = this.tokens[i];
+    curValid.leadingInvalid = firstInvalidList;
+    tokens.push(curValid);
+    for (i += 1; i < this.tokens.length; i += 1) {
+      const curToken = this.tokens[i];
+      if (curToken.isInvalid) {
+        curValid.trailingInvalid.push(curToken);
+      } else {
+        curValid = curToken;
+        tokens.push(curValid);
+      }
+    }
+
+    _.remove(this.tokens);
+    this.tokens.push(...tokens);
+  }
+
+  // Invoke a parsing callback
+  // If the parsing callback fails,
+  // the node that was partially parsed (contained in the PartialParsingError)
+  // will be passed to a partial-handler
+  // If the current context can handle the error
+  // we simply synchronize
+  // otherwise, we wrap the partial in a PartialParsingError and throw to the upper contexts
+  synchWrap<T extends SyntaxNode>(
+    parsingCallback: () => void,
+    handlePartial: (subPartial: unknown) => void,
+    constructPartial: (subPartial: unknown) => T,
+    synchronizeCallback?: () => void,
+  ) {
+    try {
+      parsingCallback();
+    } catch (e) {
+      if (!(e instanceof PartialParsingError)) {
+        throw e;
+      }
+
+      if (!this.canHandle(e) || !synchronizeCallback) {
+        handlePartial(e.partialNode);
+        throw new PartialParsingError(e.token, constructPartial(e.partialNode), e.handlerContext);
+      }
+
+      synchronizeCallback();
+      handlePartial(e.partialNode);
+    }
+  }
+
+  // Invoke a parsing callback
+  // Then invoke `assignCallback` with the value of the parsing callback
+  // If the parsing callback fails,
+  // `assignCallback` is invoked with the partial instead
+  // Otherwise the same as `synchWrap`
+  synchAssignWrap<T extends SyntaxNode, V>(
+    parsingCallback: () => V,
+    assignCallback: (value: V, isPartial: boolean) => void,
+    constructPartial: (subPartial: V) => T,
+    synchronizeCallback?: () => void,
+  ) {
+    try {
+      // eslint-disable-next-line no-param-reassign
+      assignCallback(parsingCallback(), false);
+    } catch (e) {
+      if (!(e instanceof PartialParsingError)) {
+        throw e;
+      }
+
+      // eslint-disable-next-line no-param-reassign
+      assignCallback(e.partialNode, true);
+
+      if (!this.canHandle(e) || !synchronizeCallback) {
+        throw new PartialParsingError(e.token, constructPartial(e.partialNode), e.handlerContext);
+      }
+
+      synchronizeCallback();
+    }
+  }
+
+  parse(): Report<ProgramNode, CompileError> {
+    const body = this.program();
+    const eof = this.advance();
+    const program = this.nodeFactory.create(ProgramNode, { body, eof });
+    this.gatherInvalid();
+
+    return new Report(program, this.errors);
+  }
+
+  /* Parsing and synchronizing ProgramNode */
+
+  private program() {
+    const body: ElementDeclarationNode[] = [];
+    while (!this.isAtEnd()) {
+      try {
+        const elem = this.elementDeclaration();
+        body.push(elem);
+      } catch (e) {
+        if (!(e instanceof PartialParsingError)) {
+          throw e;
+        }
+        body.push(e.partialNode);
+        this.synchronizeProgram();
+      }
+    }
+
+    return body;
+  }
+
+  private synchronizeProgram = () => {
+    const invalidToken = this.peek();
+    if (invalidToken.kind !== SyntaxTokenKind.EOF) {
+      markInvalid(this.advance());
+    } else {
+      markInvalid(this.peek());
+      this.logError(invalidToken, CompileErrorCode.UNEXPECTED_EOF, 'Unexpected EOF');
+    }
+  };
+
+  /* Parsing and synchronizing top-level ElementDeclarationNode */
+
+  private elementDeclaration(): ElementDeclarationNode {
+    const args: {
+      type: SyntaxToken | undefined;
+      name: NormalExpressionNode | undefined;
+      as: SyntaxToken | undefined;
+      alias: NormalExpressionNode | undefined;
+      attributeList: ListExpressionNode | undefined;
+      bodyColon: SyntaxToken | undefined;
+      body: FunctionApplicationNode | BlockExpressionNode | ElementDeclarationNode | undefined;
+    } = {} as any;
+    const buildElement = () => this.nodeFactory.create(ElementDeclarationNode, args);
+
+    this.synchAssignWrap(
+      () => this.consumeReturn('Expect an identifier', SyntaxTokenKind.IDENTIFIER),
+      (value) => {
+        args.type = value;
+      },
+      buildElement,
+    );
+
+    if (!this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.LBRACE, SyntaxTokenKind.LBRACKET)) {
+      this.synchAssignWrap(
+        () => this.normalExpression(),
+        (value) => {
+          args.name = value;
+        },
+        buildElement,
+        this.synchronizeElementDeclarationName,
+      );
+    }
+
+    if (isAsKeyword(this.peek())) {
+      args.as = this.advance();
+      if (!this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.LBRACE, SyntaxTokenKind.LBRACKET)) {
+        this.synchAssignWrap(
+          () => this.normalExpression(),
+          (value) => {
+            args.alias = value;
+          },
+          buildElement,
+          this.synchronizeElementDeclarationAlias,
+        );
+      } else {
+        this.logError(this.peek(), CompileErrorCode.UNEXPECTED_TOKEN, 'Expect an alias');
+      }
+    }
+
+    this.synchAssignWrap(
+      () => (this.check(SyntaxTokenKind.LBRACKET) ? this.listExpression() : undefined),
+      (value) => {
+        args.attributeList = value;
+      },
+      buildElement,
+    );
+
+    if (
+      !this.discardUntil(
+        "Expect an opening brace '{' or a colon ':'",
+        SyntaxTokenKind.LBRACE,
+        SyntaxTokenKind.COLON,
+      )
+    ) {
+      return buildElement();
+    }
+
+    if (this.match(SyntaxTokenKind.COLON)) {
+      args.bodyColon = this.previous();
+      this.synchAssignWrap(
+        () => this.expression(),
+        (value) => {
+          args.body = value;
+        },
+        buildElement,
+      );
+    } else {
+      this.synchAssignWrap(
+        () => this.blockExpression(),
+        (value) => {
+          args.body = value;
+        },
+        buildElement,
+      );
+    }
+
+    return this.nodeFactory.create(ElementDeclarationNode, args);
+  }
+
+  private synchronizeElementDeclarationName = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (
+        isAsKeyword(token) ||
+        this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.LBRACE, SyntaxTokenKind.LBRACKET)
+      ) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  private synchronizeElementDeclarationAlias = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.LBRACE, SyntaxTokenKind.LBRACKET)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  /* Parsing nested element declarations with simple body */
+
+  // e.g
+  // ```
+  //  Table Users {
+  //    Note: 'This is a note'  // fieldDeclaration() handles this
+  //  }
+  private fieldDeclaration(): ElementDeclarationNode {
+    const args: {
+      type: SyntaxToken | undefined;
+      name: NormalExpressionNode | undefined;
+      bodyColon: SyntaxToken | undefined;
+      body: FunctionApplicationNode | ElementDeclarationNode | undefined;
+    } = {} as any;
+    const buildElement = () => this.nodeFactory.create(ElementDeclarationNode, args);
+
+    this.synchAssignWrap(
+      () => this.consumeReturn('Expect an identifier', SyntaxTokenKind.IDENTIFIER),
+      (value) => {
+        args.type = value;
+      },
+      buildElement,
+    );
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect a colon ':'", SyntaxTokenKind.COLON),
+      (value) => {
+        args.bodyColon = value;
+      },
+      buildElement,
+    );
+    this.synchAssignWrap(
+      () => this.expression(),
+      (value) => {
+        args.body = value;
+      },
+      buildElement,
+    );
+
+    return this.nodeFactory.create(ElementDeclarationNode, args);
+  }
+
+  /* Parsing any ExpressionNode, including non-NormalExpression */
+
+  private expression(): FunctionApplicationNode | ElementDeclarationNode {
+    // Since function application expression is the most generic form
+    // by default, we'll interpret any expression as a function application
+    const args: {
+      callee: NormalExpressionNode | undefined;
+      args: NormalExpressionNode[];
+    } = { args: [] } as any;
+
+    // Try interpreting the function application as an element declaration expression
+    // if fail, fall back to the generic function application
+    const buildExpression = () =>
+      convertFuncAppToElem(args.callee, args.args, this.nodeFactory).unwrap_or(
+        this.nodeFactory.create(FunctionApplicationNode, args),
+      );
+
+    this.synchAssignWrap(
+      () => this.normalExpression(),
+      (value) => {
+        args.callee = value;
+      },
+      buildExpression,
+    );
+
+    // If there are newlines after the callee, then it's a simple expression
+    // such as a PrefixExpression, InfixExpression, ...
+    // e.g
+    // indexes {
+    //   (id, `id * 2`)
+    // }
+    // Note {
+    //   'This is a note'
+    // }
+    if (this.shouldStopExpression()) {
+      return buildExpression();
+    }
+
+    let prevNode = args.callee!;
+    while (!this.shouldStopExpression()) {
+      if (!hasTrailingSpaces(this.previous())) {
+        this.logError(prevNode, CompileErrorCode.MISSING_SPACES, 'Expect a following space');
+      }
+
+      this.synchAssignWrap(
+        () => this.normalExpression(),
+        (value) => {
+          prevNode = value;
+          args.args.push(prevNode);
+        },
+        buildExpression,
+      );
+    }
+
+    return buildExpression();
+  }
+
+  private shouldStopExpression(): boolean {
+    if (this.isAtEnd() || hasTrailingNewLines(this.previous())) {
+      return true;
+    }
+
+    const nextTokenKind = this.peek().kind;
+
+    return (
+      nextTokenKind === SyntaxTokenKind.RBRACE ||
+      nextTokenKind === SyntaxTokenKind.RBRACKET ||
+      nextTokenKind === SyntaxTokenKind.RPAREN ||
+      nextTokenKind === SyntaxTokenKind.COMMA ||
+      nextTokenKind === SyntaxTokenKind.COLON
+    );
+  }
+
+  private normalExpression(): NormalExpressionNode {
+    return this.expression_bp(0);
+  }
+
+  // Pratt's parsing algorithm
+  private expression_bp(mbp: number): NormalExpressionNode {
+    let leftExpression: NormalExpressionNode = this.leftExpression_bp();
+
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+
+      if (token.kind === SyntaxTokenKind.LPAREN) {
+        const { left } = postfixBindingPower(token);
+        if ((left as number) < mbp) {
+          break;
+        }
+        if (
+          // When '(' is encountered,
+          // consider it part of another expression if
+          // it's at the start of a new line
+          // and we're currently not having unmatched '(' or '['
+          isAtStartOfLine(this.previous(), token) &&
+          !this.contextStack.isWithinGroupExpressionContext() &&
+          !this.contextStack.isWithinListExpressionContext()
+        ) {
+          break;
+        }
+        this.synchAssignWrap(
+          () => this.tupleExpression(),
+          (value) => {
+            leftExpression = this.nodeFactory.create(CallExpressionNode, {
+              callee: leftExpression,
+              argumentList: value,
+            });
+          },
+          () => leftExpression,
+        );
+      } else if (!isOpToken(token)) {
+        break;
+      } else {
+        const op = token;
+        const opPostfixPower = postfixBindingPower(op);
+
+        if (opPostfixPower.left !== null) {
+          if (opPostfixPower.left <= mbp) {
+            break;
+          }
+          this.advance();
+          leftExpression = this.nodeFactory.create(PostfixExpressionNode, {
+            expression: leftExpression!,
+            op,
+          });
+        } else {
+          const opInfixPower = infixBindingPower(op);
+          if (opInfixPower.left === null || opInfixPower.left <= mbp) {
+            break;
+          }
+          this.advance();
+          this.synchAssignWrap(
+            () =>
+              (op.value === '.' ? this.extractOperand() : this.expression_bp(opInfixPower.right)),
+            (value) => {
+              leftExpression = this.nodeFactory.create(InfixExpressionNode, {
+                leftExpression: leftExpression!,
+                op,
+                rightExpression: value,
+              });
+            },
+            () => leftExpression,
+          );
+        }
+      }
+    }
+
+    return leftExpression;
+  }
+
+  private leftExpression_bp(): NormalExpressionNode {
+    let leftExpression: NormalExpressionNode | undefined;
+
+    if (isOpToken(this.peek())) {
+      const args: {
+        op: SyntaxToken | undefined;
+        expression: NormalExpressionNode | undefined;
+      } = {} as any;
+
+      args.op = this.peek();
+      const opPrefixPower = prefixBindingPower(args.op);
+
+      if (opPrefixPower.right === null) {
+        this.logError(
+          args.op,
+          CompileErrorCode.UNKNOWN_PREFIX_OP,
+          `Unexpected '${args.op.value}' in an expression`,
+        );
+
+        this.throwDummyOperand(args.op);
+      }
+      this.advance();
+
+      this.synchAssignWrap(
+        () => this.expression_bp(opPrefixPower.right as number),
+        (value) => {
+          args.expression = value;
+        },
+        () => this.nodeFactory.create(PrefixExpressionNode, args),
+      );
+
+      leftExpression = this.nodeFactory.create(PrefixExpressionNode, args);
+    } else {
+      leftExpression = this.extractOperand();
+      if (isDummyOperand(leftExpression)) {
+        this.throwDummyOperand(this.peek());
+      }
+    }
+
+    return leftExpression;
+  }
+
+  // Extract an operand to be used in a normal form expression
+  // e.g (1 + 2) in (1 + 2) * 3
+  // e.g [1, 2, 3, 4]
+  // e.g { ... }
+  private extractOperand():
+    | PrimaryExpressionNode
+    | ListExpressionNode
+    | BlockExpressionNode
+    | TupleExpressionNode
+    | FunctionExpressionNode
+    | GroupExpressionNode {
+    if (
+      this.check(
+        SyntaxTokenKind.NUMERIC_LITERAL,
+        SyntaxTokenKind.STRING_LITERAL,
+        SyntaxTokenKind.COLOR_LITERAL,
+        SyntaxTokenKind.QUOTED_STRING,
+        SyntaxTokenKind.IDENTIFIER,
+      )
+    ) {
+      return this.primaryExpression();
+    }
+
+    if (this.check(SyntaxTokenKind.FUNCTION_EXPRESSION)) {
+      return this.functionExpression();
+    }
+
+    if (this.check(SyntaxTokenKind.LBRACKET)) {
+      return this.listExpression();
+    }
+
+    if (this.check(SyntaxTokenKind.LBRACE)) {
+      return this.blockExpression();
+    }
+
+    if (this.check(SyntaxTokenKind.LPAREN)) {
+      return this.tupleExpression();
+    }
+
+    // The error is thrown here to communicate failure of operand extraction to `expression_bp`
+    this.logError(
+      this.peek(),
+      CompileErrorCode.INVALID_OPERAND,
+      `Invalid start of operand "${this.peek().value}"`,
+    );
+
+    return createDummyOperand(this.nodeFactory);
+  }
+
+  private throwDummyOperand(token: SyntaxToken): never {
+    throw new PartialParsingError(
+      token,
+      createDummyOperand(this.nodeFactory),
+      this.contextStack.findHandlerContext(this.tokens, this.current),
+    );
+  }
+
+  /* Parsing FunctionExpression */
+
+  private functionExpression(): FunctionExpressionNode {
+    const args: { value: SyntaxToken | undefined } = { value: undefined };
+    this.synchAssignWrap(
+      () => this.consumeReturn('Expect a function expression', SyntaxTokenKind.FUNCTION_EXPRESSION),
+      (value) => {
+        args.value = value;
+      },
+      () => this.nodeFactory.create(FunctionExpressionNode, args),
+    );
+
+    return this.nodeFactory.create(FunctionExpressionNode, args);
+  }
+
+  /* Parsing and synchronizing BlockExpression */
+
+  private blockExpression = this.contextStack.withContextDo(ParsingContext.BlockExpression, () => {
+    const args: {
+      blockOpenBrace: SyntaxToken | undefined;
+      body: (ElementDeclarationNode | FunctionApplicationNode)[];
+      blockCloseBrace: SyntaxToken | undefined;
+    } = { body: [] } as any;
+    const buildBlock = () => this.nodeFactory.create(BlockExpressionNode, args);
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect an opening brace '{'", SyntaxTokenKind.LBRACE),
+      (value) => {
+        args.blockOpenBrace = value;
+      },
+      buildBlock,
+      this.synchronizeBlock,
+    );
+
+    while (!this.isAtEnd() && !this.check(SyntaxTokenKind.RBRACE)) {
+      this.synchAssignWrap(
+        () => (this.canBeField() ? this.fieldDeclaration() : this.expression()),
+        (value) => args.body.push(value),
+        buildBlock,
+        this.synchronizeBlock,
+      );
+    }
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect a closing brace '}'", SyntaxTokenKind.RBRACE),
+      (value) => {
+        args.blockCloseBrace = value;
+      },
+      buildBlock,
+      this.synchronizeBlock,
+    );
+
+    return buildBlock();
+  });
+
+  private canBeField(): boolean {
+    return (
+      this.peek().kind === SyntaxTokenKind.IDENTIFIER && this.peek(1).kind === SyntaxTokenKind.COLON
+    );
+  }
+
+  private synchronizeBlock = () => {
+    if (this.check(SyntaxTokenKind.RBRACE)) {
+      return;
+    }
+    // This early advance is to prevent the case where the violating token is at the start of line
+    // where an infinite loop may occur
+    // e.g
+    // Table Math {
+    //    ** 2 + 3 // ** is not valid here but is at the start of line
+    //             // since we're synchronizing until the start of line
+    //             // the loop would terminate immediately
+    // }
+    markInvalid(this.advance());
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.RBRACE) || isAtStartOfLine(this.previous(), token)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  /* Parsing PrimaryExpression */
+
+  private primaryExpression(): PrimaryExpressionNode {
+    // Primary expression containing a nested LiteralNode
+    if (
+      this.match(
+        SyntaxTokenKind.COLOR_LITERAL,
+        SyntaxTokenKind.STRING_LITERAL,
+        SyntaxTokenKind.NUMERIC_LITERAL,
+      )
+    ) {
+      return this.nodeFactory.create(PrimaryExpressionNode, {
+        expression: this.nodeFactory.create(LiteralNode, { literal: this.previous() }),
+      });
+    }
+
+    // Primary expression containing a nested VariableNode
+    if (this.match(SyntaxTokenKind.QUOTED_STRING, SyntaxTokenKind.IDENTIFIER)) {
+      return this.nodeFactory.create(PrimaryExpressionNode, {
+        expression: this.nodeFactory.create(VariableNode, { variable: this.previous() }),
+      });
+    }
+
+    this.logError(this.peek(), CompileErrorCode.UNEXPECTED_TOKEN, 'Expect a variable or literal');
+
+    throw new PartialParsingError(
+      this.peek(),
+      this.nodeFactory.create(PrimaryExpressionNode, {
+        expression: this.nodeFactory.create(VariableNode, {}),
+      }),
+      this.contextStack.findHandlerContext(this.tokens, this.current),
+    );
+  }
+
+  /* Parsing and synchronizing TupleExpression */
+
+  private tupleExpression = this.contextStack.withContextDo(ParsingContext.GroupExpression, () => {
+    const args: {
+      tupleOpenParen: SyntaxToken | undefined;
+      elementList: NormalExpressionNode[];
+      commaList: SyntaxToken[];
+      tupleCloseParen: SyntaxToken | undefined;
+    } = { elementList: [], commaList: [] } as any;
+    const buildGroup = () =>
+      this.nodeFactory.create(GroupExpressionNode, {
+        groupOpenParen: args.tupleOpenParen,
+        groupCloseParen: args.tupleCloseParen,
+        expression: args.elementList[0],
+      });
+    const buildTuple = () => this.nodeFactory.create(TupleExpressionNode, args);
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect an opening parenthesis '('", SyntaxTokenKind.LPAREN),
+      (value) => {
+        args.tupleOpenParen = value;
+      },
+      buildTuple,
+      this.synchronizeTuple,
+    );
+
+    if (!this.isAtEnd() && !this.check(SyntaxTokenKind.RPAREN)) {
+      this.synchAssignWrap(
+        () => this.normalExpression(),
+        (value) => args.elementList.push(value),
+        buildGroup,
+        this.synchronizeTuple,
+      );
+    }
+
+    while (!this.isAtEnd() && !this.check(SyntaxTokenKind.RPAREN)) {
+      this.synchWrap(
+        () => {
+          args.commaList.push(this.consumeReturn("Expect a comma ','", SyntaxTokenKind.COMMA));
+          args.elementList.push(this.normalExpression());
+        },
+        (partial: unknown) => {
+          if (partial instanceof SyntaxNode) {
+            args.elementList.push(partial);
+          }
+        },
+        buildTuple,
+        this.synchronizeTuple,
+      );
+    }
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect a closing parenthesis '('", SyntaxTokenKind.RPAREN),
+      (value) => {
+        args.tupleCloseParen = value;
+      },
+      buildTuple,
+      this.synchronizeTuple,
+    );
+
+    return args.elementList.length === 1 ? buildGroup() : buildTuple();
+  });
+
+  private synchronizeTuple = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.RPAREN, SyntaxTokenKind.COMMA)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  /* Parsing and synchronizing ListExpression */
+
+  private listExpression = this.contextStack.withContextDo(ParsingContext.ListExpression, () => {
+    const args: {
+      listOpenBracket: SyntaxToken | undefined;
+      elementList: AttributeNode[];
+      commaList: SyntaxToken[];
+      listCloseBracket: SyntaxToken | undefined;
+    } = { elementList: [], commaList: [] } as any;
+    const buildList = () => this.nodeFactory.create(ListExpressionNode, args);
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect a closing bracket '['", SyntaxTokenKind.LBRACKET),
+      (value) => {
+        args.listOpenBracket = value;
+      },
+      buildList,
+      this.synchronizeList,
+    );
+
+    if (!this.isAtEnd() && !this.check(SyntaxTokenKind.RBRACKET)) {
+      this.synchAssignWrap(
+        () => this.attribute(),
+        (value) => args.elementList.push(value),
+        buildList,
+        this.synchronizeList,
+      );
+    }
+
+    while (!this.isAtEnd() && !this.check(SyntaxTokenKind.RBRACKET)) {
+      this.synchWrap(
+        () => {
+          args.commaList.push(this.consumeReturn("Expect a comma ','", SyntaxTokenKind.COMMA));
+          args.elementList.push(this.attribute());
+        },
+        (partial: unknown) => partial instanceof SyntaxNode && args.elementList.push(partial),
+        buildList,
+        this.synchronizeList,
+      );
+    }
+
+    this.synchAssignWrap(
+      () => this.consumeReturn("Expect a closing bracket ']'", SyntaxTokenKind.RBRACKET),
+      (value) => {
+        args.listCloseBracket = value;
+      },
+      buildList,
+      this.synchronizeList,
+    );
+
+    return buildList();
+  });
+
+  private synchronizeList = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.COMMA, SyntaxTokenKind.RBRACKET)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  private attribute(): AttributeNode {
+    const args: {
+      name: IdentiferStreamNode | undefined;
+      colon: SyntaxToken | undefined;
+      value: NormalExpressionNode | IdentiferStreamNode | undefined;
+    } = {} as any;
+
+    if (this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.RBRACKET, SyntaxTokenKind.COMMA)) {
+      const token = this.peek();
+      this.logError(
+        token,
+        CompileErrorCode.EMPTY_ATTRIBUTE_NAME,
+        'Expect a non-empty attribute name',
+      );
+      args.name = this.nodeFactory.create(IdentiferStreamNode, { identifiers: [] });
+    } else {
+      this.synchAssignWrap(
+        () => this.extractIdentifierStream(),
+        (value) => {
+          args.name = value;
+        },
+        () => this.nodeFactory.create(AttributeNode, args),
+        this.synchronizeAttributeName,
+      );
+    }
+
+    if (this.match(SyntaxTokenKind.COLON)) {
+      args.colon = this.previous();
+      args.value = this.attributeValue();
+    }
+
+    return this.nodeFactory.create(AttributeNode, args);
+  }
+
+  private synchronizeAttributeName = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.COMMA, SyntaxTokenKind.RBRACKET, SyntaxTokenKind.COLON)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  private attributeValue(): NormalExpressionNode | IdentiferStreamNode {
+    let value: NormalExpressionNode | IdentiferStreamNode | undefined;
+    this.synchAssignWrap(
+      () =>
+        (this.peek().kind === SyntaxTokenKind.IDENTIFIER &&
+        this.peek(1).kind === SyntaxTokenKind.IDENTIFIER ?
+          this.extractIdentifierStream() :
+          this.normalExpression()),
+      (_value) => {
+        value = _value;
+      },
+      () => value as any,
+      this.synchronizeAttributeValue,
+    );
+
+    return value as any;
+  }
+
+  private synchronizeAttributeValue = () => {
+    while (!this.isAtEnd()) {
+      const token = this.peek();
+      if (this.check(SyntaxTokenKind.COMMA, SyntaxTokenKind.RBRACKET)) {
+        break;
+      }
+      markInvalid(token);
+      this.advance();
+    }
+  };
+
+  private extractIdentifierStream(): IdentiferStreamNode {
+    const identifiers: SyntaxToken[] = [];
+    while (
+      !this.isAtEnd() &&
+      !this.check(SyntaxTokenKind.COLON, SyntaxTokenKind.COMMA, SyntaxTokenKind.RBRACKET)
+    ) {
+      if (
+        this.match(
+          SyntaxTokenKind.QUOTED_STRING,
+          SyntaxTokenKind.STRING_LITERAL,
+          SyntaxTokenKind.NUMERIC_LITERAL,
+        )
+      ) {
+        markInvalid(this.previous());
+        this.logError(this.previous(), CompileErrorCode.UNEXPECTED_TOKEN, 'Expect an identifier');
+      } else {
+        this.synchAssignWrap(
+          () => this.consumeReturn('Expect an identifier', SyntaxTokenKind.IDENTIFIER),
+          (value) => value && identifiers.push(value),
+          () => this.nodeFactory.create(IdentiferStreamNode, { identifiers }),
+        );
+      }
+    }
+
+    return this.nodeFactory.create(IdentiferStreamNode, { identifiers });
+  }
+
+  private logError(nodeOrToken: SyntaxToken | SyntaxNode, code: CompileErrorCode, message: string) {
+    this.errors.push(new CompileError(code, message, nodeOrToken));
+  }
+}
+
+const infixBindingPowerMap: {
+  [index: string]: { left: number; right: number } | undefined;
+} = {
+  '+': { left: 9, right: 10 },
+  '*': { left: 11, right: 12 },
+  '-': { left: 9, right: 10 },
+  '/': { left: 11, right: 12 },
+  '%': { left: 11, right: 12 },
+  '<': { left: 7, right: 8 },
+  '<=': { left: 7, right: 8 },
+  '>': { left: 7, right: 8 },
+  '>=': { left: 7, right: 8 },
+  '<>': { left: 7, right: 8 },
+  '=': { left: 2, right: 3 },
+  '==': { left: 4, right: 5 },
+  '!=': { left: 4, right: 5 },
+  '.': { left: 16, right: 17 },
+};
+
+function infixBindingPower(
+  token: SyntaxToken,
+): { left: null; right: null } | { left: number; right: number } {
+  const power = infixBindingPowerMap[token.value];
+
+  return power || { left: null, right: null };
+}
+
+const prefixBindingPowerMap: {
+  [index: string]: { left: null; right: number } | undefined;
+} = {
+  '+': { left: null, right: 15 },
+  '-': { left: null, right: 15 },
+  '<': { left: null, right: 15 },
+  '>': { left: null, right: 15 },
+  '<>': { left: null, right: 15 },
+  '!': { left: null, right: 15 },
+};
+
+function prefixBindingPower(token: SyntaxToken): { left: null; right: null | number } {
+  const power = prefixBindingPowerMap[token.value];
+
+  return power || { left: null, right: null };
+}
+
+const postfixBindingPowerMap: {
+  [index: string]: { left: number; right: null } | undefined;
+} = {
+  '(': { left: 14, right: null },
+};
+
+function postfixBindingPower(token: SyntaxToken): { left: null | number; right: null } {
+  const power = postfixBindingPowerMap[token.value];
+
+  return power || { left: null, right: null };
+}
+
+/* eslint-enable */

--- a/packages/dbml-core/src/parse/dbml/src/lib/parser/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/parser/utils.ts
@@ -1,0 +1,356 @@
+import _ from 'lodash';
+import { SyntaxToken, SyntaxTokenKind } from '../lexer/tokens';
+import { None, Option, Some } from '../option';
+import { alternateLists } from '../utils';
+import NodeFactory from './factory';
+import {
+  AttributeNode,
+  BlockExpressionNode,
+  CallExpressionNode,
+  ElementDeclarationNode,
+  ExpressionNode,
+  FunctionApplicationNode,
+  FunctionExpressionNode,
+  GroupExpressionNode,
+  IdentiferStreamNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  LiteralNode,
+  NormalExpressionNode,
+  PostfixExpressionNode,
+  PrefixExpressionNode,
+  PrimaryExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+  TupleExpressionNode,
+  VariableNode,
+} from './nodes';
+
+// Try to interpret a function application as an element
+export function convertFuncAppToElem(
+  callee: ExpressionNode | undefined,
+  args: NormalExpressionNode[],
+  factory: NodeFactory,
+): Option<ElementDeclarationNode> {
+  if (!callee || !isExpressionAnIdentifierNode(callee) || args.length === 0) {
+    return new None();
+  }
+  const cpArgs = [...args];
+
+  const type = extractVariableNode(callee).unwrap();
+
+  const body = cpArgs.pop();
+  if (!(body instanceof BlockExpressionNode)) {
+    return new None();
+  }
+
+  const attributeList =
+    _.last(cpArgs) instanceof ListExpressionNode ? (cpArgs.pop() as ListExpressionNode) : undefined;
+
+  if (cpArgs.length === 3 && extractVariableNode(cpArgs[1]).unwrap().value === 'as') {
+    return new Some(
+      factory.create(ElementDeclarationNode, {
+        type,
+        name: cpArgs[0],
+        as: extractVariableNode(cpArgs[1]).unwrap(),
+        alias: cpArgs[2],
+        attributeList,
+        body,
+      }),
+    );
+  }
+
+  if (cpArgs.length === 1) {
+    return new Some(
+      factory.create(ElementDeclarationNode, {
+        type,
+        name: cpArgs[0],
+        attributeList,
+        body,
+      }),
+    );
+  }
+
+  if (cpArgs.length === 0) {
+    return new Some(
+      factory.create(ElementDeclarationNode, {
+        type,
+        attributeList,
+        body,
+      }),
+    );
+  }
+
+  return new None();
+}
+
+// Check if a token is an `as` keyword
+export function isAsKeyword(
+  token: SyntaxToken,
+): token is SyntaxToken & { kind: SyntaxTokenKind.IDENTIFIER; value: 'as' } {
+  return token.kind === SyntaxTokenKind.IDENTIFIER && token.value === 'as';
+}
+
+export function markInvalid(nodeOrToken?: SyntaxNode | SyntaxToken) {
+  if (!nodeOrToken) {
+    return;
+  }
+
+  if (nodeOrToken instanceof SyntaxToken) {
+    markInvalidToken(nodeOrToken);
+  } else {
+    markInvalidNode(nodeOrToken);
+  }
+}
+
+function markInvalidToken(token: SyntaxToken) {
+  if (token.kind === SyntaxTokenKind.EOF) {
+    return;
+  }
+  // eslint-disable-next-line no-param-reassign
+  token.isInvalid = true;
+}
+
+function markInvalidNode(node: SyntaxNode) {
+  if (node instanceof ElementDeclarationNode) {
+    markInvalid(node.type);
+    markInvalid(node.name);
+    markInvalid(node.as);
+    markInvalid(node.alias);
+    markInvalid(node.bodyColon);
+    markInvalid(node.attributeList);
+    markInvalid(node.body);
+  } else if (node instanceof IdentiferStreamNode) {
+    node.identifiers.forEach(markInvalid);
+  } else if (node instanceof AttributeNode) {
+    markInvalid(node.name);
+    markInvalid(node.colon);
+    markInvalid(node.value);
+  } else if (node instanceof PrefixExpressionNode) {
+    markInvalid(node.op);
+    markInvalid(node.expression);
+  } else if (node instanceof InfixExpressionNode) {
+    markInvalid(node.leftExpression);
+    markInvalid(node.op);
+    markInvalid(node.rightExpression);
+  } else if (node instanceof PostfixExpressionNode) {
+    markInvalid(node.op);
+    markInvalid(node.expression);
+  } else if (node instanceof BlockExpressionNode) {
+    markInvalid(node.blockOpenBrace);
+    node.body.forEach(markInvalid);
+    markInvalid(node.blockCloseBrace);
+  } else if (node instanceof ListExpressionNode) {
+    markInvalid(node.listOpenBracket);
+    node.commaList.forEach(markInvalid);
+    node.elementList.forEach(markInvalid);
+    markInvalid(node.listCloseBracket);
+  } else if (node instanceof TupleExpressionNode) {
+    markInvalid(node.tupleOpenParen);
+    node.commaList.forEach(markInvalid);
+    node.elementList.forEach(markInvalid);
+    markInvalid(node.tupleCloseParen);
+  } else if (node instanceof CallExpressionNode) {
+    markInvalid(node.callee);
+    markInvalid(node.argumentList);
+  } else if (node instanceof FunctionApplicationNode) {
+    markInvalid(node.callee);
+    node.args.forEach(markInvalid);
+  } else if (node instanceof PrimaryExpressionNode) {
+    markInvalid(node.expression);
+  } else if (node instanceof FunctionExpressionNode) {
+    markInvalid(node.value);
+  } else if (node instanceof VariableNode) {
+    markInvalid(node.variable);
+  } else if (node instanceof LiteralNode) {
+    markInvalid(node.literal);
+  } else if (node instanceof GroupExpressionNode) {
+    throw new Error('This case is handled by the TupleExpressionNode case');
+  } else {
+    throw new Error('Unreachable case in markInvalidNode');
+  }
+}
+
+export function isInvalidToken(token?: SyntaxToken): boolean {
+  return !!token?.isInvalid;
+}
+
+function filterUndefined(
+  ...args: (SyntaxNode | SyntaxToken | undefined)[]
+): (SyntaxNode | SyntaxToken)[] {
+  return args.filter((v) => v !== undefined) as (SyntaxNode | SyntaxToken)[];
+}
+
+export function getMemberChain(node: SyntaxNode): Readonly<(SyntaxNode | SyntaxToken)[]> {
+  if (node instanceof ProgramNode) {
+    return filterUndefined(...node.body, node.eof);
+  }
+
+  if (node instanceof ElementDeclarationNode) {
+    return filterUndefined(
+      node.type,
+      node.name,
+      node.as,
+      node.alias,
+      node.attributeList,
+      node.bodyColon,
+      node.body,
+    );
+  }
+
+  if (node instanceof AttributeNode) {
+    return filterUndefined(node.name, node.colon, node.value);
+  }
+
+  if (node instanceof IdentiferStreamNode) {
+    return node.identifiers;
+  }
+
+  if (node instanceof LiteralNode) {
+    return node.literal ? [node.literal] : [];
+  }
+
+  if (node instanceof VariableNode) {
+    return filterUndefined(node.variable);
+  }
+
+  if (node instanceof PrefixExpressionNode) {
+    return filterUndefined(node.op, node.expression);
+  }
+
+  if (node instanceof InfixExpressionNode) {
+    return filterUndefined(node.leftExpression, node.op, node.rightExpression);
+  }
+
+  if (node instanceof PostfixExpressionNode) {
+    return filterUndefined(node.expression, node.op);
+  }
+
+  if (node instanceof FunctionExpressionNode) {
+    return filterUndefined(node.value);
+  }
+
+  if (node instanceof FunctionApplicationNode) {
+    return filterUndefined(node.callee, ...node.args);
+  }
+
+  if (node instanceof BlockExpressionNode) {
+    return filterUndefined(node.blockOpenBrace, ...node.body, node.blockCloseBrace);
+  }
+
+  if (node instanceof ListExpressionNode) {
+    return filterUndefined(
+      node.listOpenBracket,
+      ...alternateLists(node.elementList, node.commaList),
+      node.listCloseBracket,
+    );
+  }
+
+  if (node instanceof TupleExpressionNode) {
+    return filterUndefined(
+      node.tupleOpenParen,
+      ...alternateLists(node.elementList, node.commaList),
+      node.tupleCloseParen,
+    );
+  }
+
+  if (node instanceof CallExpressionNode) {
+    return filterUndefined(node.callee, node.argumentList);
+  }
+
+  if (node instanceof PrimaryExpressionNode) {
+    return filterUndefined(node.expression);
+  }
+
+  if (node instanceof GroupExpressionNode) {
+    throw new Error('This case is already handled by TupleExpressionNode');
+  }
+
+  throw new Error('Unreachable - no other possible cases');
+}
+
+// Return a variable node if it's nested inside a primary expression
+export function extractVariableNode(value?: unknown): Option<SyntaxToken> {
+  if (isExpressionAVariableNode(value)) {
+    return new Some(value.expression.variable);
+  }
+
+  return new None();
+}
+
+// Return true if an expression node is a primary expression
+// with a nested quoted string (", ' or ''')
+export function isExpressionAQuotedString(value?: unknown): value is PrimaryExpressionNode &
+  (
+    | { expression: VariableNode & { variable: SyntaxToken } }
+    | {
+        expression: LiteralNode & {
+          literal: SyntaxToken & { kind: SyntaxTokenKind.STRING_LITERAL };
+        };
+      }
+  ) {
+  return (
+    value instanceof PrimaryExpressionNode &&
+    ((value.expression instanceof VariableNode &&
+      value.expression.variable instanceof SyntaxToken) ||
+      (value.expression instanceof LiteralNode &&
+        value.expression.literal?.kind === SyntaxTokenKind.STRING_LITERAL))
+  );
+}
+
+// Return true if an expression node is a primary expression
+// with a variable node (identifier or a double-quoted string)
+export function isExpressionAVariableNode(
+  value?: unknown,
+): value is PrimaryExpressionNode & { expression: VariableNode & { variable: SyntaxToken } } {
+  return (
+    value instanceof PrimaryExpressionNode &&
+    value.expression instanceof VariableNode &&
+    value.expression.variable instanceof SyntaxToken
+  );
+}
+
+// Return true if an expression node is a primary expression
+// with an identifier-like variable node
+export function isExpressionAnIdentifierNode(value?: unknown): value is PrimaryExpressionNode & {
+  expression: VariableNode & { variable: { kind: SyntaxTokenKind.IDENTIFIER } };
+} {
+  return (
+    value instanceof PrimaryExpressionNode &&
+    value.expression instanceof VariableNode &&
+    value.expression.variable?.kind === SyntaxTokenKind.IDENTIFIER
+  );
+}
+
+export function isAccessExpression(node: SyntaxNode): node is InfixExpressionNode & {
+  leftExpression: SyntaxNode;
+  rightExpression: SyntaxNode;
+  op: SyntaxToken & { value: '.' };
+} {
+  return (
+    node instanceof InfixExpressionNode &&
+    node.leftExpression instanceof SyntaxNode &&
+    node.rightExpression instanceof SyntaxNode &&
+    node.op?.value === '.'
+  );
+}
+
+export function extractStringFromIdentifierStream(stream?: IdentiferStreamNode): Option<string> {
+  if (stream === undefined) {
+    return new None();
+  }
+  const name = stream.identifiers.map((identifier) => identifier.value).join(' ');
+  if (name === '') {
+    return new None();
+  }
+
+  return new Some(name);
+}
+
+export function createDummyOperand(factory: NodeFactory): SyntaxNode {
+  return factory.create(FunctionExpressionNode, {});
+}
+
+export function isDummyOperand(node: SyntaxNode): boolean {
+  return node instanceof FunctionExpressionNode && node.value === undefined;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/report.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/report.ts
@@ -1,0 +1,30 @@
+// Used to hold the result of a computation and any errors along the way
+export default class Report<T, E> {
+  private value: T;
+
+  private errors: E[];
+
+  constructor(value: T, errors?: E[]) {
+    this.value = value;
+    this.errors = errors === undefined ? [] : errors;
+  }
+
+  getValue(): T {
+    return this.value;
+  }
+
+  getErrors(): E[] {
+    return this.errors;
+  }
+
+  chain<U>(fn: (_: T) => Report<U, E>): Report<U, E> {
+    const res = fn(this.value);
+    const errors = [...this.errors, ...res.errors];
+
+    return new Report<U, E>(res.value, errors);
+  }
+
+  map<U>(fn: (_: T) => U): Report<U, E> {
+    return new Report<U, E>(fn(this.value), this.errors);
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/serialization/serialize.ts
@@ -1,0 +1,64 @@
+import { NodeSymbol } from '../analyzer/symbol/symbols';
+import { ProgramNode, SyntaxNode } from '../parser/nodes';
+import Report from '../report';
+import { CompileError } from '../errors';
+
+export function serialize(
+  report: Readonly<Report<ProgramNode, CompileError>>,
+  pretty: boolean = false,
+): string {
+  return JSON.stringify(
+    report,
+    function (key: string, value: any) {
+      // If `value` is not `symbol` of the root node
+      // Just output the `symbol`'s id is enough
+      // As the symbol's information is already reachable from the root node's symbol
+      if (!(this instanceof ProgramNode) && key === 'symbol') {
+        return (value as NodeSymbol)?.id;
+      }
+
+      // If `value` is the `symbol` of the root node
+      // output the symbol table in full,
+      // just the ids of the SyntaxNodes that refer to this symbol
+      // and just the id the root node declaration are enough
+      if (/* this instanceof SyntaxNode && */ key === 'symbol') {
+        return {
+          symbolTable: (value as NodeSymbol)?.symbolTable,
+          id: (value as NodeSymbol)?.id,
+
+          references: (value as NodeSymbol)?.references.map((ref) => ref.id),
+          declaration: (value as NodeSymbol)?.declaration?.id,
+        };
+      }
+
+      // If `value` is the NodeSymbol that a SyntaxNode refers to
+      // just the id of the `referee` is enough
+      if (/* this instanceof SyntaxNode && */ key === 'referee') {
+        return (value as NodeSymbol)?.id;
+      }
+
+      // If `value` is the parent element of the current SyntaxNode
+      // just the id of the parent is enough
+      if (/* this instanceof SyntaxNode && */ key === 'parent') {
+        return (value as SyntaxNode)?.id;
+      }
+
+      // If `value` is the declaration node that owns this symbol
+      // just the id of the declaration node is enough
+      if (/* this instanceof NodeSymbol && */ key === 'declaration') {
+        return (value as SyntaxNode)?.id;
+      }
+
+      // If `value` is the symbol table of a NodeSymbol
+      // output the `table` field of `value`
+      // The conversion to Object is necessary
+      // as by default, Map serializes to {}
+      if (/* this instanceof NodeSymbol && */ key === 'symbolTable') {
+        return Object.fromEntries((value as any).table);
+      }
+
+      return value;
+    },
+    pretty ? 2 : 0,
+  );
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/types.ts
@@ -1,0 +1,5 @@
+export interface Position {
+  offset: number;
+  line: number;
+  column: number;
+}

--- a/packages/dbml-core/src/parse/dbml/src/lib/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/lib/utils.ts
@@ -1,0 +1,71 @@
+import { SyntaxToken } from './lexer/tokens';
+import { SyntaxNode } from './parser/nodes';
+import { getTokenFullEnd, getTokenFullStart } from './lexer/utils';
+
+export function isAlphaOrUnderscore(char: string): boolean {
+  const [c] = char;
+
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c === '_';
+}
+
+export function isDigit(char: string): boolean {
+  const [c] = char;
+
+  return c >= '0' && c <= '9';
+}
+
+// Check if a character is a valid hexadecimal character
+export function isHexChar(char: string): boolean {
+  const [c] = char;
+
+  return isDigit(c) || (isAlphaOrUnderscore(c) && c.toLowerCase() >= 'a' && c.toLowerCase() <= 'f');
+}
+
+export function isAlphaNumeric(char: string): boolean {
+  return isAlphaOrUnderscore(char) || isDigit(char);
+}
+
+export function alternateLists<T, S>(firstList: T[], secondList: S[]): (T | S)[] {
+  const res: (T | S)[] = [];
+  const minLength = Math.min(firstList.length, secondList.length);
+  for (let i = 0; i < minLength; i += 1) {
+    res.push(firstList[i], secondList[i]);
+  }
+  res.push(...firstList.slice(minLength), ...secondList.slice(minLength));
+
+  return res;
+}
+
+export function isOffsetWithinFullSpan(
+  offset: number,
+  nodeOrToken: SyntaxNode | SyntaxToken,
+): boolean {
+  if (nodeOrToken instanceof SyntaxToken) {
+    return offset >= getTokenFullStart(nodeOrToken) && offset < getTokenFullEnd(nodeOrToken);
+  }
+
+  return offset >= nodeOrToken.fullStart && offset < nodeOrToken.fullEnd;
+}
+
+export function isOffsetWithinSpan(offset: number, nodeOrToken: SyntaxNode | SyntaxToken): boolean {
+  return offset >= nodeOrToken.start && offset < nodeOrToken.end;
+}
+
+export function returnIfIsOffsetWithinFullSpan(
+  offset: number,
+  node?: SyntaxNode,
+): SyntaxNode | undefined;
+export function returnIfIsOffsetWithinFullSpan(
+  offset: number,
+  token?: SyntaxToken,
+): SyntaxToken | undefined;
+export function returnIfIsOffsetWithinFullSpan(
+  offset: number,
+  nodeOrToken?: SyntaxNode | SyntaxToken,
+): SyntaxNode | SyntaxToken | undefined {
+  if (!nodeOrToken) {
+    return undefined;
+  }
+
+  return isOffsetWithinFullSpan(offset, nodeOrToken) ? nodeOrToken : undefined;
+}

--- a/packages/dbml-core/src/parse/dbml/src/services/definition/provider.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/definition/provider.ts
@@ -1,0 +1,43 @@
+import {
+ Definition, DefinitionProvider, TextModel, Position,
+} from '../types';
+import { getOffsetFromMonacoPosition } from '../utils';
+import Compiler from '../../compiler';
+import { SyntaxNodeKind } from '../../lib/parser/nodes';
+
+export default class DBMLDefinitionProvider implements DefinitionProvider {
+  private compiler: Compiler;
+
+  constructor(compiler: Compiler) {
+    this.compiler = compiler;
+  }
+
+  provideDefinition(model: TextModel, position: Position): Definition {
+    const { uri } = model;
+    const offset = getOffsetFromMonacoPosition(model, position);
+    const containers = [...this.compiler.container.stack(offset)];
+    while (containers.length !== 0) {
+      const node = containers.pop()!;
+      if (
+        node?.referee?.declaration &&
+        [SyntaxNodeKind.PRIMARY_EXPRESSION, SyntaxNodeKind.VARIABLE].includes(node?.kind)
+      ) {
+        const { startPos, endPos } = node.referee.declaration;
+
+        return [
+          {
+            range: {
+              startColumn: startPos.column + 1,
+              startLineNumber: startPos.line + 1,
+              endColumn: endPos.column + 1,
+              endLineNumber: endPos.line + 1,
+            },
+            uri,
+          },
+        ];
+      }
+    }
+
+    return [];
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/services/index.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/index.ts
@@ -1,0 +1,9 @@
+import DBMLCompletionItemProvider from './suggestions/provider';
+import DBMLDefinitionProvider from './definition/provider';
+import DBMLReferencesProvider from './references/provider';
+
+export {
+  DBMLCompletionItemProvider,
+  DBMLDefinitionProvider,
+  DBMLReferencesProvider,
+};

--- a/packages/dbml-core/src/parse/dbml/src/services/references/provider.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/references/provider.ts
@@ -1,0 +1,47 @@
+import { getOffsetFromMonacoPosition } from '../utils';
+import Compiler from '../../compiler';
+import { SyntaxNodeKind } from '../../lib/parser/nodes';
+import {
+ Location, ReferenceProvider, TextModel, Position,
+} from '../types';
+
+export default class DBMLReferencesProvider implements ReferenceProvider {
+  private compiler: Compiler;
+
+  constructor(compiler: Compiler) {
+    this.compiler = compiler;
+  }
+
+  provideReferences(model: TextModel, position: Position): Location[] {
+    const { uri } = model;
+    const offset = getOffsetFromMonacoPosition(model, position);
+
+    const containers = [...this.compiler.container.stack(offset)];
+    while (containers.length !== 0) {
+      const node = containers.pop();
+      if (
+        node &&
+        [
+          SyntaxNodeKind.ELEMENT_DECLARATION,
+          SyntaxNodeKind.FUNCTION_APPLICATION,
+          SyntaxNodeKind.PRIMARY_EXPRESSION,
+        ].includes(node?.kind)
+      ) {
+        const { symbol } = node;
+        if (symbol?.references.length) {
+          return symbol.references.map(({ startPos, endPos }) => ({
+            range: {
+              startColumn: startPos.column + 1,
+              startLineNumber: startPos.line + 1,
+              endColumn: endPos.column + 1,
+              endLineNumber: endPos.line + 1,
+            },
+            uri,
+          }));
+        }
+      }
+    }
+
+    return [];
+  }
+}

--- a/packages/dbml-core/src/parse/dbml/src/services/suggestions/provider.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/suggestions/provider.ts
@@ -1,0 +1,691 @@
+import * as monaco from 'monaco-editor-core';
+import _ from 'lodash';
+import {
+  destructureMemberAccessExpression,
+  extractVariableFromExpression,
+} from '../../lib/analyzer/utils';
+import {
+  extractStringFromIdentifierStream,
+  isExpressionAVariableNode,
+} from '../../lib/parser/utils';
+import Compiler, { ScopeKind } from '../../compiler';
+import { SyntaxToken, SyntaxTokenKind } from '../../lib/lexer/tokens';
+import { isOffsetWithinSpan } from '../../lib/utils';
+import {
+  CompletionList,
+  TextModel,
+  CompletionItemProvider,
+  Position,
+  CompletionItemKind,
+  CompletionItemInsertTextRule,
+} from '../types';
+import { TableSymbol } from '../../lib/analyzer/symbol/symbols';
+import { SymbolKind, destructureIndex } from '../../lib/analyzer/symbol/symbolIndex';
+import {
+  pickCompletionItemKind,
+  shouldPrependSpace,
+  addQuoteIfContainSpace,
+  noSuggestions,
+  prependSpace,
+} from './utils';
+import {
+  AttributeNode,
+  ElementDeclarationNode,
+  FunctionApplicationNode,
+  InfixExpressionNode,
+  ListExpressionNode,
+  PrefixExpressionNode,
+  ProgramNode,
+  SyntaxNode,
+  TupleExpressionNode,
+} from '../../lib/parser/nodes';
+import { getOffsetFromMonacoPosition } from '../utils';
+import { isComment } from '../../lib/lexer/utils';
+
+/* eslint-disable @typescript-eslint/no-redeclare,no-import-assign */
+const { CompletionItemKind, CompletionItemInsertTextRule } = monaco.languages;
+/* eslint-enable @typescript-eslint/no-redeclare,no-import-assign */
+
+export default class DBMLCompletionItemProvider implements CompletionItemProvider {
+  private compiler: Compiler;
+  // alphabetic characters implictily invoke the autocompletion provider
+  triggerCharacters = ['.', ':'];
+
+  constructor(compiler: Compiler) {
+    this.compiler = compiler;
+  }
+
+  provideCompletionItems(model: TextModel, position: Position): CompletionList {
+    const offset = getOffsetFromMonacoPosition(model, position);
+    const flatStream = this.compiler.token.flatStream();
+    // bOc: before-or-contain
+    const { token: bOcToken, index: bOcTokenId } = this.compiler.container.token(offset);
+    if (bOcTokenId === undefined) {
+      return suggestTopLevelElementType();
+    }
+    // abOc: after before-or-contain
+    const abOcToken = flatStream[bOcTokenId + 1];
+
+    // Check if we're inside a comment
+    if (
+      [
+        ...(bOcToken?.trailingTrivia || []),
+        ...(bOcToken?.leadingTrivia || []),
+        ...(abOcToken?.leadingTrivia || []),
+      ].find((token) => isComment(token) && isOffsetWithinSpan(offset, token))
+    ) {
+      return noSuggestions();
+    }
+
+    const element = this.compiler.container.element(offset);
+    if (
+      this.compiler.container.scopeKind(offset) === ScopeKind.TOPLEVEL ||
+      (element instanceof ElementDeclarationNode &&
+        element.type &&
+        element.type.start <= offset &&
+        element.type.end >= offset)
+    ) {
+      return suggestTopLevelElementType();
+    }
+
+    const containers = [...this.compiler.container.stack(offset)].reverse();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const container of containers) {
+      if (container instanceof PrefixExpressionNode) {
+        switch (container.op?.value) {
+          case '>':
+          case '<':
+          case '<>':
+          case '-':
+            return suggestOnRelOp(
+              this.compiler,
+              offset,
+              container as PrefixExpressionNode & { op: SyntaxToken },
+            );
+        }
+      } else if (container instanceof InfixExpressionNode) {
+        switch (container.op?.value) {
+          case '>':
+          case '<':
+          case '<>':
+          case '-':
+            return suggestOnRelOp(
+              this.compiler,
+              offset,
+              container as InfixExpressionNode & { op: SyntaxToken },
+            );
+          case '.':
+            return suggestMembers(
+              this.compiler,
+              offset,
+              container as InfixExpressionNode & { op: SyntaxToken },
+            );
+        }
+      } else if (container instanceof AttributeNode) {
+        return suggestInAttribute(this.compiler, offset, container);
+      } else if (container instanceof ListExpressionNode) {
+        return suggestInAttribute(this.compiler, offset, container);
+      } else if (container instanceof TupleExpressionNode) {
+        return suggestInTuple(this.compiler, offset);
+      } else if (container instanceof FunctionApplicationNode) {
+        return suggestInSubField(this.compiler, offset, container);
+      } else if (container instanceof ElementDeclarationNode) {
+        if (
+          (container.bodyColon && offset >= container.bodyColon.end) ||
+          (container.body && isOffsetWithinSpan(offset, container.body))
+        ) {
+          return suggestInSubField(this.compiler, offset, undefined);
+        }
+      }
+    }
+
+    return noSuggestions();
+  }
+}
+
+function suggestOnRelOp(
+  compiler: Compiler,
+  offset: number,
+  container: (PrefixExpressionNode | InfixExpressionNode) & { op: SyntaxToken },
+): CompletionList {
+  const scopeKind = compiler.container.scopeKind(offset);
+
+  if ([ScopeKind.REF, ScopeKind.TABLE].includes(scopeKind)) {
+    const res = suggestNamesInScope(compiler, offset, compiler.container.element(offset), [
+      SymbolKind.Table,
+      SymbolKind.Schema,
+      SymbolKind.Column,
+    ]);
+
+    return !shouldPrependSpace(container.op, offset) ? res : prependSpace(res);
+  }
+
+  return noSuggestions();
+}
+
+function suggestNamesInScope(
+  compiler: Compiler,
+  offset: number,
+  parent: ElementDeclarationNode | ProgramNode | undefined,
+  acceptedKinds: SymbolKind[],
+): CompletionList {
+  if (parent === undefined) {
+    return noSuggestions();
+  }
+
+  let curElement: SyntaxNode | undefined = parent;
+  const res: CompletionList = { suggestions: [] };
+  while (curElement) {
+    if (curElement?.symbol?.symbolTable) {
+      const { symbol } = curElement;
+      res.suggestions.push(
+        ...compiler.symbol
+          .members(symbol)
+          .filter(({ kind }) => acceptedKinds.includes(kind))
+          .map(({ name, kind }) => ({
+            label: name,
+            insertText: name,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            kind: pickCompletionItemKind(kind),
+            sortText: pickCompletionItemKind(kind).toString().padStart(2, '0'),
+            range: undefined as any,
+          })),
+      );
+    }
+    curElement = curElement instanceof ElementDeclarationNode ? curElement.parent : undefined;
+  }
+
+  return addQuoteIfContainSpace(res);
+}
+
+function suggestInTuple(compiler: Compiler, offset: number): CompletionList {
+  const scopeKind = compiler.container.scopeKind(offset);
+  switch (scopeKind) {
+    case ScopeKind.INDEXES:
+      return suggestColumnNameInIndexes(compiler, offset);
+    case ScopeKind.REF: {
+      const containers = [...compiler.container.stack(offset)];
+      while (containers.length > 0) {
+        const container = containers.pop()!;
+        if (container instanceof InfixExpressionNode && container.op?.value === '.') {
+          return suggestMembers(compiler, offset, container as InfixExpressionNode & { op: { value: '.' } });
+        }
+      }
+    }
+
+      return suggestInRefField(compiler, offset);
+    default:
+      break;
+  }
+
+  return noSuggestions();
+}
+
+function suggestInAttribute(
+  compiler: Compiler,
+  offset: number,
+  container: AttributeNode,
+): CompletionList {
+  const { token } = compiler.container.token(offset);
+  if ([SyntaxTokenKind.COMMA, SyntaxTokenKind.LBRACKET].includes(token?.kind as any)) {
+    const res = suggestAttributeName(compiler, offset);
+
+    return token?.kind === SyntaxTokenKind.COMMA && shouldPrependSpace(token, offset) ?
+      prependSpace(res) :
+      res;
+  }
+
+  if (container.name && token?.kind === SyntaxTokenKind.COLON) {
+    const res = suggestAttributeValue(
+      compiler,
+      offset,
+      extractStringFromIdentifierStream(container.name).unwrap(),
+    );
+
+    return shouldPrependSpace(token, offset) ? prependSpace(res) : res;
+  }
+
+  if (container.name && container.name.start <= offset && container.name.end >= offset) {
+    return suggestAttributeName(compiler, offset);
+  }
+
+  return noSuggestions();
+}
+
+function suggestAttributeName(compiler: Compiler, offset: number): CompletionList {
+  const element = compiler.container.element(offset);
+  const scopeKind = compiler.container.scopeKind(offset);
+  if (element instanceof ProgramNode) {
+    return noSuggestions();
+  }
+  if (element.body && !isOffsetWithinSpan(offset, (element as ElementDeclarationNode).body!)) {
+    switch (scopeKind) {
+      case ScopeKind.TABLE:
+        return {
+          suggestions: [
+            {
+              label: 'headercolor',
+              insertText: 'headercolor: ',
+              kind: CompletionItemKind.Field,
+              insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+              range: undefined as any,
+            },
+            {
+              label: 'note',
+              insertText: 'note: ',
+              kind: CompletionItemKind.Field,
+              insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+              range: undefined as any,
+            },
+          ],
+        };
+      default:
+        return noSuggestions();
+    }
+  }
+
+  switch (scopeKind) {
+    case ScopeKind.TABLE:
+      return {
+        suggestions: [
+          ...['primary key', 'null', 'not null', 'increment', 'pk', 'unique'].map((name) => ({
+            label: name,
+            insertText: name,
+            kind: CompletionItemKind.Property,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            range: undefined as any,
+          })),
+          ...['ref', 'default'].map((name) => ({
+            label: name,
+            insertText: `${name}: `,
+            kind: CompletionItemKind.Property,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            range: undefined as any,
+          })),
+          {
+            label: 'note',
+            insertText: 'note: ',
+            kind: CompletionItemKind.Property,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            range: undefined as any,
+          },
+        ],
+      };
+    case ScopeKind.INDEXES:
+      return {
+        suggestions: [
+          ...['unique', 'pk'].map((name) => ({
+            label: name,
+            insertText: name,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            kind: CompletionItemKind.Property,
+            range: undefined as any,
+          })),
+          ...['note', 'name', 'type'].map((name) => ({
+            label: name,
+            insertText: `${name}: `,
+            kind: CompletionItemKind.Property,
+            insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+            range: undefined as any,
+          })),
+        ],
+      };
+    case ScopeKind.REF:
+      return {
+        suggestions: ['update', 'delete'].map((name) => ({
+          label: name,
+          insertText: `${name}: `,
+          kind: CompletionItemKind.Property,
+          insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+          range: undefined as any,
+        })),
+      };
+    default:
+      break;
+  }
+
+  return noSuggestions();
+}
+
+function suggestAttributeValue(
+  compiler: Compiler,
+  offset: number,
+  settingName: string,
+): CompletionList {
+  switch (settingName?.toLowerCase()) {
+    case 'update':
+    case 'delete':
+      return {
+        suggestions: ['cascade', 'set default', 'set null', 'restrict'].map((name) => ({
+          label: name,
+          insertText: name,
+          kind: CompletionItemKind.Value,
+          insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+          range: undefined as any,
+        })),
+      };
+    case 'type':
+      return {
+        suggestions: ['btree', 'hash'].map((name) => ({
+          label: name,
+          insertText: `${name}`,
+          kind: CompletionItemKind.Value,
+          insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+          range: undefined as any,
+        })),
+      };
+    default:
+      break;
+  }
+
+  return noSuggestions();
+}
+
+function suggestMembers(
+  compiler: Compiler,
+  offset: number,
+  container: InfixExpressionNode & { op: SyntaxToken },
+): CompletionList {
+  const fragments = destructureMemberAccessExpression(container).unwrap_or([]);
+  fragments.pop(); // The last fragment is not used in suggestions: v1.table.a<>
+  if (fragments.some((f) => !isExpressionAVariableNode(f))) {
+    return noSuggestions();
+  }
+
+  const nameStack = fragments.map((f) => extractVariableFromExpression(f).unwrap());
+
+  return {
+    suggestions: compiler.symbol
+      .ofName({ nameStack, owner: compiler.container.element(offset) })
+      .flatMap(({ symbol }) => compiler.symbol.members(symbol))
+      .map(({ kind, name }) => ({
+        label: name,
+        insertText: name,
+        kind: pickCompletionItemKind(kind),
+        range: undefined as any,
+      })),
+  };
+}
+
+function suggestInSubField(
+  compiler: Compiler,
+  offset: number,
+  container?: FunctionApplicationNode,
+): CompletionList {
+  const scopeKind = compiler.container.scopeKind(offset);
+
+  switch (scopeKind) {
+    case ScopeKind.TABLE:
+      return suggestInColumn(compiler, offset, container);
+    case ScopeKind.PROJECT:
+      return suggestInProjectField(compiler, offset, container);
+    case ScopeKind.INDEXES:
+      return suggestInIndex(compiler, offset);
+    case ScopeKind.ENUM:
+      return suggestInEnumField(compiler, offset, container);
+    case ScopeKind.REF: {
+      const suggestions = suggestInRefField(compiler, offset);
+
+      return compiler.container.token(offset).token?.kind === SyntaxTokenKind.COLON &&
+        shouldPrependSpace(compiler.container.token(offset).token, offset) ?
+        prependSpace(suggestions) :
+        suggestions;
+    }
+    case ScopeKind.TABLEGROUP:
+      return suggestInTableGroupField(compiler);
+    default:
+      return noSuggestions();
+  }
+}
+
+function suggestTopLevelElementType(): CompletionList {
+  return {
+    suggestions: ['Table', 'TableGroup', 'Enum', 'Project', 'Ref'].map((name) => ({
+      label: name,
+      insertText: name,
+      insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+      kind: CompletionItemKind.Keyword,
+      range: undefined as any,
+    })),
+  };
+}
+
+function suggestInEnumField(
+  compiler: Compiler,
+  offset: number,
+  container?: FunctionApplicationNode,
+): CompletionList {
+  if (!container?.callee) {
+    return noSuggestions();
+  }
+  const containerArgId = findContainerArg(offset, container);
+
+  if (containerArgId === 1) {
+    return suggestNamesInScope(compiler, offset, compiler.container.element(offset), [
+      SymbolKind.Schema,
+      SymbolKind.Table,
+      SymbolKind.Column,
+    ]);
+  }
+
+  return noSuggestions();
+}
+
+function suggestInColumn(
+  compiler: Compiler,
+  offset: number,
+  container?: FunctionApplicationNode,
+): CompletionList {
+  if (!container?.callee) {
+    return {
+      suggestions: ['Ref', 'Note', 'indexes'].map((name) => ({
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: CompletionItemKind.Keyword,
+        range: undefined as any,
+      })),
+    };
+  }
+
+  const containerArgId = findContainerArg(offset, container);
+
+  if (containerArgId === 0) {
+    return {
+      suggestions: ['Ref', 'Note', 'indexes'].map((name) => ({
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: CompletionItemKind.Keyword,
+        range: undefined as any,
+      })),
+    };
+  }
+  if (containerArgId === 1) {
+    return suggestColumnType(compiler, offset);
+  }
+
+  return noSuggestions();
+}
+
+function suggestInProjectField(
+  compiler: Compiler,
+  offset: number,
+  container?: FunctionApplicationNode,
+): CompletionList {
+  if (!container?.callee) {
+    return {
+      suggestions: ['Table', 'TableGroup', 'Enum', 'Note', 'Ref'].map((name) => ({
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: CompletionItemKind.Keyword,
+        range: undefined as any,
+      })),
+    };
+  }
+
+  const containerArgId = findContainerArg(offset, container);
+
+  if (containerArgId === 0) {
+    return {
+      suggestions: ['Table', 'TableGroup', 'Enum', 'Note', 'Ref'].map((name) => ({
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: CompletionItemKind.Keyword,
+        range: undefined as any,
+      })),
+    };
+  }
+
+  return noSuggestions();
+}
+
+function suggestInRefField(compiler: Compiler, offset: number): CompletionList {
+  return suggestNamesInScope(compiler, offset, compiler.container.element(offset), [
+    SymbolKind.Schema,
+    SymbolKind.Table,
+    SymbolKind.Column,
+  ]);
+}
+
+function suggestInTableGroupField(compiler: Compiler): CompletionList {
+  return addQuoteIfContainSpace({
+    suggestions: [...compiler.parse.publicSymbolTable().entries()].flatMap(([index]) => {
+      const res = destructureIndex(index).unwrap_or(undefined);
+      if (res === undefined) {
+        return [];
+      }
+      const { kind, name } = res;
+      if (kind !== SymbolKind.Table && kind !== SymbolKind.Schema) {
+        return [];
+      }
+
+      return {
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: pickCompletionItemKind(kind),
+        range: undefined as any,
+      };
+    }),
+  });
+}
+
+function suggestInIndex(compiler: Compiler, offset: number): CompletionList {
+  return suggestColumnNameInIndexes(compiler, offset);
+}
+
+function suggestColumnType(compiler: Compiler, offset: number): CompletionList {
+  return {
+    suggestions: [
+      ...[
+        'integer',
+        'int',
+        'tinyint',
+        'smallint',
+        'mediumint',
+        'bigint',
+        'bit',
+        'bool',
+        'binary',
+        'varbinary',
+        'logical',
+        'char',
+        'nchar',
+        'varchar',
+        'varchar2',
+        'nvarchar',
+        'nvarchar2',
+        'binary_float',
+        'binary_double',
+        'float',
+        'double',
+        'decimal',
+        'dec',
+        'real',
+        'money',
+        'smallmoney',
+        'enum',
+        'tinyblob',
+        'tinytext',
+        'blob',
+        'text',
+        'mediumblob',
+        'mediumtext',
+        'longblob',
+        'longtext',
+        'ntext',
+        'set',
+        'inet6',
+        'uuid',
+        'image',
+        'date',
+        'time',
+        'datetime',
+        'datetime2',
+        'timestamp',
+        'year',
+        'smalldatetime',
+        'datetimeoffset',
+        'XML',
+        'sql_variant',
+        'uniqueidentifier',
+        'CURSOR',
+        'BFILE',
+        'CLOB',
+        'NCLOB',
+        'RAW',
+      ].map((name) => ({
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: CompletionItemKind.TypeParameter,
+        sortText: CompletionItemKind.TypeParameter.toString().padStart(2, '0'),
+        range: undefined as any,
+      })),
+      ...suggestNamesInScope(compiler, offset, compiler.container.element(offset), [
+        SymbolKind.Enum,
+        SymbolKind.Schema,
+      ]).suggestions,
+    ],
+  };
+}
+
+function suggestColumnNameInIndexes(compiler: Compiler, offset: number): CompletionList {
+  const indexesNode = compiler.container.element(offset);
+  const tableNode = indexesNode.parent;
+  if (!(tableNode?.symbol instanceof TableSymbol)) {
+    return noSuggestions();
+  }
+
+  const { symbolTable } = tableNode.symbol;
+
+  return addQuoteIfContainSpace({
+    suggestions: [...symbolTable.entries()].flatMap(([index]) => {
+      const res = destructureIndex(index).unwrap_or(undefined);
+      if (res === undefined) {
+        return [];
+      }
+      const { name } = res;
+
+      return {
+        label: name,
+        insertText: name,
+        insertTextRules: CompletionItemInsertTextRule.KeepWhitespace,
+        kind: pickCompletionItemKind(SymbolKind.Column),
+        range: undefined as any,
+      };
+    }),
+  });
+}
+
+function findContainerArg(offset: number, node: FunctionApplicationNode): number {
+  if (!node.callee) return -1;
+  const args = [node.callee, ...node.args];
+
+  const containerArgId = args.findIndex((c) => c.start <= offset && offset <= c.end);
+
+  return containerArgId === -1 ? args.length : containerArgId;
+}

--- a/packages/dbml-core/src/parse/dbml/src/services/suggestions/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/suggestions/utils.ts
@@ -1,0 +1,80 @@
+import * as monaco from 'monaco-editor-core';
+import { SymbolKind } from '../../lib/analyzer/symbol/symbolIndex';
+import { CompletionItemKind, CompletionList } from '../types';
+import { SyntaxToken, SyntaxTokenKind } from '../../lib/lexer/tokens';
+import { hasTrailingSpaces } from '../../lib/lexer/utils';
+
+/* eslint-disable @typescript-eslint/no-redeclare,no-import-assign */
+const { CompletionItemKind } = monaco.languages;
+/* eslint-enable @typescript-eslint/no-redeclare,no-import-assign */
+
+export function pickCompletionItemKind(symbolKind: SymbolKind): CompletionItemKind {
+  switch (symbolKind) {
+    case SymbolKind.Schema:
+      return CompletionItemKind.Module;
+    case SymbolKind.Table:
+      return CompletionItemKind.Class;
+    case SymbolKind.Column:
+      return CompletionItemKind.Field;
+    case SymbolKind.Enum:
+      return CompletionItemKind.Enum;
+    case SymbolKind.EnumField:
+      return CompletionItemKind.EnumMember;
+    case SymbolKind.TableGroup:
+      return CompletionItemKind.Struct;
+    case SymbolKind.TableGroupField:
+      return CompletionItemKind.Field;
+    default:
+      return CompletionItemKind.Text;
+  }
+}
+
+// To determine if autocompletion should insert an additional space before
+// inserting other tokens
+export function shouldPrependSpace(token: SyntaxToken | undefined, offset: number): boolean {
+  if (!token) {
+    return false;
+  }
+
+  if (hasTrailingSpaces(token)) {
+    return false;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const trivia of token.trailingTrivia) {
+    if (trivia.start > offset) {
+      break;
+    }
+    if (trivia.kind === SyntaxTokenKind.NEWLINE && trivia.end <= offset) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function noSuggestions(): CompletionList {
+  return {
+    suggestions: [],
+  };
+}
+
+export function prependSpace(completionList: CompletionList): CompletionList {
+  return {
+    ...completionList,
+    suggestions: completionList.suggestions.map((s) => ({
+      ...s,
+      insertText: ` ${s.insertText}`,
+    })),
+  };
+}
+
+export function addQuoteIfContainSpace(completionList: CompletionList): CompletionList {
+  return {
+    ...completionList,
+    suggestions: completionList.suggestions.map((s) => ({
+      ...s,
+      insertText: s.insertText.search(' ') !== -1 ? `"${s.insertText}"` : s.insertText,
+    })),
+  };
+}

--- a/packages/dbml-core/src/parse/dbml/src/services/types.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/types.ts
@@ -1,0 +1,45 @@
+import * as monaco from 'monaco-editor-core';
+
+export type Position = monaco.Position;
+export type TextModel = monaco.editor.ITextModel;
+export type ProviderResult<T> = monaco.languages.ProviderResult<T>;
+export type Range = monaco.IRange;
+export type Location = monaco.languages.Location;
+export type Disposable = monaco.IDisposable;
+
+// Autocompletion types
+export type CompletionContext = monaco.languages.CompletionContext;
+export type CancellationToken = monaco.CancellationToken;
+
+export interface CompletionItemProvider {
+  triggerCharacters?: string[];
+  provideCompletionItems(
+    model: TextModel,
+    position: Position,
+    context: CompletionContext,
+    token: CancellationToken,
+  ): ProviderResult<CompletionList>;
+  resolveCompletionItem?(
+    item: CompletionItem,
+    token: CancellationToken,
+  ): ProviderResult<CompletionItem>;
+}
+export type CompletionItem = monaco.languages.CompletionItem;
+export type CompletionList = monaco.languages.CompletionList;
+export type CompletionItemKind = monaco.languages.CompletionItemKind;
+export type CompletionItemInsertTextRule = monaco.languages.CompletionItemInsertTextRule;
+
+// Color provider types
+export type DocumentColorProvider = monaco.languages.DocumentColorProvider;
+export type ColorInformation = monaco.languages.IColorInformation;
+export type ColorPresentation = monaco.languages.IColorPresentation;
+export type Color = monaco.languages.IColor;
+
+// Go to definition
+export type DefinitionProvider = monaco.languages.DefinitionProvider;
+export type Definition = monaco.languages.Definition;
+export type CodeActionList = monaco.languages.CodeActionList;
+export type SignatureHelpResult = monaco.languages.SignatureHelpResult;
+
+// Show references
+export type ReferenceProvider = monaco.languages.ReferenceProvider;

--- a/packages/dbml-core/src/parse/dbml/src/services/utils.ts
+++ b/packages/dbml-core/src/parse/dbml/src/services/utils.ts
@@ -1,0 +1,6 @@
+import { Position } from 'monaco-editor-core';
+import { TextModel } from './types';
+
+export function getOffsetFromMonacoPosition(model: TextModel, position: Position): number {
+  return model.getOffsetAt(position);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,6 +6105,11 @@ modify-values@^1.0.1:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+monaco-editor-core@^0.44.0:
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.44.0.tgz#c3a85e9889dd514b4d0b1b965c4c4c79eb956a04"
+  integrity sha512-gPhXfbi0RCnIRXMUzkvjRc8tUiD56lkuw7uRr2dUv00owYthFRlyot2R0ECFuA5F3YKei4OlFjALDahxIC/6Jg==
+
 ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
## Summary
* Implement an alternative dbml parser
* Doc: https://www.notion.so/holistics/DBML-Alternative-parser-6d3dff42a26d486eb70bdf519eac52a1?pvs=4
* Playground: https://dbml-explorer-demo-1.vercel.app/

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review