### PR TITLE
Fix old test files of DBML

### DIFF
--- a/packages/dbml-core/__tests__/parser/dbml-parse/input/array_type.in.dbml
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/input/array_type.in.dbml
@@ -1,9 +1,9 @@
 Table sal_emp {
   name text
-  pay_by_quarter int[] [not null]
-  schedule text[][] [null]
+  pay_by_quarter "int[]" [not null]
+  schedule "text[][]" [null]
 }
 
 Table tictactoe {
-  squares integer[3][3]
+  squares "integer[3][3]"
 }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/input/composite_pk.in.dbml
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/input/composite_pk.in.dbml
@@ -1,4 +1,4 @@
-Table users {
+Table user1 {
   id int [primary key]
   full_name varchar
   email varchar [unique]
@@ -13,7 +13,7 @@ Table users {
   }
 }
 
-Table users {
+Table user2 {
   id int [primary key]
   full_name varchar
   email varchar [unique]

--- a/packages/dbml-core/__tests__/parser/dbml-parse/input/default_tables.in.dbml
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/input/default_tables.in.dbml
@@ -1,7 +1,7 @@
 Table orders {
   id int [pk, default: 123]
   user_id int [not null, unique]
-  status varchar [default: "Completed"]
+  status varchar [default: 'Completed']
   created_at varchar [default: `now()`]
 }
 

--- a/packages/dbml-core/__tests__/parser/dbml-parse/input/enum_tables.in.dbml
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/input/enum_tables.in.dbml
@@ -19,7 +19,7 @@ Enum "order status" {
 }
 
 Table orders {
-  id int PK unique
+  id int [PK, unique]
   status "order status"
   created_at varchar
 }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/input/table_element.in.dbml
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/input/table_element.in.dbml
@@ -1,10 +1,8 @@
-Table users [note: 'note in table settings'] {
+Table users {
   id int [pk]
   name varchar [pk]
   gender varchar
   created_at datetime
-
-  Note: 'Short note'
 
   Indexes {
     id

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/array_type.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/array_type.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 28,
-              "line": 3,
-              "column": 1
+              "offset": 27,
+              "line": 2,
+              "column": 12
             }
           },
           "inline_refs": []
@@ -36,14 +36,14 @@
           },
           "token": {
             "start": {
-              "offset": 28,
+              "offset": 30,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 62,
-              "line": 4,
-              "column": 1
+              "offset": 63,
+              "line": 3,
+              "column": 36
             }
           },
           "inline_refs": [],
@@ -58,14 +58,14 @@
           },
           "token": {
             "start": {
-              "offset": 62,
+              "offset": 66,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 89,
-              "line": 5,
-              "column": 1
+              "offset": 92,
+              "line": 4,
+              "column": 29
             }
           },
           "inline_refs": [],
@@ -79,7 +79,7 @@
           "column": 1
         },
         "end": {
-          "offset": 90,
+          "offset": 94,
           "line": 5,
           "column": 2
         }
@@ -100,14 +100,14 @@
           },
           "token": {
             "start": {
-              "offset": 112,
+              "offset": 116,
               "line": 8,
               "column": 3
             },
             "end": {
-              "offset": 134,
-              "line": 9,
-              "column": 1
+              "offset": 139,
+              "line": 8,
+              "column": 26
             }
           },
           "inline_refs": []
@@ -115,12 +115,12 @@
       ],
       "token": {
         "start": {
-          "offset": 92,
+          "offset": 96,
           "line": 7,
           "column": 1
         },
         "end": {
-          "offset": 135,
+          "offset": 141,
           "line": 9,
           "column": 2
         }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/comment.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/comment.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 144,
-              "line": 16,
-              "column": 1
+              "offset": 128,
+              "line": 15,
+              "column": 14
             }
           },
           "inline_refs": [],
@@ -37,19 +37,19 @@
           },
           "token": {
             "start": {
-              "offset": 144,
+              "offset": 146,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 177,
-              "line": 17,
-              "column": 1
+              "offset": 176,
+              "line": 16,
+              "column": 33
             }
           },
           "inline_refs": [],
-          "not_null": true,
-          "unique": true
+          "unique": true,
+          "not_null": true
         },
         {
           "name": "status",
@@ -60,14 +60,14 @@
           },
           "token": {
             "start": {
-              "offset": 177,
+              "offset": 179,
               "line": 17,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 223,
-              "line": 18,
-              "column": 1
+              "offset": 222,
+              "line": 17,
+              "column": 46
             }
           },
           "inline_refs": [],
@@ -96,14 +96,14 @@
           },
           "token": {
             "start": {
-              "offset": 223,
+              "offset": 225,
               "line": 18,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 292,
-              "line": 19,
-              "column": 1
+              "offset": 272,
+              "line": 18,
+              "column": 50
             }
           },
           "inline_refs": [],
@@ -172,9 +172,9 @@
               "column": 5
             },
             "end": {
-              "offset": 410,
+              "offset": 409,
               "line": 25,
-              "column": 16
+              "column": 15
             }
           }
         }
@@ -208,9 +208,9 @@
               "column": 3
             },
             "end": {
-              "offset": 511,
-              "line": 35,
-              "column": 1
+              "offset": 499,
+              "line": 34,
+              "column": 15
             }
           }
         },
@@ -218,14 +218,14 @@
           "name": "in_stock",
           "token": {
             "start": {
-              "offset": 511,
+              "offset": 513,
               "line": 35,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 541,
-              "line": 36,
-              "column": 1
+              "offset": 540,
+              "line": 35,
+              "column": 30
             }
           },
           "note": {
@@ -248,14 +248,14 @@
           "name": "running_low",
           "token": {
             "start": {
-              "offset": 541,
+              "offset": 543,
               "line": 36,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 597,
-              "line": 37,
-              "column": 1
+              "offset": 577,
+              "line": 36,
+              "column": 37
             }
           },
           "note": {
@@ -301,9 +301,9 @@
               "column": 3
             },
             "end": {
-              "offset": 723,
-              "line": 47,
-              "column": 1
+              "offset": 711,
+              "line": 46,
+              "column": 15
             }
           }
         },
@@ -311,14 +311,14 @@
           "name": "in_stock",
           "token": {
             "start": {
-              "offset": 723,
+              "offset": 725,
               "line": 47,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 769,
-              "line": 48,
-              "column": 1
+              "offset": 733,
+              "line": 47,
+              "column": 11
             }
           }
         },
@@ -326,14 +326,14 @@
           "name": "running_low",
           "token": {
             "start": {
-              "offset": 769,
-              "line": 48,
-              "column": 1
+              "offset": 807,
+              "line": 52,
+              "column": 3
             },
             "end": {
-              "offset": 863,
-              "line": 53,
-              "column": 1
+              "offset": 841,
+              "line": 52,
+              "column": 37
             }
           },
           "note": {

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/composite_pk.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/composite_pk.out.json
@@ -2,7 +2,7 @@
   "schemas": [],
   "tables": [
     {
-      "name": "users",
+      "name": "user1",
       "schemaName": null,
       "alias": null,
       "fields": [
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 37,
-              "line": 3,
-              "column": 1
+              "offset": 36,
+              "line": 2,
+              "column": 23
             }
           },
           "inline_refs": [],
@@ -37,14 +37,14 @@
           },
           "token": {
             "start": {
-              "offset": 37,
+              "offset": 39,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 57,
-              "line": 4,
-              "column": 1
+              "offset": 56,
+              "line": 3,
+              "column": 20
             }
           },
           "inline_refs": []
@@ -58,14 +58,14 @@
           },
           "token": {
             "start": {
-              "offset": 57,
+              "offset": 59,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 82,
-              "line": 5,
-              "column": 1
+              "offset": 81,
+              "line": 4,
+              "column": 25
             }
           },
           "inline_refs": [],
@@ -80,14 +80,14 @@
           },
           "token": {
             "start": {
-              "offset": 82,
+              "offset": 84,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 99,
-              "line": 6,
-              "column": 1
+              "offset": 98,
+              "line": 5,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -101,14 +101,14 @@
           },
           "token": {
             "start": {
-              "offset": 99,
+              "offset": 101,
               "line": 6,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 123,
-              "line": 7,
-              "column": 1
+              "offset": 122,
+              "line": 6,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -122,14 +122,14 @@
           },
           "token": {
             "start": {
-              "offset": 123,
+              "offset": 125,
               "line": 7,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 144,
-              "line": 8,
-              "column": 1
+              "offset": 143,
+              "line": 7,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -143,14 +143,14 @@
           },
           "token": {
             "start": {
-              "offset": 144,
+              "offset": 146,
               "line": 8,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 164,
-              "line": 9,
-              "column": 1
+              "offset": 162,
+              "line": 8,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -164,14 +164,14 @@
           },
           "token": {
             "start": {
-              "offset": 164,
+              "offset": 166,
               "line": 9,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 192,
-              "line": 10,
-              "column": 1
+              "offset": 191,
+              "line": 9,
+              "column": 28
             }
           },
           "inline_refs": [],
@@ -215,7 +215,7 @@
       ]
     },
     {
-      "name": "users",
+      "name": "user2",
       "schemaName": null,
       "alias": null,
       "fields": [
@@ -233,9 +233,9 @@
               "column": 3
             },
             "end": {
-              "offset": 263,
-              "line": 18,
-              "column": 1
+              "offset": 262,
+              "line": 17,
+              "column": 23
             }
           },
           "inline_refs": [],
@@ -250,14 +250,14 @@
           },
           "token": {
             "start": {
-              "offset": 263,
+              "offset": 265,
               "line": 18,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 283,
-              "line": 19,
-              "column": 1
+              "offset": 282,
+              "line": 18,
+              "column": 20
             }
           },
           "inline_refs": []
@@ -271,14 +271,14 @@
           },
           "token": {
             "start": {
-              "offset": 283,
+              "offset": 285,
               "line": 19,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 308,
-              "line": 20,
-              "column": 1
+              "offset": 307,
+              "line": 19,
+              "column": 25
             }
           },
           "inline_refs": [],
