### PR TITLE
fix(sql2dbml): properly escape notes when notes do contain some '

### DIFF
--- a/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
+++ b/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
@@ -365,9 +365,9 @@ Table "production"."productreview" {
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "reviewername" public.Name [not null, note: 'Name of the reviewer.']
   "reviewdate" timestamp [not null, default: `now()`, note: 'Date review was submitted.']
-  "emailaddress" "character varying(50)" [not null, note: 'Reviewer''s e-mail address.']
+  "emailaddress" "character varying(50)" [not null, note: 'Reviewer\'s e-mail address.']
   "rating" integer [not null, note: 'Product rating given by the reviewer. Scale is 1 to 5 with 5 as the highest rating.']
-  "comments" "character varying(3850)" [note: 'Reviewer''s comments']
+  "comments" "character varying(3850)" [note: 'Reviewer\'s comments']
   "modifieddate" timestamp [not null, default: `now()`]
   Note: 'Customer reviews of products they have purchased.'
 }
@@ -456,7 +456,7 @@ Table "purchasing"."purchaseorderdetail" {
   "duedate" timestamp [not null, note: 'Date the product is expected to be received.']
   "orderqty" smallint [not null, note: 'Quantity ordered.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
-  "unitprice" numeric [not null, note: 'Vendor''s selling price of a single product.']
+  "unitprice" numeric [not null, note: 'Vendor\'s selling price of a single product.']
   "receivedqty" numeric(8,2) [not null, note: 'Quantity actually received from the vendor.']
   "rejectedqty" numeric(8,2) [not null, note: 'Quantity rejected during inspection.']
   "modifieddate" timestamp [not null, default: `now()`]
@@ -483,13 +483,13 @@ Table "purchasing"."productvendor" {
   "productid" integer [not null, note: 'Primary key. Foreign key to Product.ProductID.']
   "businessentityid" integer [not null, note: 'Primary key. Foreign key to Vendor.BusinessEntityID.']
   "averageleadtime" integer [not null, note: 'The average span of time (in days) between placing an order with the vendor and receiving the purchased product.']
-  "standardprice" numeric [not null, note: 'The vendor''s usual selling price.']
+  "standardprice" numeric [not null, note: 'The vendor\'s usual selling price.']
   "lastreceiptcost" numeric [note: 'The selling price when last purchased.']
   "lastreceiptdate" timestamp [note: 'Date the product was last received by the vendor.']
   "minorderqty" integer [not null, note: 'The maximum quantity that should be ordered.']
   "maxorderqty" integer [not null, note: 'The minimum quantity that should be ordered.']
   "onorderqty" integer [note: 'The quantity currently on order.']
-  "unitmeasurecode" "character (3)" [not null, note: 'The product''s unit of measure.']
+  "unitmeasurecode" "character (3)" [not null, note: 'The product\'s unit of measure.']
   "modifieddate" timestamp [not null, default: `now()`]
   Note: 'Cross-reference table mapping vendors with the products they supply.'
 }

--- a/packages/dbml-core/src/export/DbmlExporter.js
+++ b/packages/dbml-core/src/export/DbmlExporter.js
@@ -15,6 +15,10 @@ class DbmlExporter {
     return /\s*(\*|\+|-|\([A-Za-z0-9_]+\)|\(\))/g.test(str);
   }
 
+  static escapeNote (str) {
+    return str.replaceAll("'", "\\'")
+  }
+
   static exportEnums (enumIds, model) {
     const enumStrs = enumIds.map(enumId => {
       const _enum = model.enums[enumId];
@@ -23,7 +27,7 @@ class DbmlExporter {
       return `Enum ${shouldPrintSchema(schema, model)
         ? `"${schema.name}".` : ''}"${_enum.name}" {\n${
         _enum.valueIds.map(valueId => `  "${model.enumValues[valueId].name}"${model.enumValues[valueId].note
-          ? ` [note: '${model.enumValues[valueId].note}']` : ''}`).join('\n')}\n}\n`;
+          ? ` [note: '${DbmlExporter.escapeNote(model.enumValues[valueId].note)}']` : ''}`).join('\n')}\n}\n`;
     });
 
     return enumStrs.length ? enumStrs.join('\n') : '';
@@ -78,7 +82,7 @@ class DbmlExporter {
         constraints.push(value);
       }
       if (field.note) {
-        constraints.push(`note: '${field.note.replaceAll("'", "\\'")}'`);
+        constraints.push(`note: '${DbmlExporter.escapeNote(field.note)}'`);
       }
 
       if (constraints.length > 0) {
@@ -175,7 +179,7 @@ class DbmlExporter {
       if (!_.isEmpty(tableContent.indexContents)) {
         indexStr = `\nIndexes {\n${tableContent.indexContents.map(indexLine => `  ${indexLine}`).join('\n')}\n}`;
       }
-      const tableNote = table.note ? `  Note: '${table.note}'\n` : '';
+      const tableNote = table.note ? `  Note: '${DbmlExporter.escapeNote(table.note)}'\n` : '';
 
       const tableStr = `Table ${shouldPrintSchema(schema, model)
         ? `"${schema.name}".` : ''}"${table.name}"${tableSettingStr} {\n${

--- a/packages/dbml-core/src/export/DbmlExporter.js
+++ b/packages/dbml-core/src/export/DbmlExporter.js
@@ -78,7 +78,7 @@ class DbmlExporter {
         constraints.push(value);
       }
       if (field.note) {
-        constraints.push(`note: '${field.note}'`);
+        constraints.push(`note: '${field.note.replaceAll("'", "\\'")}'`);
       }
 
       if (constraints.length > 0) {

--- a/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
+++ b/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
@@ -21,6 +21,13 @@ const findTable = (tables, schemaName, tableName) => {
   return table;
 };
 
+const escapeStr = (str) => {
+  if (str) {
+    return str.replaceAll("''", "'");
+  }
+  return str;
+}
+
 export default class PostgresASTGen extends PostgreSQLParserVisitor {
 
   constructor () {
@@ -856,7 +863,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
         if (!table) return;
 
         const note = ctx.comment_text().accept(this);
-        table.note = { value: note };
+        table.note = { value: escapeStr(note) };
       }
     }
 
@@ -872,7 +879,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
       if (!field) return;
 
       const note = ctx.comment_text().accept(this);
-      field.note = { value: note };
+      field.note = { value: escapeStr(note) };
     }
   }
 


### PR DESCRIPTION
## Summary
* Allow putting notes with simple quotes

## Issue
https://github.com/holistics/dbml/issues/492


## Lasting Changes (Technical)

Simply escape simple quotes in notes to avolid dbml parsers to fail

## Checklist

Please check directly on the box once each of these are done

- [x] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review