### PR TITLE
Replace 'sp+' with '__' around the relation sign in the ref body

### DIFF
--- a/packages/dbml-core/src/parse/dbml/parser.pegjs
+++ b/packages/dbml-core/src/parse/dbml/parser.pegjs
@@ -40,7 +40,7 @@ expr
   }
   / __
 
-ProjectSyntax 
+ProjectSyntax
   = project name:(__ name)? _ "{" _ body:ProjectBody _ "}" {
     return {
       name: name ? name[1] : null,
@@ -152,7 +152,7 @@ RefSyntax
     return {
       ...r,
       schemaName,
-    }; 
+    };
   }
 
 ref_long
@@ -178,7 +178,7 @@ ref_short
     }
 
 ref_body
-  = field1:field_identifier sp+ relation:relation sp+ field2:field_identifier sp* ref_settings:RefSettings? {
+  = field1:field_identifier __ relation:relation __ field2:field_identifier sp* ref_settings:RefSettings? {
     const rel = getRelations(relation);
     const endpoints = [
       {
@@ -203,14 +203,14 @@ ref_body
   }
 //CHANGE
 RefField
-  = field:(RefSingleField/RefMultipleFields) { 
+  = field:(RefSingleField/RefMultipleFields) {
     if (typeof field === "string") field = [field];
-    return field; 
+    return field;
   }
 
 RefSingleField
   =  field:name { return field; }
- 
+
 RefMultipleFields
   = "(" sp* first:RefSingleField rest:(sp* Comma sp* RefSingleField)* sp* ")"  {
     let arrField = [first].concat(rest.map(el => el[3]));
@@ -484,7 +484,7 @@ Indexes
     {
       return body;
     }
-    
+
 IndexesBody = _ index: Index+ _ {
   return index;
 }
@@ -636,11 +636,11 @@ name "valid name"
 
 schema_name "schema name" = name:name "." { return name }
 
-field_identifier = 
+field_identifier =
   schemaName:name "." tableName:name "." fieldNames:RefField { return { schemaName, tableName, fieldNames } } /
   tableName:name "." fieldNames:RefField { return { schemaName: null, tableName, fieldNames } }
 
-inline_field_identifier = 
+inline_field_identifier =
   schemaName:name "." tableName:name "." fieldName:name { return { schemaName, tableName, fieldName } } /
   tableName:name "." fieldName:name { return { schemaName: null, tableName, fieldName } }
 
@@ -704,7 +704,7 @@ StringLiteral "string"
     / "'''" chars: MultiLineStringCharacter* "'''" {
         let str = chars.join('');
         // // replace line continuation using look around, but this is not compatible with firefox, safari.
-        // str = str.replace(/(?<!\\)\\(?!\\)(?:\n|\r\n)?/g, ''); 
+        // str = str.replace(/(?<!\\)\\(?!\\)(?:\n|\r\n)?/g, '');
         // str = str.replace(/\\\\/, '\\');
 
         let lines = str.split(/\n|\r\n?/);


### PR DESCRIPTION
## Summary
Replaced 'sp+' with '__' (requiring at least 1 whitespace) around the relation sign in the ref body, so it's possible to break a line before or after the relation sign for long `Ref` declarations representing composite foreign keys.

## Issue
#470

## Lasting Changes (Technical)

* Replaced 'sp+' with '__' around the relation sign in the ref body (line 181)
* Formatted the file on save, trimming trailing whitespaces (actually, unintentionally, can revert it and only leave the first change)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review

## P.S.
Please, let me know if I should continue with this PR and what else needs to be done (adding tests, etc.).