@@ -293,14 +293,14 @@
           },
           "token": {
             "start": {
-              "offset": 308,
+              "offset": 310,
               "line": 20,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 325,
-              "line": 21,
-              "column": 1
+              "offset": 324,
+              "line": 20,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -314,14 +314,14 @@
           },
           "token": {
             "start": {
-              "offset": 325,
+              "offset": 327,
               "line": 21,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 349,
-              "line": 22,
-              "column": 1
+              "offset": 348,
+              "line": 21,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -335,14 +335,14 @@
           },
           "token": {
             "start": {
-              "offset": 349,
+              "offset": 351,
               "line": 22,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 370,
-              "line": 23,
-              "column": 1
+              "offset": 369,
+              "line": 22,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -356,14 +356,14 @@
           },
           "token": {
             "start": {
-              "offset": 370,
+              "offset": 372,
               "line": 23,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 390,
-              "line": 24,
-              "column": 1
+              "offset": 388,
+              "line": 23,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -377,14 +377,14 @@
           },
           "token": {
             "start": {
-              "offset": 390,
+              "offset": 392,
               "line": 24,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 418,
-              "line": 25,
-              "column": 1
+              "offset": 417,
+              "line": 24,
+              "column": 28
             }
           },
           "inline_refs": [],

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/default_tables.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/default_tables.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 43,
-              "line": 3,
-              "column": 1
+              "offset": 42,
+              "line": 2,
+              "column": 28
             }
           },
           "inline_refs": [],
@@ -41,19 +41,19 @@
           },
           "token": {
             "start": {
-              "offset": 43,
+              "offset": 45,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 76,
-              "line": 4,
-              "column": 1
+              "offset": 75,
+              "line": 3,
+              "column": 33
             }
           },
           "inline_refs": [],
-          "not_null": true,
-          "unique": true
+          "unique": true,
+          "not_null": true
         },
         {
           "name": "status",
@@ -64,14 +64,14 @@
           },
           "token": {
             "start": {
-              "offset": 76,
+              "offset": 78,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 116,
-              "line": 5,
-              "column": 1
+              "offset": 115,
+              "line": 4,
+              "column": 40
             }
           },
           "inline_refs": [],
@@ -89,14 +89,14 @@
           },
           "token": {
             "start": {
-              "offset": 116,
+              "offset": 118,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 156,
-              "line": 6,
-              "column": 1
+              "offset": 155,
+              "line": 5,
+              "column": 40
             }
           },
           "inline_refs": [],
@@ -139,9 +139,9 @@
               "column": 3
             },
             "end": {
-              "offset": 194,
-              "line": 10,
-              "column": 1
+              "offset": 193,
+              "line": 9,
+              "column": 15
             }
           },
           "inline_refs": []
@@ -155,14 +155,14 @@
           },
           "token": {
             "start": {
-              "offset": 194,
+              "offset": 196,
               "line": 10,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 211,
-              "line": 11,
-              "column": 1
+              "offset": 210,
+              "line": 10,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -176,14 +176,14 @@
           },
           "token": {
             "start": {
-              "offset": 211,
+              "offset": 213,
               "line": 11,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 226,
-              "line": 12,
-              "column": 1
+              "offset": 225,
+              "line": 11,
+              "column": 15
             }
           },
           "inline_refs": []
@@ -222,9 +222,9 @@
               "column": 3
             },
             "end": {
-              "offset": 260,
-              "line": 16,
-              "column": 1
+              "offset": 259,
+              "line": 15,
+              "column": 14
             }
           },
           "inline_refs": [],
@@ -239,14 +239,14 @@
           },
           "token": {
             "start": {
-              "offset": 260,
+              "offset": 262,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 291,
-              "line": 17,
-              "column": 1
+              "offset": 290,
+              "line": 16,
+              "column": 31
             }
           },
           "inline_refs": [],
@@ -264,14 +264,14 @@
           },
           "token": {
             "start": {
-              "offset": 291,
+              "offset": 293,
               "line": 17,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 333,
-              "line": 18,
-              "column": 1
+              "offset": 332,
+              "line": 17,
+              "column": 42
             }
           },
           "inline_refs": [],
@@ -290,14 +290,14 @@
           },
           "token": {
             "start": {
-              "offset": 333,
+              "offset": 335,
               "line": 18,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 366,
-              "line": 19,
-              "column": 1
+              "offset": 365,
+              "line": 18,
+              "column": 33
             }
           },
           "inline_refs": [],
@@ -315,14 +315,14 @@
           },
           "token": {
             "start": {
-              "offset": 366,
+              "offset": 368,
               "line": 19,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 398,
-              "line": 20,
-              "column": 1
+              "offset": 397,
+              "line": 19,
+              "column": 32
             }
           },
           "inline_refs": [],
@@ -340,14 +340,14 @@
           },
           "token": {
             "start": {
-              "offset": 398,
+              "offset": 400,
               "line": 20,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 459,
-              "line": 21,
-              "column": 1
+              "offset": 458,
+              "line": 20,
+              "column": 61
             }
           },
           "inline_refs": [],

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/enum_tables.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/enum_tables.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 231,
-              "line": 11,
-              "column": 1
+              "offset": 230,
+              "line": 10,
+              "column": 18
             }
           },
           "inline_refs": [],
@@ -37,14 +37,14 @@
           },
           "token": {
             "start": {
-              "offset": 231,
+              "offset": 233,
               "line": 11,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 283,
-              "line": 12,
-              "column": 1
+              "offset": 282,
+              "line": 11,
+              "column": 52
             }
           },
           "inline_refs": [],
@@ -98,9 +98,9 @@
               "column": 3
             },
             "end": {
-              "offset": 414,
-              "line": 23,
-              "column": 1
+              "offset": 416,
+              "line": 22,
+              "column": 22
             }
           },
           "inline_refs": [],
@@ -116,14 +116,14 @@
           },
           "token": {
             "start": {
-              "offset": 414,
+              "offset": 419,
               "line": 23,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 438,
-              "line": 24,
-              "column": 1
+              "offset": 440,
+              "line": 23,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -137,14 +137,14 @@
           },
           "token": {
             "start": {
-              "offset": 438,
+              "offset": 443,
               "line": 24,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 459,
-              "line": 25,
-              "column": 1
+              "offset": 461,
+              "line": 24,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -157,7 +157,7 @@
           "column": 1
         },
         "end": {
-          "offset": 460,
+          "offset": 463,
           "line": 25,
           "column": 2
         }
@@ -192,9 +192,9 @@
               "column": 3
             },
             "end": {
-              "offset": 62,
-              "line": 3,
-              "column": 1
+              "offset": 61,
+              "line": 2,
+              "column": 44
             }
           },
           "note": {
@@ -217,14 +217,14 @@
           "name": "running",
           "token": {
             "start": {
-              "offset": 62,
+              "offset": 64,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 115,
-              "line": 4,
-              "column": 1
+              "offset": 114,
+              "line": 3,
+              "column": 53
             }
           },
           "note": {
@@ -247,14 +247,14 @@
           "name": "done",
           "token": {
             "start": {
-              "offset": 115,
+              "offset": 117,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 122,
-              "line": 5,
-              "column": 1
+              "offset": 121,
+              "line": 4,
+              "column": 7
             }
           }
         },
@@ -262,14 +262,14 @@
           "name": "failed",
           "token": {
             "start": {
-              "offset": 122,
+              "offset": 124,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 131,
-              "line": 6,
-              "column": 1
+              "offset": 130,
+              "line": 5,
+              "column": 9
             }
           }
         },
