### PR TITLE
fix: bearer scan continue-on-error not works

### DIFF
--- a/.github/workflows/bearer.yml
+++ b/.github/workflows/bearer.yml
@@ -13,6 +13,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
+      - uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
       - name: Run Report
         id: report
         uses: bearer/bearer-action@v2
@@ -21,10 +24,8 @@ jobs:
           output: rd.json
           diff: true
           config-file: 'bearer.yml'
-      - uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest
       - name: Run reviewdog
+        if: always()
         env:
           REVIEWDOG_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
         run:


### PR DESCRIPTION
## Summary
we have continue-on-error: true to always run reviewdog but this option not always work -> refactored flow with if: always()

Ref: https://github.com/Bearer/bearer/pull/1281

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review