@@ -277,14 +277,14 @@
           "name": "wait for validation",
           "token": {
             "start": {
-              "offset": 131,
+              "offset": 132,
               "line": 6,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 197,
-              "line": 7,
-              "column": 1
+              "offset": 196,
+              "line": 6,
+              "column": 66
             }
           },
           "note": {
@@ -330,9 +330,9 @@
               "column": 3
             },
             "end": {
-              "offset": 342,
-              "line": 16,
-              "column": 1
+              "offset": 341,
+              "line": 15,
+              "column": 34
             }
           },
           "note": {
@@ -355,14 +355,14 @@
           "name": "pending",
           "token": {
             "start": {
-              "offset": 342,
+              "offset": 344,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 352,
-              "line": 17,
-              "column": 1
+              "offset": 351,
+              "line": 16,
+              "column": 10
             }
           }
         },
@@ -370,14 +370,14 @@
           "name": "processing",
           "token": {
             "start": {
-              "offset": 352,
+              "offset": 354,
               "line": 17,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 365,
-              "line": 18,
-              "column": 1
+              "offset": 364,
+              "line": 17,
+              "column": 13
             }
           }
         },
@@ -385,14 +385,14 @@
           "name": "completed",
           "token": {
             "start": {
-              "offset": 365,
+              "offset": 367,
               "line": 18,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 377,
-              "line": 19,
-              "column": 1
+              "offset": 376,
+              "line": 18,
+              "column": 12
             }
           }
         }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/general_schema.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/general_schema.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 192,
-              "line": 15,
-              "column": 1
+              "offset": 191,
+              "line": 14,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -38,14 +38,14 @@
           },
           "token": {
             "start": {
-              "offset": 192,
+              "offset": 194,
               "line": 15,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 227,
-              "line": 16,
-              "column": 1
+              "offset": 226,
+              "line": 15,
+              "column": 35
             }
           },
           "inline_refs": [],
@@ -61,14 +61,14 @@
           },
           "token": {
             "start": {
-              "offset": 227,
+              "offset": 229,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 252,
-              "line": 17,
-              "column": 1
+              "offset": 251,
+              "line": 16,
+              "column": 25
             }
           },
           "inline_refs": []
@@ -82,14 +82,14 @@
           },
           "token": {
             "start": {
-              "offset": 252,
+              "offset": 254,
               "line": 17,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 275,
-              "line": 18,
-              "column": 1
+              "offset": 274,
+              "line": 17,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -108,7 +108,7 @@
         }
       },
       "indexes": [],
-      "headerColor": "#FFF"
+      "headerColor": "#fff"
     },
     {
       "name": "order_items",
@@ -129,9 +129,9 @@
               "column": 3
             },
             "end": {
-              "offset": 317,
-              "line": 22,
-              "column": 1
+              "offset": 316,
+              "line": 21,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -145,14 +145,14 @@
           },
           "token": {
             "start": {
-              "offset": 317,
+              "offset": 319,
               "line": 22,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 336,
-              "line": 23,
-              "column": 1
+              "offset": 335,
+              "line": 22,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -166,14 +166,14 @@
           },
           "token": {
             "start": {
-              "offset": 336,
+              "offset": 338,
               "line": 23,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 366,
-              "line": 24,
-              "column": 1
+              "offset": 365,
+              "line": 23,
+              "column": 30
             }
           },
           "inline_refs": [],
@@ -216,9 +216,9 @@
               "column": 3
             },
             "end": {
-              "offset": 404,
-              "line": 28,
-              "column": 1
+              "offset": 403,
+              "line": 27,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -233,14 +233,14 @@
           },
           "token": {
             "start": {
-              "offset": 404,
+              "offset": 406,
               "line": 28,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 421,
-              "line": 29,
-              "column": 1
+              "offset": 420,
+              "line": 28,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -254,14 +254,14 @@
           },
           "token": {
             "start": {
-              "offset": 421,
+              "offset": 423,
               "line": 29,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 452,
-              "line": 30,
-              "column": 1
+              "offset": 451,
+              "line": 29,
+              "column": 31
             }
           },
           "inline_refs": [],
@@ -276,14 +276,14 @@
           },
           "token": {
             "start": {
-              "offset": 452,
+              "offset": 454,
               "line": 30,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 466,
-              "line": 31,
-              "column": 1
+              "offset": 465,
+              "line": 30,
+              "column": 14
             }
           },
           "inline_refs": []
@@ -297,14 +297,14 @@
           },
           "token": {
             "start": {
-              "offset": 466,
+              "offset": 468,
               "line": 31,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 494,
-              "line": 32,
-              "column": 1
+              "offset": 493,
+              "line": 31,
+              "column": 28
             }
           },
           "inline_refs": []
@@ -318,14 +318,14 @@
           },
           "token": {
             "start": {
-              "offset": 494,
+              "offset": 496,
               "line": 32,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 537,
-              "line": 33,
-              "column": 1
+              "offset": 536,
+              "line": 32,
+              "column": 43
             }
           },
           "inline_refs": [],
@@ -416,9 +416,9 @@
               "column": 3
             },
             "end": {
-              "offset": 669,
-              "line": 43,
-              "column": 1
+              "offset": 668,
+              "line": 42,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -433,14 +433,14 @@
           },
           "token": {
             "start": {
-              "offset": 669,
+              "offset": 671,
               "line": 43,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 691,
-              "line": 44,
-              "column": 1
+              "offset": 690,
+              "line": 43,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -454,14 +454,14 @@
           },
           "token": {
             "start": {
-              "offset": 691,
+              "offset": 693,
               "line": 44,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 718,
-              "line": 45,
-              "column": 1
+              "offset": 717,
+              "line": 44,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -476,14 +476,14 @@
           },
           "token": {
             "start": {
-              "offset": 718,
+              "offset": 720,
               "line": 45,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 737,
-              "line": 46,
-              "column": 1
+              "offset": 736,
+              "line": 45,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -497,14 +497,14 @@
           },
           "token": {
             "start": {
-              "offset": 737,
+              "offset": 739,
               "line": 46,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 763,
-              "line": 47,
-              "column": 1
+              "offset": 762,
+              "line": 46,
+              "column": 26
             }
           },
           "inline_refs": []
@@ -518,14 +518,14 @@
           },
           "token": {
             "start": {
-              "offset": 763,
+              "offset": 765,
               "line": 47,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 786,
-              "line": 48,
-              "column": 1
+              "offset": 785,
+              "line": 47,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -539,14 +539,14 @@
           },
           "token": {
             "start": {
-              "offset": 786,
+              "offset": 788,
               "line": 48,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 807,
-              "line": 49,
-              "column": 1
+              "offset": 806,
+              "line": 48,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -585,9 +585,9 @@
               "column": 3
             },
             "end": {
-              "offset": 925,
-              "line": 63,
-              "column": 1
+              "offset": 924,
+              "line": 62,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -602,14 +602,14 @@
           },
           "token": {
             "start": {
-              "offset": 925,
+              "offset": 927,
               "line": 63,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 951,
-              "line": 64,
-              "column": 1
+              "offset": 950,
+              "line": 63,
+              "column": 26
             }
           },
           "inline_refs": []
@@ -623,14 +623,14 @@
           },
           "token": {
             "start": {
-              "offset": 951,
+              "offset": 953,
               "line": 64,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 972,
-              "line": 65,
-              "column": 1
+              "offset": 971,
+              "line": 64,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -644,14 +644,14 @@
           },
           "token": {
             "start": {
-              "offset": 972,
+              "offset": 974,
               "line": 65,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 995,
-              "line": 66,
-              "column": 1
+              "offset": 994,
+              "line": 65,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -665,14 +665,14 @@
           },
           "token": {
             "start": {
-              "offset": 995,
+              "offset": 997,
               "line": 66,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1012,
-              "line": 67,
-              "column": 1
+              "offset": 1011,
+              "line": 66,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -711,9 +711,9 @@
               "column": 3
             },
             "end": {
-              "offset": 1053,
-              "line": 71,
-              "column": 1
+              "offset": 1052,
+              "line": 70,
+              "column": 18
             }
           },
           "inline_refs": [],
@@ -728,14 +728,14 @@
           },
           "token": {
             "start": {
-              "offset": 1053,
+              "offset": 1055,
               "line": 71,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1070,
-              "line": 72,
-              "column": 1
+              "offset": 1069,
+              "line": 71,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -749,14 +749,14 @@
           },
           "token": {
             "start": {
-              "offset": 1070,
+              "offset": 1072,
               "line": 72,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1097,
-              "line": 73,
-              "column": 1
+              "offset": 1096,
+              "line": 72,
+              "column": 27
             }
           },
           "inline_refs": []
@@ -795,9 +795,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1144,
+              "offset": 1117,
               "line": 75,
-              "column": 45
+              "column": 18
             }
           }
         },
@@ -810,9 +810,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1104,
+              "offset": 1120,
               "line": 75,
-              "column": 5
+              "column": 21
             },
             "end": {
               "offset": 1144,
@@ -824,9 +824,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1100,
+          "offset": 1104,
           "line": 75,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1144,
@@ -853,9 +853,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1194,
+              "offset": 1165,
               "line": 77,
-              "column": 49
+              "column": 20
             }
           }
         },
@@ -868,9 +868,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1150,
+              "offset": 1168,
               "line": 77,
-              "column": 5
+              "column": 23
             },
             "end": {
               "offset": 1194,
@@ -882,9 +882,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1146,
+          "offset": 1150,
           "line": 77,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1194,
@@ -911,9 +911,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1243,
+              "offset": 1218,
               "line": 79,
-              "column": 48
+              "column": 23
             }
           }
         },
@@ -926,9 +926,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1200,
+              "offset": 1221,
               "line": 79,
-              "column": 5
+              "column": 26
             },
             "end": {
               "offset": 1243,
@@ -940,9 +940,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1196,
+          "offset": 1200,
           "line": 79,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1243,
@@ -969,9 +969,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1296,
+              "offset": 1267,
               "line": 81,
-              "column": 52
+              "column": 23
             }
           }
         },
@@ -984,9 +984,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1249,
+              "offset": 1270,
               "line": 81,
-              "column": 5
+              "column": 26
             },
             "end": {
               "offset": 1296,
@@ -998,9 +998,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1245,
+          "offset": 1249,
           "line": 81,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1296,
@@ -1027,9 +1027,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1345,
+              "offset": 1318,
               "line": 83,
-              "column": 48
+              "column": 21
             }
           }
         },
@@ -1042,9 +1042,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1302,
+              "offset": 1321,
               "line": 83,
-              "column": 5
+              "column": 24
             },
             "end": {
               "offset": 1345,
@@ -1056,9 +1056,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1298,
+          "offset": 1302,
           "line": 83,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1345,
@@ -1085,9 +1085,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1388,
+              "offset": 1363,
               "line": 85,
-              "column": 42
+              "column": 17
             }
           }
         },
@@ -1100,9 +1100,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1351,
+              "offset": 1366,
               "line": 85,
-              "column": 5
+              "column": 20
             },
             "end": {
               "offset": 1388,
@@ -1114,9 +1114,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1347,
+          "offset": 1351,
           "line": 85,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1388,
@@ -1153,9 +1153,9 @@
               "column": 3
             },
             "end": {
-              "offset": 35,
-              "line": 3,
-              "column": 1
+              "offset": 34,
+              "line": 2,
+              "column": 12
             }
           }
         },
@@ -1163,14 +1163,14 @@
           "name": "running",
           "token": {
             "start": {
-              "offset": 35,
+              "offset": 37,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 47,
-              "line": 4,
-              "column": 1
+              "offset": 46,
+              "line": 3,
+              "column": 12
             }
           }
         },
@@ -1178,14 +1178,14 @@
           "name": "done",
           "token": {
             "start": {
-              "offset": 47,
+              "offset": 49,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 56,
-              "line": 5,
-              "column": 1
+              "offset": 55,
+              "line": 4,
+              "column": 9
             }
           }
         },
@@ -1193,14 +1193,14 @@
           "name": "failure",
           "token": {
             "start": {
-              "offset": 56,
+              "offset": 58,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 68,
-              "line": 6,
-              "column": 1
+              "offset": 67,
+              "line": 5,
+              "column": 12
             }
           }
         }
@@ -1231,9 +1231,9 @@
               "column": 3
             },
             "end": {
-              "offset": 112,
-              "line": 10,
-              "column": 1
+              "offset": 111,
+              "line": 9,
+              "column": 17
             }
           }
         },
@@ -1241,14 +1241,14 @@
           "name": "In Stock",
           "token": {
             "start": {
-              "offset": 112,
+              "offset": 114,
               "line": 10,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 125,
-              "line": 11,
-              "column": 1
+              "offset": 124,
+              "line": 10,
+              "column": 13
             }
           }
         }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/header_color_tables.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/header_color_tables.out.json
@@ -20,9 +20,9 @@
               "column": 2
             },
             "end": {
-              "offset": 92,
-              "line": 3,
-              "column": 1
+              "offset": 81,
+              "line": 2,
+              "column": 8
             }
           },
           "inline_refs": []
@@ -36,14 +36,14 @@
           },
           "token": {
             "start": {
-              "offset": 92,
+              "offset": 93,
               "line": 3,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 105,
-              "line": 4,
-              "column": 1
+              "offset": 104,
+              "line": 3,
+              "column": 13
             }
           },
           "inline_refs": []
@@ -57,14 +57,14 @@
           },
           "token": {
             "start": {
-              "offset": 105,
+              "offset": 106,
               "line": 4,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 121,
-              "line": 5,
-              "column": 1
+              "offset": 120,
+              "line": 4,
+              "column": 16
             }
           },
           "inline_refs": []
@@ -78,14 +78,14 @@
           },
           "token": {
             "start": {
-              "offset": 121,
+              "offset": 122,
               "line": 5,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 142,
-              "line": 6,
-              "column": 1
+              "offset": 141,
+              "line": 5,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -104,7 +104,7 @@
         }
       },
       "indexes": [],
-      "headerColor": "#0065AB"
+      "headerColor": "#0065ab"
     }
   ],
   "refs": [],

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/index_tables.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/index_tables.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 37,
-              "line": 3,
-              "column": 1
+              "offset": 36,
+              "line": 2,
+              "column": 23
             }
           },
           "inline_refs": [],
@@ -37,14 +37,14 @@
           },
           "token": {
             "start": {
-              "offset": 37,
+              "offset": 39,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 57,
-              "line": 4,
-              "column": 1
+              "offset": 56,
+              "line": 3,
+              "column": 20
             }
           },
           "inline_refs": []
@@ -58,14 +58,14 @@
           },
           "token": {
             "start": {
-              "offset": 57,
+              "offset": 59,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 82,
-              "line": 5,
-              "column": 1
+              "offset": 81,
+              "line": 4,
+              "column": 25
             }
           },
           "inline_refs": [],
@@ -80,14 +80,14 @@
           },
           "token": {
             "start": {
-              "offset": 82,
+              "offset": 84,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 99,
-              "line": 6,
-              "column": 1
+              "offset": 98,
+              "line": 5,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -101,14 +101,14 @@
           },
           "token": {
             "start": {
-              "offset": 99,
+              "offset": 101,
               "line": 6,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 123,
-              "line": 7,
-              "column": 1
+              "offset": 122,
+              "line": 6,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -122,14 +122,14 @@
           },
           "token": {
             "start": {
-              "offset": 123,
+              "offset": 125,
               "line": 7,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 144,
-              "line": 8,
-              "column": 1
+              "offset": 143,
+              "line": 7,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -143,14 +143,14 @@
           },
           "token": {
             "start": {
-              "offset": 144,
+              "offset": 146,
               "line": 8,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 164,
-              "line": 9,
-              "column": 1
+              "offset": 162,
+              "line": 8,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -164,14 +164,14 @@
           },
           "token": {
             "start": {
-              "offset": 164,
+              "offset": 166,
               "line": 9,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 192,
-              "line": 10,
-              "column": 1
+              "offset": 191,
+              "line": 9,
+              "column": 28
             }
           },
           "inline_refs": [],
@@ -296,12 +296,12 @@
         {
           "columns": [
             {
-              "value": "active",
-              "type": "column"
-            },
-            {
               "value": "lower(full_name)",
               "type": "expression"
+            },
+            {
+              "value": "active",
+              "type": "column"
             }
           ],
           "token": {

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/multi_notes.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/multi_notes.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 240,
-              "line": 15,
-              "column": 1
+              "offset": 239,
+              "line": 14,
+              "column": 41
             }
           },
           "inline_refs": [],
@@ -52,14 +52,14 @@
           },
           "token": {
             "start": {
-              "offset": 240,
+              "offset": 242,
               "line": 15,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 264,
-              "line": 16,
-              "column": 1
+              "offset": 263,
+              "line": 15,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -73,14 +73,14 @@
           },
           "token": {
             "start": {
-              "offset": 264,
+              "offset": 266,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 285,
-              "line": 17,
-              "column": 1
+              "offset": 284,
+              "line": 16,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -134,9 +134,9 @@
               "column": 3
             },
             "end": {
-              "offset": 358,
-              "line": 24,
-              "column": 1
+              "offset": 357,
+              "line": 23,
+              "column": 13
             }
           },
           "inline_refs": []
@@ -150,14 +150,14 @@
           },
           "token": {
             "start": {
-              "offset": 358,
+              "offset": 360,
               "line": 24,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 376,
-              "line": 25,
-              "column": 1
+              "offset": 375,
+              "line": 24,
+              "column": 18
             }
           },
           "inline_refs": []
@@ -171,14 +171,14 @@
           },
           "token": {
             "start": {
-              "offset": 376,
+              "offset": 378,
               "line": 25,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 396,
-              "line": 26,
-              "column": 1
+              "offset": 395,
+              "line": 25,
+              "column": 20
             }
           },
           "inline_refs": []
@@ -192,14 +192,14 @@
           },
           "token": {
             "start": {
-              "offset": 396,
+              "offset": 398,
               "line": 26,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 419,
-              "line": 27,
-              "column": 1
+              "offset": 418,
+              "line": 26,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -443,9 +443,9 @@
               "column": 3
             },
             "end": {
-              "offset": 146,
-              "line": 8,
-              "column": 1
+              "offset": 145,
+              "line": 7,
+              "column": 34
             }
           },
           "note": {
@@ -468,14 +468,14 @@
           "name": "pending",
           "token": {
             "start": {
-              "offset": 146,
+              "offset": 148,
               "line": 8,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 156,
-              "line": 9,
-              "column": 1
+              "offset": 155,
+              "line": 8,
+              "column": 10
             }
           }
         },
@@ -483,14 +483,14 @@
           "name": "processing",
           "token": {
             "start": {
-              "offset": 156,
+              "offset": 158,
               "line": 9,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 169,
-              "line": 10,
-              "column": 1
+              "offset": 168,
+              "line": 9,
+              "column": 13
             }
           }
         },
@@ -498,14 +498,14 @@
           "name": "completed",
           "token": {
             "start": {
-              "offset": 169,
+              "offset": 171,
               "line": 10,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 181,
-              "line": 11,
-              "column": 1
+              "offset": 180,
+              "line": 10,
+              "column": 12
             }
           }
         }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/multiline_string.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/multiline_string.out.json
@@ -20,14 +20,14 @@
               "column": 3
             },
             "end": {
-              "offset": 196,
-              "line": 12,
-              "column": 1
+              "offset": 195,
+              "line": 11,
+              "column": 7
             }
           },
           "inline_refs": [],
           "note": {
-            "value": "# Objective\n  * Support writing long string that can 'span' over multiple lines\n  * Support writing markdown for DBML Note\n\n# Syntax",
+            "value": "\n\n# Objective\n* Support writing long string that can \\undefined'span' over multiple lines\n* Support writing markdown for DBML Note\n\n# Syntax\n\n",
             "token": {
               "start": {
                 "offset": 24,

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/project.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/project.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 342,
-              "line": 26,
-              "column": 1
+              "offset": 341,
+              "line": 25,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -38,14 +38,14 @@
           },
           "token": {
             "start": {
-              "offset": 342,
+              "offset": 344,
               "line": 26,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 377,
-              "line": 27,
-              "column": 1
+              "offset": 376,
+              "line": 26,
+              "column": 35
             }
           },
           "inline_refs": [],
@@ -61,14 +61,14 @@
           },
           "token": {
             "start": {
-              "offset": 377,
+              "offset": 379,
               "line": 27,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 402,
-              "line": 28,
-              "column": 1
+              "offset": 401,
+              "line": 27,
+              "column": 25
             }
           },
           "inline_refs": []
@@ -82,14 +82,14 @@
           },
           "token": {
             "start": {
-              "offset": 402,
+              "offset": 404,
               "line": 28,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 425,
-              "line": 29,
-              "column": 1
+              "offset": 424,
+              "line": 28,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -108,7 +108,7 @@
         }
       },
       "indexes": [],
-      "headerColor": "#FFF"
+      "headerColor": "#fff"
     },
     {
       "name": "order_items",
@@ -129,9 +129,9 @@
               "column": 3
             },
             "end": {
-              "offset": 467,
-              "line": 33,
-              "column": 1
+              "offset": 466,
+              "line": 32,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -145,14 +145,14 @@
           },
           "token": {
             "start": {
-              "offset": 467,
+              "offset": 469,
               "line": 33,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 486,
-              "line": 34,
-              "column": 1
+              "offset": 485,
+              "line": 33,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -166,14 +166,14 @@
           },
           "token": {
             "start": {
-              "offset": 486,
+              "offset": 488,
               "line": 34,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 516,
-              "line": 35,
-              "column": 1
+              "offset": 515,
+              "line": 34,
+              "column": 30
             }
           },
           "inline_refs": [],
@@ -216,9 +216,9 @@
               "column": 3
             },
             "end": {
-              "offset": 554,
-              "line": 39,
-              "column": 1
+              "offset": 553,
+              "line": 38,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -233,14 +233,14 @@
           },
           "token": {
             "start": {
-              "offset": 554,
+              "offset": 556,
               "line": 39,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 571,
-              "line": 40,
-              "column": 1
+              "offset": 570,
+              "line": 39,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -254,14 +254,14 @@
           },
           "token": {
             "start": {
-              "offset": 571,
+              "offset": 573,
               "line": 40,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 602,
-              "line": 41,
-              "column": 1
+              "offset": 601,
+              "line": 40,
+              "column": 31
             }
           },
           "inline_refs": [],
@@ -276,14 +276,14 @@
           },
           "token": {
             "start": {
-              "offset": 602,
+              "offset": 604,
               "line": 41,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 616,
-              "line": 42,
-              "column": 1
+              "offset": 615,
+              "line": 41,
+              "column": 14
             }
           },
           "inline_refs": []
@@ -297,14 +297,14 @@
           },
           "token": {
             "start": {
-              "offset": 616,
+              "offset": 618,
               "line": 42,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 644,
-              "line": 43,
-              "column": 1
+              "offset": 643,
+              "line": 42,
+              "column": 28
             }
           },
           "inline_refs": []
@@ -318,14 +318,14 @@
           },
           "token": {
             "start": {
-              "offset": 644,
+              "offset": 646,
               "line": 43,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 687,
-              "line": 44,
-              "column": 1
+              "offset": 686,
+              "line": 43,
+              "column": 43
             }
           },
           "inline_refs": [],
@@ -416,9 +416,9 @@
               "column": 3
             },
             "end": {
-              "offset": 819,
-              "line": 54,
-              "column": 1
+              "offset": 818,
+              "line": 53,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -433,14 +433,14 @@
           },
           "token": {
             "start": {
-              "offset": 819,
+              "offset": 821,
               "line": 54,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 841,
-              "line": 55,
-              "column": 1
+              "offset": 840,
+              "line": 54,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -454,14 +454,14 @@
           },
           "token": {
             "start": {
-              "offset": 841,
+              "offset": 843,
               "line": 55,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 868,
-              "line": 56,
-              "column": 1
+              "offset": 867,
+              "line": 55,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -476,14 +476,14 @@
           },
           "token": {
             "start": {
-              "offset": 868,
+              "offset": 870,
               "line": 56,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 887,
-              "line": 57,
-              "column": 1
+              "offset": 886,
+              "line": 56,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -497,14 +497,14 @@
           },
           "token": {
             "start": {
-              "offset": 887,
+              "offset": 889,
               "line": 57,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 913,
-              "line": 58,
-              "column": 1
+              "offset": 912,
+              "line": 57,
+              "column": 26
             }
           },
           "inline_refs": []
@@ -518,14 +518,14 @@
           },
           "token": {
             "start": {
-              "offset": 913,
+              "offset": 915,
               "line": 58,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 936,
-              "line": 59,
-              "column": 1
+              "offset": 935,
+              "line": 58,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -539,14 +539,14 @@
           },
           "token": {
             "start": {
-              "offset": 936,
+              "offset": 938,
               "line": 59,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 957,
-              "line": 60,
-              "column": 1
+              "offset": 956,
+              "line": 59,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -585,9 +585,9 @@
               "column": 3
             },
             "end": {
-              "offset": 1075,
-              "line": 74,
-              "column": 1
+              "offset": 1074,
+              "line": 73,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -602,14 +602,14 @@
           },
           "token": {
             "start": {
-              "offset": 1075,
+              "offset": 1077,
               "line": 74,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1101,
-              "line": 75,
-              "column": 1
+              "offset": 1100,
+              "line": 74,
+              "column": 26
             }
           },
           "inline_refs": []
@@ -623,14 +623,14 @@
           },
           "token": {
             "start": {
-              "offset": 1101,
+              "offset": 1103,
               "line": 75,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1122,
-              "line": 76,
-              "column": 1
+              "offset": 1121,
+              "line": 75,
+              "column": 21
             }
           },
           "inline_refs": []
@@ -644,14 +644,14 @@
           },
           "token": {
             "start": {
-              "offset": 1122,
+              "offset": 1124,
               "line": 76,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1145,
-              "line": 77,
-              "column": 1
+              "offset": 1144,
+              "line": 76,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -665,14 +665,14 @@
           },
           "token": {
             "start": {
-              "offset": 1145,
+              "offset": 1147,
               "line": 77,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1162,
-              "line": 78,
-              "column": 1
+              "offset": 1161,
+              "line": 77,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -711,9 +711,9 @@
               "column": 3
             },
             "end": {
-              "offset": 1203,
-              "line": 82,
-              "column": 1
+              "offset": 1202,
+              "line": 81,
+              "column": 18
             }
           },
           "inline_refs": [],
@@ -728,14 +728,14 @@
           },
           "token": {
             "start": {
-              "offset": 1203,
+              "offset": 1205,
               "line": 82,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1220,
-              "line": 83,
-              "column": 1
+              "offset": 1219,
+              "line": 82,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -749,14 +749,14 @@
           },
           "token": {
             "start": {
-              "offset": 1220,
+              "offset": 1222,
               "line": 83,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 1247,
-              "line": 84,
-              "column": 1
+              "offset": 1246,
+              "line": 83,
+              "column": 27
             }
           },
           "inline_refs": []
@@ -795,9 +795,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1294,
+              "offset": 1267,
               "line": 86,
-              "column": 45
+              "column": 18
             }
           }
         },
@@ -810,9 +810,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1254,
+              "offset": 1270,
               "line": 86,
-              "column": 5
+              "column": 21
             },
             "end": {
               "offset": 1294,
@@ -824,9 +824,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1250,
+          "offset": 1254,
           "line": 86,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1294,
@@ -853,9 +853,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1344,
+              "offset": 1315,
               "line": 88,
-              "column": 49
+              "column": 20
             }
           }
         },
@@ -868,9 +868,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1300,
+              "offset": 1318,
               "line": 88,
-              "column": 5
+              "column": 23
             },
             "end": {
               "offset": 1344,
@@ -882,9 +882,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1296,
+          "offset": 1300,
           "line": 88,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1344,
@@ -911,9 +911,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1393,
+              "offset": 1368,
               "line": 90,
-              "column": 48
+              "column": 23
             }
           }
         },
@@ -926,9 +926,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1350,
+              "offset": 1371,
               "line": 90,
-              "column": 5
+              "column": 26
             },
             "end": {
               "offset": 1393,
@@ -940,9 +940,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1346,
+          "offset": 1350,
           "line": 90,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1393,
@@ -969,9 +969,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1446,
+              "offset": 1417,
               "line": 92,
-              "column": 52
+              "column": 23
             }
           }
         },
@@ -984,9 +984,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1399,
+              "offset": 1420,
               "line": 92,
-              "column": 5
+              "column": 26
             },
             "end": {
               "offset": 1446,
@@ -998,9 +998,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1395,
+          "offset": 1399,
           "line": 92,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1446,
@@ -1027,9 +1027,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1495,
+              "offset": 1468,
               "line": 94,
-              "column": 48
+              "column": 21
             }
           }
         },
@@ -1042,9 +1042,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1452,
+              "offset": 1471,
               "line": 94,
-              "column": 5
+              "column": 24
             },
             "end": {
               "offset": 1495,
@@ -1056,9 +1056,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1448,
+          "offset": 1452,
           "line": 94,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1495,
@@ -1085,9 +1085,9 @@
               "column": 5
             },
             "end": {
-              "offset": 1538,
+              "offset": 1513,
               "line": 96,
-              "column": 42
+              "column": 17
             }
           }
         },
@@ -1100,9 +1100,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1501,
+              "offset": 1516,
               "line": 96,
-              "column": 5
+              "column": 20
             },
             "end": {
               "offset": 1538,
@@ -1114,9 +1114,9 @@
       ],
       "token": {
         "start": {
-          "offset": 1497,
+          "offset": 1501,
           "line": 96,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 1538,
@@ -1153,9 +1153,9 @@
               "column": 3
             },
             "end": {
-              "offset": 185,
-              "line": 14,
-              "column": 1
+              "offset": 184,
+              "line": 13,
+              "column": 12
             }
           }
         },
@@ -1163,14 +1163,14 @@
           "name": "running",
           "token": {
             "start": {
-              "offset": 185,
+              "offset": 187,
               "line": 14,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 197,
-              "line": 15,
-              "column": 1
+              "offset": 196,
+              "line": 14,
+              "column": 12
             }
           }
         },
@@ -1178,14 +1178,14 @@
           "name": "done",
           "token": {
             "start": {
-              "offset": 197,
+              "offset": 199,
               "line": 15,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 206,
-              "line": 16,
-              "column": 1
+              "offset": 205,
+              "line": 15,
+              "column": 9
             }
           }
         },
@@ -1193,14 +1193,14 @@
           "name": "failure",
           "token": {
             "start": {
-              "offset": 206,
+              "offset": 208,
               "line": 16,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 218,
-              "line": 17,
-              "column": 1
+              "offset": 217,
+              "line": 16,
+              "column": 12
             }
           }
         }
@@ -1231,9 +1231,9 @@
               "column": 3
             },
             "end": {
-              "offset": 262,
-              "line": 21,
-              "column": 1
+              "offset": 261,
+              "line": 20,
+              "column": 17
             }
           }
         },
@@ -1241,14 +1241,14 @@
           "name": "In Stock",
           "token": {
             "start": {
-              "offset": 262,
+              "offset": 264,
               "line": 21,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 275,
-              "line": 22,
-              "column": 1
+              "offset": 274,
+              "line": 21,
+              "column": 13
             }
           }
         }
@@ -1317,7 +1317,7 @@
     "enums": [],
     "tableGroups": [],
     "note": {
-      "value": "# Introduction\nThis is an ecommerce project\n\n# Description\n...",
+      "value": "\n# Introduction\nThis is an ecommerce project\n\n# Description\n...\n",
       "token": {
         "start": {
           "offset": 22,

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/referential_actions.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/referential_actions.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 44,
-              "line": 3,
-              "column": 1
+              "offset": 43,
+              "line": 2,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -38,14 +38,14 @@
           },
           "token": {
             "start": {
-              "offset": 44,
+              "offset": 46,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 79,
-              "line": 4,
-              "column": 1
+              "offset": 78,
+              "line": 3,
+              "column": 35
             }
           },
           "inline_refs": [],
@@ -61,14 +61,14 @@
           },
           "token": {
             "start": {
-              "offset": 79,
+              "offset": 81,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 109,
-              "line": 5,
-              "column": 1
+              "offset": 108,
+              "line": 4,
+              "column": 30
             }
           },
           "inline_refs": []
@@ -82,14 +82,14 @@
           },
           "token": {
             "start": {
-              "offset": 109,
+              "offset": 111,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 137,
-              "line": 6,
-              "column": 1
+              "offset": 136,
+              "line": 5,
+              "column": 28
             }
           },
           "inline_refs": []
@@ -128,9 +128,9 @@
               "column": 3
             },
             "end": {
-              "offset": 179,
-              "line": 10,
-              "column": 1
+              "offset": 178,
+              "line": 9,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -144,14 +144,14 @@
           },
           "token": {
             "start": {
-              "offset": 179,
+              "offset": 181,
               "line": 10,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 198,
-              "line": 11,
-              "column": 1
+              "offset": 197,
+              "line": 10,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -165,14 +165,14 @@
           },
           "token": {
             "start": {
-              "offset": 198,
+              "offset": 200,
               "line": 11,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 228,
-              "line": 12,
-              "column": 1
+              "offset": 227,
+              "line": 11,
+              "column": 30
             }
           },
           "inline_refs": []
@@ -186,14 +186,14 @@
           },
           "token": {
             "start": {
-              "offset": 228,
+              "offset": 230,
               "line": 12,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 258,
-              "line": 13,
-              "column": 1
+              "offset": 257,
+              "line": 12,
+              "column": 30
             }
           },
           "inline_refs": [],
@@ -236,9 +236,9 @@
               "column": 3
             },
             "end": {
-              "offset": 291,
-              "line": 17,
-              "column": 1
+              "offset": 290,
+              "line": 16,
+              "column": 11
             }
           },
           "inline_refs": []
@@ -252,14 +252,14 @@
           },
           "token": {
             "start": {
-              "offset": 291,
+              "offset": 293,
               "line": 17,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 313,
-              "line": 18,
-              "column": 1
+              "offset": 312,
+              "line": 17,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -273,14 +273,14 @@
           },
           "token": {
             "start": {
-              "offset": 313,
+              "offset": 315,
               "line": 18,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 337,
-              "line": 19,
-              "column": 1
+              "offset": 336,
+              "line": 18,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -294,14 +294,14 @@
           },
           "token": {
             "start": {
-              "offset": 337,
+              "offset": 339,
               "line": 19,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 380,
-              "line": 20,
-              "column": 1
+              "offset": 379,
+              "line": 19,
+              "column": 43
             }
           },
           "inline_refs": [],
@@ -370,9 +370,9 @@
               "column": 3
             },
             "end": {
-              "offset": 457,
-              "line": 28,
-              "column": 1
+              "offset": 456,
+              "line": 27,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -388,14 +388,14 @@
           },
           "token": {
             "start": {
-              "offset": 457,
+              "offset": 459,
               "line": 28,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 479,
-              "line": 29,
-              "column": 1
+              "offset": 478,
+              "line": 28,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -409,14 +409,14 @@
           },
           "token": {
             "start": {
-              "offset": 479,
+              "offset": 481,
               "line": 29,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 511,
-              "line": 30,
-              "column": 1
+              "offset": 510,
+              "line": 29,
+              "column": 32
             }
           },
           "inline_refs": [],
@@ -431,14 +431,14 @@
           },
           "token": {
             "start": {
-              "offset": 511,
+              "offset": 513,
               "line": 30,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 538,
-              "line": 31,
-              "column": 1
+              "offset": 537,
+              "line": 30,
+              "column": 27
             }
           },
           "inline_refs": []
@@ -452,14 +452,14 @@
           },
           "token": {
             "start": {
-              "offset": 538,
+              "offset": 540,
               "line": 31,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 581,
-              "line": 32,
-              "column": 1
+              "offset": 580,
+              "line": 31,
+              "column": 43
             }
           },
           "inline_refs": [],
@@ -477,14 +477,14 @@
           },
           "token": {
             "start": {
-              "offset": 581,
+              "offset": 583,
               "line": 32,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 613,
-              "line": 33,
-              "column": 1
+              "offset": 612,
+              "line": 32,
+              "column": 32
             }
           },
           "inline_refs": [],
@@ -524,9 +524,9 @@
               "column": 3
             },
             "end": {
-              "offset": 654,
-              "line": 37,
-              "column": 1
+              "offset": 653,
+              "line": 36,
+              "column": 18
             }
           },
           "inline_refs": [],
@@ -541,14 +541,14 @@
           },
           "token": {
             "start": {
-              "offset": 654,
+              "offset": 656,
               "line": 37,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 676,
-              "line": 38,
-              "column": 1
+              "offset": 675,
+              "line": 37,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -562,14 +562,14 @@
           },
           "token": {
             "start": {
-              "offset": 676,
+              "offset": 678,
               "line": 38,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 708,
-              "line": 39,
-              "column": 1
+              "offset": 707,
+              "line": 38,
+              "column": 32
             }
           },
           "inline_refs": []
@@ -608,9 +608,9 @@
               "column": 5
             },
             "end": {
-              "offset": 767,
+              "offset": 727,
               "line": 41,
-              "column": 57
+              "column": 17
             }
           }
         },
@@ -623,31 +623,31 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 715,
+              "offset": 730,
               "line": 41,
-              "column": 5
+              "column": 20
             },
             "end": {
-              "offset": 767,
+              "offset": 748,
               "line": 41,
-              "column": 57
+              "column": 38
             }
           }
         }
       ],
+      "onDelete": "restrict",
       "token": {
         "start": {
-          "offset": 711,
+          "offset": 715,
           "line": 41,
-          "column": 1
+          "column": 5
         },
         "end": {
-          "offset": 767,
+          "offset": 748,
           "line": 41,
-          "column": 57
+          "column": 38
         }
       },
-      "onDelete": "restrict",
       "schemaName": null
     },
     {
@@ -667,9 +667,9 @@
               "column": 5
             },
             "end": {
-              "offset": 831,
+              "offset": 786,
               "line": 43,
-              "column": 63
+              "column": 18
             }
           }
         },
@@ -682,31 +682,31 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 773,
+              "offset": 789,
               "line": 43,
-              "column": 5
+              "column": 21
             },
             "end": {
-              "offset": 831,
+              "offset": 813,
               "line": 43,
-              "column": 63
+              "column": 45
             }
           }
         }
       ],
+      "onDelete": "cascade",
       "token": {
         "start": {
-          "offset": 769,
+          "offset": 773,
           "line": 43,
-          "column": 1
+          "column": 5
         },
         "end": {
-          "offset": 831,
+          "offset": 813,
           "line": 43,
-          "column": 63
+          "column": 45
         }
       },
-      "onDelete": "cascade",
       "schemaName": null
     },
     {
@@ -727,9 +727,9 @@
               "column": 5
             },
             "end": {
-              "offset": 928,
+              "offset": 862,
               "line": 45,
-              "column": 96
+              "column": 30
             }
           }
         },
@@ -743,31 +743,31 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 837,
+              "offset": 865,
               "line": 45,
-              "column": 5
+              "column": 33
             },
             "end": {
-              "offset": 928,
+              "offset": 909,
               "line": 45,
-              "column": 96
+              "column": 77
             }
           }
         }
       ],
+      "onDelete": "set null",
       "token": {
         "start": {
-          "offset": 833,
+          "offset": 837,
           "line": 45,
-          "column": 1
+          "column": 5
         },
         "end": {
-          "offset": 928,
+          "offset": 909,
           "line": 45,
-          "column": 96
+          "column": 77
         }
       },
-      "onDelete": "set null",
       "schemaName": null
     },
     {
@@ -787,9 +787,9 @@
               "column": 5
             },
             "end": {
-              "offset": 997,
+              "offset": 952,
               "line": 47,
-              "column": 68
+              "column": 23
             }
           }
         },
@@ -802,31 +802,31 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 934,
+              "offset": 955,
               "line": 47,
-              "column": 5
+              "column": 26
             },
             "end": {
-              "offset": 997,
+              "offset": 977,
               "line": 47,
-              "column": 68
+              "column": 48
             }
           }
         }
       ],
+      "onDelete": "no action",
       "token": {
         "start": {
-          "offset": 930,
+          "offset": 934,
           "line": 47,
-          "column": 1
+          "column": 5
         },
         "end": {
-          "offset": 997,
+          "offset": 977,
           "line": 47,
-          "column": 68
+          "column": 48
         }
       },
-      "onDelete": "no action",
       "schemaName": null
     }
   ],

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/table_element.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/table_element.out.json
@@ -15,17 +15,18 @@
           },
           "token": {
             "start": {
-              "offset": 49,
+              "offset": 16,
               "line": 2,
               "column": 3
             },
             "end": {
-              "offset": 61,
-              "line": 3,
-              "column": 1
+              "offset": 27,
+              "line": 2,
+              "column": 14
             }
           },
-          "inline_refs": []
+          "inline_refs": [],
+          "pk": true
         },
         {
           "name": "name",
@@ -36,17 +37,18 @@
           },
           "token": {
             "start": {
-              "offset": 61,
+              "offset": 30,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 81,
-              "line": 4,
-              "column": 1
+              "offset": 47,
+              "line": 3,
+              "column": 20
             }
           },
-          "inline_refs": []
+          "inline_refs": [],
+          "pk": true
         },
         {
           "name": "gender",
@@ -57,14 +59,14 @@
           },
           "token": {
             "start": {
-              "offset": 81,
+              "offset": 50,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 98,
-              "line": 5,
-              "column": 1
+              "offset": 64,
+              "line": 4,
+              "column": 17
             }
           },
           "inline_refs": []
@@ -78,14 +80,14 @@
           },
           "token": {
             "start": {
-              "offset": 98,
+              "offset": 67,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 120,
-              "line": 6,
-              "column": 1
+              "offset": 86,
+              "line": 5,
+              "column": 22
             }
           },
           "inline_refs": []
@@ -98,8 +100,8 @@
           "column": 1
         },
         "end": {
-          "offset": 407,
-          "line": 29,
+          "offset": 352,
+          "line": 27,
           "column": 2
         }
       },
@@ -113,13 +115,13 @@
           ],
           "token": {
             "start": {
-              "offset": 159,
-              "line": 10,
+              "offset": 104,
+              "line": 8,
               "column": 5
             },
             "end": {
-              "offset": 161,
-              "line": 10,
+              "offset": 106,
+              "line": 8,
               "column": 7
             }
           }
@@ -137,13 +139,13 @@
           ],
           "token": {
             "start": {
-              "offset": 166,
-              "line": 11,
+              "offset": 111,
+              "line": 9,
               "column": 5
             },
             "end": {
-              "offset": 176,
-              "line": 11,
+              "offset": 121,
+              "line": 9,
               "column": 15
             }
           }
@@ -157,13 +159,13 @@
           ],
           "token": {
             "start": {
-              "offset": 198,
-              "line": 15,
+              "offset": 143,
+              "line": 13,
               "column": 5
             },
             "end": {
-              "offset": 204,
-              "line": 15,
+              "offset": 149,
+              "line": 13,
               "column": 11
             }
           }
@@ -177,54 +179,29 @@
           ],
           "token": {
             "start": {
-              "offset": 209,
-              "line": 16,
+              "offset": 154,
+              "line": 14,
               "column": 5
             },
             "end": {
-              "offset": 219,
-              "line": 16,
+              "offset": 164,
+              "line": 14,
               "column": 15
             }
           }
-        },
-        {
-          "columns": [
-            {
-              "value": "id",
-              "type": "column"
-            },
-            {
-              "value": "name",
-              "type": "column"
-            }
-          ],
-          "token": {
-            "start": {
-              "offset": 49,
-              "line": 2,
-              "column": 3
-            },
-            "end": {
-              "offset": 61,
-              "line": 3,
-              "column": 1
-            }
-          },
-          "pk": true
         }
       ],
       "note": {
-        "value": "# Note\n\n## Objective\n  * Support define element's note inside element body\n  * Make writing long note easier with the new syntax",
+        "value": "\n# Note\n\n## Objective\n* Support define element's note inside element body\n* Make writing long note easier with the new syntax\n\n",
         "token": {
           "start": {
-            "offset": 227,
-            "line": 19,
+            "offset": 172,
+            "line": 17,
             "column": 3
           },
           "end": {
-            "offset": 405,
-            "line": 28,
+            "offset": 350,
+            "line": 26,
             "column": 4
           }
         }

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/table_group.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/table_group.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 28,
-              "line": 3,
-              "column": 1
+              "offset": 27,
+              "line": 2,
+              "column": 9
             }
           },
           "inline_refs": []
@@ -36,14 +36,14 @@
           },
           "token": {
             "start": {
-              "offset": 28,
+              "offset": 29,
               "line": 3,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 47,
-              "line": 4,
-              "column": 1
+              "offset": 46,
+              "line": 3,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -57,14 +57,14 @@
           },
           "token": {
             "start": {
-              "offset": 47,
+              "offset": 49,
               "line": 4,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 70,
-              "line": 5,
-              "column": 1
+              "offset": 69,
+              "line": 4,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -78,14 +78,14 @@
           },
           "token": {
             "start": {
-              "offset": 70,
+              "offset": 72,
               "line": 5,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 89,
-              "line": 6,
-              "column": 1
+              "offset": 88,
+              "line": 5,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -124,9 +124,9 @@
               "column": 3
             },
             "end": {
-              "offset": 120,
-              "line": 10,
-              "column": 1
+              "offset": 118,
+              "line": 9,
+              "column": 9
             }
           },
           "inline_refs": []
@@ -140,14 +140,14 @@
           },
           "token": {
             "start": {
-              "offset": 120,
+              "offset": 122,
               "line": 10,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 144,
-              "line": 11,
-              "column": 1
+              "offset": 143,
+              "line": 10,
+              "column": 24
             }
           },
           "inline_refs": []
@@ -161,14 +161,14 @@
           },
           "token": {
             "start": {
-              "offset": 144,
+              "offset": 145,
               "line": 11,
-              "column": 1
+              "column": 2
             },
             "end": {
-              "offset": 162,
-              "line": 12,
-              "column": 1
+              "offset": 161,
+              "line": 11,
+              "column": 18
             }
           },
           "inline_refs": []
@@ -182,14 +182,14 @@
           },
           "token": {
             "start": {
-              "offset": 162,
+              "offset": 164,
               "line": 12,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 185,
-              "line": 13,
-              "column": 1
+              "offset": 184,
+              "line": 12,
+              "column": 23
             }
           },
           "inline_refs": []
@@ -203,14 +203,14 @@
           },
           "token": {
             "start": {
-              "offset": 185,
+              "offset": 187,
               "line": 13,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 251,
-              "line": 14,
-              "column": 1
+              "offset": 213,
+              "line": 13,
+              "column": 29
             }
           },
           "inline_refs": [
@@ -223,9 +223,9 @@
               "relation": ">",
               "token": {
                 "start": {
-                  "offset": 201,
+                  "offset": 206,
                   "line": 13,
-                  "column": 17
+                  "column": 22
                 },
                 "end": {
                   "offset": 212,
@@ -259,26 +259,6 @@
       "endpoints": [
         {
           "schemaName": null,
-          "tableName": "U",
-          "fieldNames": [
-            "id"
-          ],
-          "relation": "1",
-          "token": {
-            "start": {
-              "offset": 201,
-              "line": 13,
-              "column": 17
-            },
-            "end": {
-              "offset": 212,
-              "line": 13,
-              "column": 28
-            }
-          }
-        },
-        {
-          "schemaName": null,
           "tableName": "merchants",
           "fieldNames": [
             "admin_id"
@@ -286,9 +266,29 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 201,
+              "offset": 187,
               "line": 13,
-              "column": 17
+              "column": 3
+            },
+            "end": {
+              "offset": 213,
+              "line": 13,
+              "column": 29
+            }
+          }
+        },
+        {
+          "schemaName": null,
+          "tableName": "U",
+          "fieldNames": [
+            "id"
+          ],
+          "relation": "1",
+          "token": {
+            "start": {
+              "offset": 206,
+              "line": 13,
+              "column": 22
             },
             "end": {
               "offset": 212,
@@ -300,9 +300,9 @@
       ],
       "token": {
         "start": {
-          "offset": 201,
+          "offset": 206,
           "line": 13,
-          "column": 17
+          "column": 22
         },
         "end": {
           "offset": 212,

--- a/packages/dbml-core/__tests__/parser/dbml-parse/output/table_settings.out.json
+++ b/packages/dbml-core/__tests__/parser/dbml-parse/output/table_settings.out.json
@@ -20,9 +20,9 @@
               "column": 3
             },
             "end": {
-              "offset": 51,
-              "line": 3,
-              "column": 1
+              "offset": 50,
+              "line": 2,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -37,14 +37,14 @@
           },
           "token": {
             "start": {
-              "offset": 51,
+              "offset": 53,
               "line": 3,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 67,
-              "line": 4,
-              "column": 1
+              "offset": 66,
+              "line": 3,
+              "column": 16
             }
           },
           "inline_refs": []
@@ -84,9 +84,9 @@
               "column": 3
             },
             "end": {
-              "offset": 131,
-              "line": 8,
-              "column": 1
+              "offset": 130,
+              "line": 7,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -101,14 +101,14 @@
           },
           "token": {
             "start": {
-              "offset": 131,
+              "offset": 133,
               "line": 8,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 158,
-              "line": 9,
-              "column": 1
+              "offset": 157,
+              "line": 8,
+              "column": 27
             }
           },
           "inline_refs": [],
@@ -163,9 +163,9 @@
               "column": 3
             },
             "end": {
-              "offset": 251,
-              "line": 13,
-              "column": 1
+              "offset": 250,
+              "line": 12,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -180,14 +180,14 @@
           },
           "token": {
             "start": {
-              "offset": 251,
+              "offset": 253,
               "line": 13,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 267,
-              "line": 14,
-              "column": 1
+              "offset": 266,
+              "line": 13,
+              "column": 16
             }
           },
           "inline_refs": []
@@ -201,14 +201,14 @@
           },
           "token": {
             "start": {
-              "offset": 267,
+              "offset": 269,
               "line": 14,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 296,
-              "line": 15,
-              "column": 1
+              "offset": 295,
+              "line": 14,
+              "column": 29
             }
           },
           "inline_refs": [],
@@ -264,9 +264,9 @@
               "column": 3
             },
             "end": {
-              "offset": 387,
-              "line": 19,
-              "column": 1
+              "offset": 386,
+              "line": 18,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -281,14 +281,14 @@
           },
           "token": {
             "start": {
-              "offset": 387,
+              "offset": 389,
               "line": 19,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 403,
-              "line": 20,
-              "column": 1
+              "offset": 402,
+              "line": 19,
+              "column": 16
             }
           },
           "inline_refs": []
@@ -302,14 +302,14 @@
           },
           "token": {
             "start": {
-              "offset": 403,
+              "offset": 405,
               "line": 20,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 422,
-              "line": 21,
-              "column": 1
+              "offset": 421,
+              "line": 20,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -323,14 +323,14 @@
           },
           "token": {
             "start": {
-              "offset": 422,
+              "offset": 424,
               "line": 21,
-              "column": 1
+              "column": 3
             },
             "end": {
-              "offset": 441,
-              "line": 22,
-              "column": 1
+              "offset": 440,
+              "line": 21,
+              "column": 19
             }
           },
           "inline_refs": []
@@ -385,9 +385,9 @@
               "column": 5
             },
             "end": {
-              "offset": 482,
+              "offset": 459,
               "line": 24,
-              "column": 39
+              "column": 16
             }
           }
         },
@@ -400,9 +400,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 448,
+              "offset": 462,
               "line": 24,
-              "column": 5
+              "column": 19
             },
             "end": {
               "offset": 482,
@@ -414,9 +414,9 @@
       ],
       "token": {
         "start": {
-          "offset": 444,
+          "offset": 448,
           "line": 24,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 482,
@@ -443,9 +443,9 @@
               "column": 5
             },
             "end": {
-              "offset": 528,
+              "offset": 502,
               "line": 26,
-              "column": 45
+              "column": 19
             }
           }
         },
@@ -458,9 +458,9 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 488,
+              "offset": 505,
               "line": 26,
-              "column": 5
+              "column": 22
             },
             "end": {
               "offset": 528,
@@ -472,9 +472,9 @@
       ],
       "token": {
         "start": {
-          "offset": 484,
+          "offset": 488,
           "line": 26,
-          "column": 1
+          "column": 5
         },
         "end": {
           "offset": 528,


### PR DESCRIPTION
## Summary
* Inspect and fix old tests.
* Test input changes: See the commit history
* Test output changes: All output changes fall into one of these:
   * 2 trivial output changes:
     Some fields are reordered when serialized.
     Some extra newlines during note content normalization (removing spaces at the start of a line).
   * 1 major output change: Offset calculation
      * Subfield's offset:
        * The new parser sets the span of a subfield from the start of its callee till the end of its last argument.
        * The old parser always takes the whole line to be a subfield's span (except for the first subfield, it doesn't consider leading spaces at all).
      * Ref endpoint's offset:
         * The new parser sets the span of an endpoint to be the span of the endpoint's expression.
         * The old parser takes the whole ref to be an endpoint's span.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review