### PR TITLE
Fix/dbml alias & primary key & note content bug

### DIFF
--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/table.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/table.ts
@@ -85,7 +85,7 @@ export default class TableValidator implements ElementValidator {
     }
 
     if (!isValidAlias(aliasNode)) {
-      return [new CompileError(CompileErrorCode.INVALID_ALIAS, 'A Table alias must be of the form <alias>', aliasNode)]
+      return [new CompileError(CompileErrorCode.INVALID_ALIAS, 'Table aliases can only contains alphanumeric and underscore unless surrounded by double quotes', aliasNode)]
     }
 
     return [];
@@ -428,12 +428,5 @@ function isValidColumnType(type: SyntaxNode): boolean {
 }
 
 function isAliasSameAsName(alias: string, nameFragments: string[]): boolean {
-  if (nameFragments.length > 1 || nameFragments.length === 0) {
-    return false;
-  }
-  if (alias === nameFragments[0]) {
-    return true;
-  }
-
-  return false;
+  return nameFragments.length === 1 && alias === nameFragments[0];
 }

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/enum.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/enum.ts
@@ -3,7 +3,7 @@ import { aggregateSettingList } from "../../analyzer/validator/utils";
 import { CompileError, CompileErrorCode } from "../../errors";
 import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, ListExpressionNode, SyntaxNode } from "../../parser/nodes";
 import { ElementInterpreter, Enum, EnumField, InterpreterDatabase, Table } from "../types";
-import { extractElementName, getTokenPosition, normalizeNoteContent } from "../utils";
+import { extractElementName, getTokenPosition } from "../utils";
 
 export class EnumInterpreter implements ElementInterpreter {
   private declarationNode: ElementDeclarationNode;
@@ -50,7 +50,7 @@ export class EnumInterpreter implements ElementInterpreter {
       const settingMap = aggregateSettingList(field.args[0] as ListExpressionNode).getValue();
       const noteNode = settingMap['note']?.at(0);
       enumField.note = noteNode && {
-        value: normalizeNoteContent(extractQuotedStringToken(noteNode.value).unwrap()),
+        value: extractQuotedStringToken(noteNode.value).unwrap(),
         token: getTokenPosition(noteNode),
       };
 

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/project.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/project.ts
@@ -2,7 +2,7 @@ import { extractQuotedStringToken } from "../../analyzer/utils";
 import { CompileError } from "../../errors";
 import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, SyntaxNode } from "../../parser/nodes";
 import { ElementInterpreter, InterpreterDatabase, Project } from "../types";
-import { extractElementName, getTokenPosition, normalizeNoteContent } from "../utils";
+import { extractElementName, getTokenPosition } from "../utils";
 import { EnumInterpreter } from "./enum";
 import { RefInterpreter } from "./ref";
 import { TableInterpreter } from "./table";
@@ -63,7 +63,7 @@ export class ProjectInterpreter implements ElementInterpreter {
         }
         case 'note': {
           this.project.note = {
-            value: normalizeNoteContent(extractQuotedStringToken(sub.body instanceof BlockExpressionNode ? (sub.body.body[0] as FunctionApplicationNode).callee : sub.body!.callee).unwrap()),
+            value: extractQuotedStringToken(sub.body instanceof BlockExpressionNode ? (sub.body.body[0] as FunctionApplicationNode).callee : sub.body!.callee).unwrap(),
             token: getTokenPosition(sub),
           }
           return [];

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -1,6 +1,6 @@
 import { Column, ColumnType, ElementInterpreter, Index, InlineRef, InterpreterDatabase, Table } from '../types';
 import { ArrayNode, AttributeNode, BlockExpressionNode, CallExpressionNode, ElementDeclarationNode, FunctionApplicationNode, FunctionExpressionNode, ListExpressionNode, PrefixExpressionNode, SyntaxNode } from '../../parser/nodes';
-import { extractColor, extractElementName, getColumnSymbolsOfRefOperand, getMultiplicities, getRefId, getTokenPosition, isSameEndpoint, normalizeNoteContent } from '../utils';
+import { extractColor, extractElementName, getColumnSymbolsOfRefOperand, getMultiplicities, getRefId, getTokenPosition, isSameEndpoint } from '../utils';
 import { destructureComplexVariable, destructureIndexNode, extractQuotedStringToken, extractVarNameFromPrimaryVariable, extractVariableFromExpression } from '../../analyzer/utils';
 import { CompileError, CompileErrorCode } from '../../errors';
 import { aggregateSettingList, isExpressionANumber } from '../../analyzer/validator/utils';
@@ -97,7 +97,7 @@ export class TableInterpreter implements ElementInterpreter {
     const [noteNode] = settingMap['note'] || [];
     const noteValue = extractQuotedStringToken(noteNode?.value).unwrap_or(undefined);
     this.table.note = noteNode && {
-      value: normalizeNoteContent(noteValue!),
+      value: noteValue!,
       token: getTokenPosition(noteNode),
     };
 
@@ -114,7 +114,7 @@ export class TableInterpreter implements ElementInterpreter {
       switch (sub.type?.value.toLowerCase()) {
         case 'note':
           this.table.note = {
-            value: normalizeNoteContent(extractQuotedStringToken(sub.body instanceof BlockExpressionNode ? (sub.body.body[0] as FunctionApplicationNode).callee : sub.body!.callee).unwrap()),
+            value: extractQuotedStringToken(sub.body instanceof BlockExpressionNode ? (sub.body.body[0] as FunctionApplicationNode).callee : sub.body!.callee).unwrap(),
             token: getTokenPosition(sub),
           }
           return [];
@@ -156,7 +156,7 @@ export class TableInterpreter implements ElementInterpreter {
       column.dbdefault = processDefaultValue(settingMap['default']?.at(0)?.value);
       const noteNode = settingMap['note']?.at(0);
       column.note = noteNode && {
-        value: normalizeNoteContent(extractQuotedStringToken(noteNode.value).unwrap()),
+        value: extractQuotedStringToken(noteNode.value).unwrap(),
         token: getTokenPosition(noteNode),
       }
       const refs = settingMap['ref'] || [];
@@ -244,7 +244,7 @@ export class TableInterpreter implements ElementInterpreter {
         index.name = extractQuotedStringToken(settingMap['name']?.at(0)?.value).unwrap_or(undefined);
         const noteNode = settingMap['note']?.at(0);
         index.note = noteNode && {
-          value: normalizeNoteContent(extractQuotedStringToken(noteNode.value).unwrap()),
+          value: extractQuotedStringToken(noteNode.value).unwrap(),
           token: getTokenPosition(noteNode),
         };
         index.type = extractVariableFromExpression(settingMap['type']?.at(0)?.value).unwrap_or(undefined); 

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -149,7 +149,7 @@ export class TableInterpreter implements ElementInterpreter {
     const settings = field.args.slice(1);
     if (_.last(settings) instanceof ListExpressionNode) {
       const settingMap = aggregateSettingList(settings.pop() as ListExpressionNode).getValue();
-      column.pk = !!settingMap['pk']?.length;
+      column.pk = !!settingMap['pk']?.length || !!settingMap['primary key']?.length;
       column.increment = !!settingMap['increment']?.length;
       column.unique = !!settingMap['unique']?.length;
       column.not_null = !!settingMap['not null']?.length && true;

--- a/packages/dbml-parse/src/lib/interpreter/utils.ts
+++ b/packages/dbml-parse/src/lib/interpreter/utils.ts
@@ -74,13 +74,6 @@ export function getColumnSymbolsOfRefOperand(ref: SyntaxNode): ColumnSymbol[] {
   return [colNode!.referee as ColumnSymbol];
 }
 
-export function normalizeNoteContent(content: string): string {
-  return content
-    .split('\n')
-    .map((s) => s.trim())
-    .join('\n');
-}
-
 export function extractElementName(nameNode: SyntaxNode): { schemaName: string[]; name: string } {
   const fragments = destructureComplexVariable(nameNode).unwrap();
   const name = fragments.pop()!;

--- a/packages/dbml-parse/tests/interpreter/input/primary_key.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/primary_key.in.dbml
@@ -1,0 +1,3 @@
+Table A {
+    id int [primary key]
+}

--- a/packages/dbml-parse/tests/interpreter/output/index_tables.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/index_tables.out.json
@@ -26,7 +26,7 @@
             }
           },
           "inline_refs": [],
-          "pk": false,
+          "pk": true,
           "increment": false,
           "unique": false,
           "not_null": false

--- a/packages/dbml-parse/tests/interpreter/output/multiline_string.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/multiline_string.out.json
@@ -31,7 +31,7 @@
           "unique": false,
           "not_null": false,
           "note": {
-            "value": "\n\n# Objective\n* Support writing long string that can \\undefined'span' over multiple lines\n* Support writing markdown for DBML Note\n\n# Syntax\n\n",
+            "value": "\n\n    # Objective\n      * Support writing long string that can \\undefined'span' over multiple lines\n      * Support writing markdown for DBML Note\n  \n    # Syntax\n\n  ",
             "token": {
               "start": {
                 "offset": 24,

--- a/packages/dbml-parse/tests/interpreter/output/old_undocumented_syntax.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/old_undocumented_syntax.out.json
@@ -287,7 +287,7 @@
             }
           },
           "inline_refs": [],
-          "pk": false,
+          "pk": true,
           "increment": false,
           "unique": false,
           "not_null": false

--- a/packages/dbml-parse/tests/interpreter/output/primary_key.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/primary_key.out.json
@@ -1,0 +1,55 @@
+{
+  "schemas": [],
+  "tables": [
+    {
+      "name": "A",
+      "schemaName": null,
+      "alias": null,
+      "fields": [
+        {
+          "name": "id",
+          "type": {
+            "schemaName": null,
+            "type_name": "int",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 14,
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "offset": 34,
+              "line": 2,
+              "column": 25
+            }
+          },
+          "inline_refs": [],
+          "pk": true,
+          "increment": false,
+          "unique": false,
+          "not_null": false
+        }
+      ],
+      "token": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 36,
+          "line": 3,
+          "column": 2
+        }
+      },
+      "indexes": []
+    }
+  ],
+  "refs": [],
+  "enums": [],
+  "tableGroups": [],
+  "aliases": [],
+  "project": {}
+}

--- a/packages/dbml-parse/tests/interpreter/output/project.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/project.out.json
@@ -1386,7 +1386,7 @@
     "tables": [],
     "name": "ecommerce",
     "note": {
-      "value": "\n# Introduction\nThis is an ecommerce project\n\n# Description\n...\n",
+      "value": "\n    # Introduction\n    This is an ecommerce project\n\n    # Description\n    ...\n  ",
       "token": {
         "start": {
           "offset": 22,

--- a/packages/dbml-parse/tests/old_tests/output/index_tables.out.json
+++ b/packages/dbml-parse/tests/old_tests/output/index_tables.out.json
@@ -26,7 +26,7 @@
             }
           },
           "inline_refs": [],
-          "pk": false,
+          "pk": true,
           "increment": false,
           "unique": false,
           "not_null": false

--- a/packages/dbml-parse/tests/old_tests/output/multiline_string.out.json
+++ b/packages/dbml-parse/tests/old_tests/output/multiline_string.out.json
@@ -31,7 +31,7 @@
           "unique": false,
           "not_null": false,
           "note": {
-            "value": "\n\n# Objective\n* Support writing long string that can \\undefined'span' over multiple lines\n* Support writing markdown for DBML Note\n\n# Syntax\n\n",
+            "value": "\n\n    # Objective\n      * Support writing long string that can \\undefined'span' over multiple lines\n      * Support writing markdown for DBML Note\n  \n    # Syntax\n\n  ",
             "token": {
               "start": {
                 "offset": 24,

--- a/packages/dbml-parse/tests/old_tests/output/project.out.json
+++ b/packages/dbml-parse/tests/old_tests/output/project.out.json
@@ -1386,7 +1386,7 @@
     "tables": [],
     "name": "ecommerce",
     "note": {
-      "value": "\n# Introduction\nThis is an ecommerce project\n\n# Description\n...\n",
+      "value": "\n    # Introduction\n    This is an ecommerce project\n\n    # Description\n    ...\n  ",
       "token": {
         "start": {
           "offset": 22,

--- a/packages/dbml-parse/tests/validator/input/duplicate_alias_name.in.dbml
+++ b/packages/dbml-parse/tests/validator/input/duplicate_alias_name.in.dbml
@@ -1,0 +1,3 @@
+Table A as A {
+    id int [primary key]
+}

--- a/packages/dbml-parse/tests/validator/input/duplicate_alias_name.in.dbml
+++ b/packages/dbml-parse/tests/validator/input/duplicate_alias_name.in.dbml
@@ -1,3 +1,15 @@
 Table A as A {
     id int [primary key]
 }
+
+Table "B" as B {
+    id int [primary key]
+}
+
+Table C as "C" {
+    id int [primary key]
+}
+
+Table "D" as "D" {
+    id int [primary key]
+}

--- a/packages/dbml-parse/tests/validator/output/alias_of_duplicated_names.out.json
+++ b/packages/dbml-parse/tests/validator/output/alias_of_duplicated_names.out.json
@@ -2256,7 +2256,7 @@
     },
     {
       "code": 3003,
-      "diagnostic": "Table name '[object Object]' already exists",
+      "diagnostic": "Table name 'U1' already exists",
       "nodeOrToken": {
         "id": 13,
         "kind": "<primary-expression>",

--- a/packages/dbml-parse/tests/validator/output/duplicate_alias_name.out.json
+++ b/packages/dbml-parse/tests/validator/output/duplicate_alias_name.out.json
@@ -1,6 +1,6 @@
 {
   "value": {
-    "id": 14,
+    "id": 56,
     "kind": "<program>",
     "startPos": {
       "offset": 0,
@@ -9,13 +9,13 @@
     },
     "fullStart": 0,
     "endPos": {
-      "offset": 41,
-      "line": 2,
+      "offset": 178,
+      "line": 14,
       "column": 1
     },
-    "fullEnd": 41,
+    "fullEnd": 178,
     "start": 0,
-    "end": 41,
+    "end": 178,
     "body": [
       {
         "id": 13,
@@ -31,7 +31,7 @@
           "line": 2,
           "column": 1
         },
-        "fullEnd": 41,
+        "fullEnd": 42,
         "start": 0,
         "end": 41,
         "type": {
@@ -292,7 +292,7 @@
             "line": 2,
             "column": 1
           },
-          "fullEnd": 41,
+          "fullEnd": 42,
           "start": 13,
           "end": 41,
           "blockOpenBrace": {
@@ -805,7 +805,29 @@
             },
             "value": "}",
             "leadingTrivia": [],
-            "trailingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 41,
+                  "line": 2,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 42,
+                  "line": 3,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 41,
+                "end": 42
+              }
+            ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
@@ -813,20 +835,2527 @@
             "end": 41
           }
         },
-        "parent": 14,
+        "parent": 56,
         "symbol": 1
+      },
+      {
+        "id": 27,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 43,
+          "line": 4,
+          "column": 0
+        },
+        "fullStart": 42,
+        "endPos": {
+          "offset": 86,
+          "line": 6,
+          "column": 1
+        },
+        "fullEnd": 87,
+        "start": 43,
+        "end": 86,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 43,
+            "line": 4,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 48,
+            "line": 4,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 42,
+                "line": 3,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 43,
+                "line": 4,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 42,
+              "end": 43
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 48,
+                "line": 4,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 49,
+                "line": 4,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 48,
+              "end": 49
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 43,
+          "end": 48
+        },
+        "name": {
+          "id": 15,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 49,
+            "line": 4,
+            "column": 6
+          },
+          "fullStart": 49,
+          "endPos": {
+            "offset": 52,
+            "line": 4,
+            "column": 9
+          },
+          "fullEnd": 53,
+          "start": 49,
+          "end": 52,
+          "expression": {
+            "id": 14,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 49,
+              "line": 4,
+              "column": 6
+            },
+            "fullStart": 49,
+            "endPos": {
+              "offset": 52,
+              "line": 4,
+              "column": 9
+            },
+            "fullEnd": 53,
+            "start": 49,
+            "end": 52,
+            "variable": {
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 49,
+                "line": 4,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 52,
+                "line": 4,
+                "column": 9
+              },
+              "value": "B",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 52,
+                    "line": 4,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 53,
+                    "line": 4,
+                    "column": 10
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 52,
+                  "end": 53
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 49,
+              "end": 52
+            }
+          }
+        },
+        "as": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 53,
+            "line": 4,
+            "column": 10
+          },
+          "endPos": {
+            "offset": 55,
+            "line": 4,
+            "column": 12
+          },
+          "value": "as",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 55,
+                "line": 4,
+                "column": 12
+              },
+              "endPos": {
+                "offset": 56,
+                "line": 4,
+                "column": 13
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 55,
+              "end": 56
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 53,
+          "end": 55
+        },
+        "alias": {
+          "id": 17,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 56,
+            "line": 4,
+            "column": 13
+          },
+          "fullStart": 56,
+          "endPos": {
+            "offset": 57,
+            "line": 4,
+            "column": 14
+          },
+          "fullEnd": 58,
+          "start": 56,
+          "end": 57,
+          "expression": {
+            "id": 16,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 56,
+              "line": 4,
+              "column": 13
+            },
+            "fullStart": 56,
+            "endPos": {
+              "offset": 57,
+              "line": 4,
+              "column": 14
+            },
+            "fullEnd": 58,
+            "start": 56,
+            "end": 57,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 56,
+                "line": 4,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 57,
+                "line": 4,
+                "column": 14
+              },
+              "value": "B",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 57,
+                    "line": 4,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 58,
+                    "line": 4,
+                    "column": 15
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 57,
+                  "end": 58
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 56,
+              "end": 57
+            }
+          }
+        },
+        "body": {
+          "id": 26,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 58,
+            "line": 4,
+            "column": 15
+          },
+          "fullStart": 58,
+          "endPos": {
+            "offset": 86,
+            "line": 6,
+            "column": 1
+          },
+          "fullEnd": 87,
+          "start": 58,
+          "end": 86,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 58,
+              "line": 4,
+              "column": 15
+            },
+            "endPos": {
+              "offset": 59,
+              "line": 4,
+              "column": 16
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 59,
+                  "line": 4,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 60,
+                  "line": 5,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 59,
+                "end": 60
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 58,
+            "end": 59
+          },
+          "body": [
+            {
+              "id": 25,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 64,
+                "line": 5,
+                "column": 4
+              },
+              "fullStart": 60,
+              "endPos": {
+                "offset": 84,
+                "line": 5,
+                "column": 24
+              },
+              "fullEnd": 85,
+              "start": 64,
+              "end": 84,
+              "callee": {
+                "id": 19,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 64,
+                  "line": 5,
+                  "column": 4
+                },
+                "fullStart": 60,
+                "endPos": {
+                  "offset": 66,
+                  "line": 5,
+                  "column": 6
+                },
+                "fullEnd": 67,
+                "start": 64,
+                "end": 66,
+                "expression": {
+                  "id": 18,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 64,
+                    "line": 5,
+                    "column": 4
+                  },
+                  "fullStart": 60,
+                  "endPos": {
+                    "offset": 66,
+                    "line": 5,
+                    "column": 6
+                  },
+                  "fullEnd": 67,
+                  "start": 64,
+                  "end": 66,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 64,
+                      "line": 5,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 66,
+                      "line": 5,
+                      "column": 6
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 60,
+                          "line": 5,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 61,
+                          "line": 5,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 60,
+                        "end": 61
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 61,
+                          "line": 5,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 62,
+                          "line": 5,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 61,
+                        "end": 62
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 62,
+                          "line": 5,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 63,
+                          "line": 5,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 62,
+                        "end": 63
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 63,
+                          "line": 5,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 64,
+                          "line": 5,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 63,
+                        "end": 64
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 66,
+                          "line": 5,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 67,
+                          "line": 5,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 66,
+                        "end": 67
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 64,
+                    "end": 66
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 21,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 67,
+                    "line": 5,
+                    "column": 7
+                  },
+                  "fullStart": 67,
+                  "endPos": {
+                    "offset": 70,
+                    "line": 5,
+                    "column": 10
+                  },
+                  "fullEnd": 71,
+                  "start": 67,
+                  "end": 70,
+                  "expression": {
+                    "id": 20,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 67,
+                      "line": 5,
+                      "column": 7
+                    },
+                    "fullStart": 67,
+                    "endPos": {
+                      "offset": 70,
+                      "line": 5,
+                      "column": 10
+                    },
+                    "fullEnd": 71,
+                    "start": 67,
+                    "end": 70,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 67,
+                        "line": 5,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 70,
+                        "line": 5,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 70,
+                            "line": 5,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 71,
+                            "line": 5,
+                            "column": 11
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 70,
+                          "end": 71
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 67,
+                      "end": 70
+                    }
+                  }
+                },
+                {
+                  "id": 24,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 71,
+                    "line": 5,
+                    "column": 11
+                  },
+                  "fullStart": 71,
+                  "endPos": {
+                    "offset": 84,
+                    "line": 5,
+                    "column": 24
+                  },
+                  "fullEnd": 85,
+                  "start": 71,
+                  "end": 84,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 71,
+                      "line": 5,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 72,
+                      "line": 5,
+                      "column": 12
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 71,
+                    "end": 72
+                  },
+                  "elementList": [
+                    {
+                      "id": 23,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 72,
+                        "line": 5,
+                        "column": 12
+                      },
+                      "fullStart": 72,
+                      "endPos": {
+                        "offset": 83,
+                        "line": 5,
+                        "column": 23
+                      },
+                      "fullEnd": 83,
+                      "start": 72,
+                      "end": 83,
+                      "name": {
+                        "id": 22,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 72,
+                          "line": 5,
+                          "column": 12
+                        },
+                        "fullStart": 72,
+                        "endPos": {
+                          "offset": 83,
+                          "line": 5,
+                          "column": 23
+                        },
+                        "fullEnd": 83,
+                        "start": 72,
+                        "end": 83,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 72,
+                              "line": 5,
+                              "column": 12
+                            },
+                            "endPos": {
+                              "offset": 79,
+                              "line": 5,
+                              "column": 19
+                            },
+                            "value": "primary",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [
+                              {
+                                "kind": "<space>",
+                                "startPos": {
+                                  "offset": 79,
+                                  "line": 5,
+                                  "column": 19
+                                },
+                                "endPos": {
+                                  "offset": 80,
+                                  "line": 5,
+                                  "column": 20
+                                },
+                                "value": " ",
+                                "leadingTrivia": [],
+                                "trailingTrivia": [],
+                                "leadingInvalid": [],
+                                "trailingInvalid": [],
+                                "isInvalid": false,
+                                "start": 79,
+                                "end": 80
+                              }
+                            ],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 72,
+                            "end": 79
+                          },
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 80,
+                              "line": 5,
+                              "column": 20
+                            },
+                            "endPos": {
+                              "offset": 83,
+                              "line": 5,
+                              "column": 23
+                            },
+                            "value": "key",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 80,
+                            "end": 83
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 83,
+                      "line": 5,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 84,
+                      "line": 5,
+                      "column": 24
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 84,
+                          "line": 5,
+                          "column": 24
+                        },
+                        "endPos": {
+                          "offset": 85,
+                          "line": 6,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 84,
+                        "end": 85
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 83,
+                    "end": 84
+                  }
+                }
+              ],
+              "symbol": 4
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 85,
+              "line": 6,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 86,
+              "line": 6,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 86,
+                  "line": 6,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 87,
+                  "line": 7,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 86,
+                "end": 87
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 85,
+            "end": 86
+          }
+        },
+        "parent": 56,
+        "symbol": 3
+      },
+      {
+        "id": 41,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 88,
+          "line": 8,
+          "column": 0
+        },
+        "fullStart": 87,
+        "endPos": {
+          "offset": 131,
+          "line": 10,
+          "column": 1
+        },
+        "fullEnd": 132,
+        "start": 88,
+        "end": 131,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 88,
+            "line": 8,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 93,
+            "line": 8,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 87,
+                "line": 7,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 88,
+                "line": 8,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 87,
+              "end": 88
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 93,
+                "line": 8,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 94,
+                "line": 8,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 93,
+              "end": 94
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 88,
+          "end": 93
+        },
+        "name": {
+          "id": 29,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 94,
+            "line": 8,
+            "column": 6
+          },
+          "fullStart": 94,
+          "endPos": {
+            "offset": 95,
+            "line": 8,
+            "column": 7
+          },
+          "fullEnd": 96,
+          "start": 94,
+          "end": 95,
+          "expression": {
+            "id": 28,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 94,
+              "line": 8,
+              "column": 6
+            },
+            "fullStart": 94,
+            "endPos": {
+              "offset": 95,
+              "line": 8,
+              "column": 7
+            },
+            "fullEnd": 96,
+            "start": 94,
+            "end": 95,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 94,
+                "line": 8,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 95,
+                "line": 8,
+                "column": 7
+              },
+              "value": "C",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 95,
+                    "line": 8,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 96,
+                    "line": 8,
+                    "column": 8
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 95,
+                  "end": 96
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 94,
+              "end": 95
+            }
+          }
+        },
+        "as": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 96,
+            "line": 8,
+            "column": 8
+          },
+          "endPos": {
+            "offset": 98,
+            "line": 8,
+            "column": 10
+          },
+          "value": "as",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 98,
+                "line": 8,
+                "column": 10
+              },
+              "endPos": {
+                "offset": 99,
+                "line": 8,
+                "column": 11
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 98,
+              "end": 99
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 96,
+          "end": 98
+        },
+        "alias": {
+          "id": 31,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 99,
+            "line": 8,
+            "column": 11
+          },
+          "fullStart": 99,
+          "endPos": {
+            "offset": 102,
+            "line": 8,
+            "column": 14
+          },
+          "fullEnd": 103,
+          "start": 99,
+          "end": 102,
+          "expression": {
+            "id": 30,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 99,
+              "line": 8,
+              "column": 11
+            },
+            "fullStart": 99,
+            "endPos": {
+              "offset": 102,
+              "line": 8,
+              "column": 14
+            },
+            "fullEnd": 103,
+            "start": 99,
+            "end": 102,
+            "variable": {
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 99,
+                "line": 8,
+                "column": 11
+              },
+              "endPos": {
+                "offset": 102,
+                "line": 8,
+                "column": 14
+              },
+              "value": "C",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 102,
+                    "line": 8,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 103,
+                    "line": 8,
+                    "column": 15
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 102,
+                  "end": 103
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 99,
+              "end": 102
+            }
+          }
+        },
+        "body": {
+          "id": 40,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 103,
+            "line": 8,
+            "column": 15
+          },
+          "fullStart": 103,
+          "endPos": {
+            "offset": 131,
+            "line": 10,
+            "column": 1
+          },
+          "fullEnd": 132,
+          "start": 103,
+          "end": 131,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 103,
+              "line": 8,
+              "column": 15
+            },
+            "endPos": {
+              "offset": 104,
+              "line": 8,
+              "column": 16
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 104,
+                  "line": 8,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 105,
+                  "line": 9,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 104,
+                "end": 105
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 103,
+            "end": 104
+          },
+          "body": [
+            {
+              "id": 39,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 109,
+                "line": 9,
+                "column": 4
+              },
+              "fullStart": 105,
+              "endPos": {
+                "offset": 129,
+                "line": 9,
+                "column": 24
+              },
+              "fullEnd": 130,
+              "start": 109,
+              "end": 129,
+              "callee": {
+                "id": 33,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 109,
+                  "line": 9,
+                  "column": 4
+                },
+                "fullStart": 105,
+                "endPos": {
+                  "offset": 111,
+                  "line": 9,
+                  "column": 6
+                },
+                "fullEnd": 112,
+                "start": 109,
+                "end": 111,
+                "expression": {
+                  "id": 32,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 109,
+                    "line": 9,
+                    "column": 4
+                  },
+                  "fullStart": 105,
+                  "endPos": {
+                    "offset": 111,
+                    "line": 9,
+                    "column": 6
+                  },
+                  "fullEnd": 112,
+                  "start": 109,
+                  "end": 111,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 109,
+                      "line": 9,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 111,
+                      "line": 9,
+                      "column": 6
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 105,
+                          "line": 9,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 106,
+                          "line": 9,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 105,
+                        "end": 106
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 106,
+                          "line": 9,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 107,
+                          "line": 9,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 106,
+                        "end": 107
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 107,
+                          "line": 9,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 108,
+                          "line": 9,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 107,
+                        "end": 108
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 108,
+                          "line": 9,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 109,
+                          "line": 9,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 108,
+                        "end": 109
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 111,
+                          "line": 9,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 112,
+                          "line": 9,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 111,
+                        "end": 112
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 109,
+                    "end": 111
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 35,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 112,
+                    "line": 9,
+                    "column": 7
+                  },
+                  "fullStart": 112,
+                  "endPos": {
+                    "offset": 115,
+                    "line": 9,
+                    "column": 10
+                  },
+                  "fullEnd": 116,
+                  "start": 112,
+                  "end": 115,
+                  "expression": {
+                    "id": 34,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 112,
+                      "line": 9,
+                      "column": 7
+                    },
+                    "fullStart": 112,
+                    "endPos": {
+                      "offset": 115,
+                      "line": 9,
+                      "column": 10
+                    },
+                    "fullEnd": 116,
+                    "start": 112,
+                    "end": 115,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 112,
+                        "line": 9,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 115,
+                        "line": 9,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 115,
+                            "line": 9,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 116,
+                            "line": 9,
+                            "column": 11
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 115,
+                          "end": 116
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 112,
+                      "end": 115
+                    }
+                  }
+                },
+                {
+                  "id": 38,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 116,
+                    "line": 9,
+                    "column": 11
+                  },
+                  "fullStart": 116,
+                  "endPos": {
+                    "offset": 129,
+                    "line": 9,
+                    "column": 24
+                  },
+                  "fullEnd": 130,
+                  "start": 116,
+                  "end": 129,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 116,
+                      "line": 9,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 117,
+                      "line": 9,
+                      "column": 12
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 116,
+                    "end": 117
+                  },
+                  "elementList": [
+                    {
+                      "id": 37,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 117,
+                        "line": 9,
+                        "column": 12
+                      },
+                      "fullStart": 117,
+                      "endPos": {
+                        "offset": 128,
+                        "line": 9,
+                        "column": 23
+                      },
+                      "fullEnd": 128,
+                      "start": 117,
+                      "end": 128,
+                      "name": {
+                        "id": 36,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 117,
+                          "line": 9,
+                          "column": 12
+                        },
+                        "fullStart": 117,
+                        "endPos": {
+                          "offset": 128,
+                          "line": 9,
+                          "column": 23
+                        },
+                        "fullEnd": 128,
+                        "start": 117,
+                        "end": 128,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 117,
+                              "line": 9,
+                              "column": 12
+                            },
+                            "endPos": {
+                              "offset": 124,
+                              "line": 9,
+                              "column": 19
+                            },
+                            "value": "primary",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [
+                              {
+                                "kind": "<space>",
+                                "startPos": {
+                                  "offset": 124,
+                                  "line": 9,
+                                  "column": 19
+                                },
+                                "endPos": {
+                                  "offset": 125,
+                                  "line": 9,
+                                  "column": 20
+                                },
+                                "value": " ",
+                                "leadingTrivia": [],
+                                "trailingTrivia": [],
+                                "leadingInvalid": [],
+                                "trailingInvalid": [],
+                                "isInvalid": false,
+                                "start": 124,
+                                "end": 125
+                              }
+                            ],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 117,
+                            "end": 124
+                          },
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 125,
+                              "line": 9,
+                              "column": 20
+                            },
+                            "endPos": {
+                              "offset": 128,
+                              "line": 9,
+                              "column": 23
+                            },
+                            "value": "key",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 125,
+                            "end": 128
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 128,
+                      "line": 9,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 129,
+                      "line": 9,
+                      "column": 24
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 129,
+                          "line": 9,
+                          "column": 24
+                        },
+                        "endPos": {
+                          "offset": 130,
+                          "line": 10,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 129,
+                        "end": 130
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 128,
+                    "end": 129
+                  }
+                }
+              ],
+              "symbol": 6
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 130,
+              "line": 10,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 131,
+              "line": 10,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 131,
+                  "line": 10,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 132,
+                  "line": 11,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 131,
+                "end": 132
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 130,
+            "end": 131
+          }
+        },
+        "parent": 56,
+        "symbol": 5
+      },
+      {
+        "id": 55,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 133,
+          "line": 12,
+          "column": 0
+        },
+        "fullStart": 132,
+        "endPos": {
+          "offset": 178,
+          "line": 14,
+          "column": 1
+        },
+        "fullEnd": 178,
+        "start": 133,
+        "end": 178,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 133,
+            "line": 12,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 138,
+            "line": 12,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 132,
+                "line": 11,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 133,
+                "line": 12,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 132,
+              "end": 133
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 138,
+                "line": 12,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 139,
+                "line": 12,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 138,
+              "end": 139
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 133,
+          "end": 138
+        },
+        "name": {
+          "id": 43,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 139,
+            "line": 12,
+            "column": 6
+          },
+          "fullStart": 139,
+          "endPos": {
+            "offset": 142,
+            "line": 12,
+            "column": 9
+          },
+          "fullEnd": 143,
+          "start": 139,
+          "end": 142,
+          "expression": {
+            "id": 42,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 139,
+              "line": 12,
+              "column": 6
+            },
+            "fullStart": 139,
+            "endPos": {
+              "offset": 142,
+              "line": 12,
+              "column": 9
+            },
+            "fullEnd": 143,
+            "start": 139,
+            "end": 142,
+            "variable": {
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 139,
+                "line": 12,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 142,
+                "line": 12,
+                "column": 9
+              },
+              "value": "D",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 142,
+                    "line": 12,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 143,
+                    "line": 12,
+                    "column": 10
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 142,
+                  "end": 143
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 139,
+              "end": 142
+            }
+          }
+        },
+        "as": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 143,
+            "line": 12,
+            "column": 10
+          },
+          "endPos": {
+            "offset": 145,
+            "line": 12,
+            "column": 12
+          },
+          "value": "as",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 145,
+                "line": 12,
+                "column": 12
+              },
+              "endPos": {
+                "offset": 146,
+                "line": 12,
+                "column": 13
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 145,
+              "end": 146
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 143,
+          "end": 145
+        },
+        "alias": {
+          "id": 45,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 146,
+            "line": 12,
+            "column": 13
+          },
+          "fullStart": 146,
+          "endPos": {
+            "offset": 149,
+            "line": 12,
+            "column": 16
+          },
+          "fullEnd": 150,
+          "start": 146,
+          "end": 149,
+          "expression": {
+            "id": 44,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 146,
+              "line": 12,
+              "column": 13
+            },
+            "fullStart": 146,
+            "endPos": {
+              "offset": 149,
+              "line": 12,
+              "column": 16
+            },
+            "fullEnd": 150,
+            "start": 146,
+            "end": 149,
+            "variable": {
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 146,
+                "line": 12,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 149,
+                "line": 12,
+                "column": 16
+              },
+              "value": "D",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 149,
+                    "line": 12,
+                    "column": 16
+                  },
+                  "endPos": {
+                    "offset": 150,
+                    "line": 12,
+                    "column": 17
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 149,
+                  "end": 150
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 146,
+              "end": 149
+            }
+          }
+        },
+        "body": {
+          "id": 54,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 150,
+            "line": 12,
+            "column": 17
+          },
+          "fullStart": 150,
+          "endPos": {
+            "offset": 178,
+            "line": 14,
+            "column": 1
+          },
+          "fullEnd": 178,
+          "start": 150,
+          "end": 178,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 150,
+              "line": 12,
+              "column": 17
+            },
+            "endPos": {
+              "offset": 151,
+              "line": 12,
+              "column": 18
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 151,
+                  "line": 12,
+                  "column": 18
+                },
+                "endPos": {
+                  "offset": 152,
+                  "line": 13,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 151,
+                "end": 152
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 150,
+            "end": 151
+          },
+          "body": [
+            {
+              "id": 53,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 156,
+                "line": 13,
+                "column": 4
+              },
+              "fullStart": 152,
+              "endPos": {
+                "offset": 176,
+                "line": 13,
+                "column": 24
+              },
+              "fullEnd": 177,
+              "start": 156,
+              "end": 176,
+              "callee": {
+                "id": 47,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 156,
+                  "line": 13,
+                  "column": 4
+                },
+                "fullStart": 152,
+                "endPos": {
+                  "offset": 158,
+                  "line": 13,
+                  "column": 6
+                },
+                "fullEnd": 159,
+                "start": 156,
+                "end": 158,
+                "expression": {
+                  "id": 46,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 156,
+                    "line": 13,
+                    "column": 4
+                  },
+                  "fullStart": 152,
+                  "endPos": {
+                    "offset": 158,
+                    "line": 13,
+                    "column": 6
+                  },
+                  "fullEnd": 159,
+                  "start": 156,
+                  "end": 158,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 156,
+                      "line": 13,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 158,
+                      "line": 13,
+                      "column": 6
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 152,
+                          "line": 13,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 153,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 152,
+                        "end": 153
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 153,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 154,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 153,
+                        "end": 154
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 154,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 155,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 154,
+                        "end": 155
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 155,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 156,
+                          "line": 13,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 155,
+                        "end": 156
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 158,
+                          "line": 13,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 159,
+                          "line": 13,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 158,
+                        "end": 159
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 156,
+                    "end": 158
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 49,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 159,
+                    "line": 13,
+                    "column": 7
+                  },
+                  "fullStart": 159,
+                  "endPos": {
+                    "offset": 162,
+                    "line": 13,
+                    "column": 10
+                  },
+                  "fullEnd": 163,
+                  "start": 159,
+                  "end": 162,
+                  "expression": {
+                    "id": 48,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 159,
+                      "line": 13,
+                      "column": 7
+                    },
+                    "fullStart": 159,
+                    "endPos": {
+                      "offset": 162,
+                      "line": 13,
+                      "column": 10
+                    },
+                    "fullEnd": 163,
+                    "start": 159,
+                    "end": 162,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 159,
+                        "line": 13,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 162,
+                        "line": 13,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 162,
+                            "line": 13,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 163,
+                            "line": 13,
+                            "column": 11
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 162,
+                          "end": 163
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 159,
+                      "end": 162
+                    }
+                  }
+                },
+                {
+                  "id": 52,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 163,
+                    "line": 13,
+                    "column": 11
+                  },
+                  "fullStart": 163,
+                  "endPos": {
+                    "offset": 176,
+                    "line": 13,
+                    "column": 24
+                  },
+                  "fullEnd": 177,
+                  "start": 163,
+                  "end": 176,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 163,
+                      "line": 13,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 164,
+                      "line": 13,
+                      "column": 12
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 163,
+                    "end": 164
+                  },
+                  "elementList": [
+                    {
+                      "id": 51,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 164,
+                        "line": 13,
+                        "column": 12
+                      },
+                      "fullStart": 164,
+                      "endPos": {
+                        "offset": 175,
+                        "line": 13,
+                        "column": 23
+                      },
+                      "fullEnd": 175,
+                      "start": 164,
+                      "end": 175,
+                      "name": {
+                        "id": 50,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 164,
+                          "line": 13,
+                          "column": 12
+                        },
+                        "fullStart": 164,
+                        "endPos": {
+                          "offset": 175,
+                          "line": 13,
+                          "column": 23
+                        },
+                        "fullEnd": 175,
+                        "start": 164,
+                        "end": 175,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 164,
+                              "line": 13,
+                              "column": 12
+                            },
+                            "endPos": {
+                              "offset": 171,
+                              "line": 13,
+                              "column": 19
+                            },
+                            "value": "primary",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [
+                              {
+                                "kind": "<space>",
+                                "startPos": {
+                                  "offset": 171,
+                                  "line": 13,
+                                  "column": 19
+                                },
+                                "endPos": {
+                                  "offset": 172,
+                                  "line": 13,
+                                  "column": 20
+                                },
+                                "value": " ",
+                                "leadingTrivia": [],
+                                "trailingTrivia": [],
+                                "leadingInvalid": [],
+                                "trailingInvalid": [],
+                                "isInvalid": false,
+                                "start": 171,
+                                "end": 172
+                              }
+                            ],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 164,
+                            "end": 171
+                          },
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 172,
+                              "line": 13,
+                              "column": 20
+                            },
+                            "endPos": {
+                              "offset": 175,
+                              "line": 13,
+                              "column": 23
+                            },
+                            "value": "key",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 172,
+                            "end": 175
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 175,
+                      "line": 13,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 176,
+                      "line": 13,
+                      "column": 24
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 176,
+                          "line": 13,
+                          "column": 24
+                        },
+                        "endPos": {
+                          "offset": 177,
+                          "line": 14,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 176,
+                        "end": 177
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 175,
+                    "end": 176
+                  }
+                }
+              ],
+              "symbol": 8
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 177,
+              "line": 14,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 178,
+              "line": 14,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 177,
+            "end": 178
+          }
+        },
+        "parent": 56,
+        "symbol": 7
       }
     ],
     "eof": {
       "kind": "<eof>",
       "startPos": {
-        "offset": 41,
-        "line": 2,
+        "offset": 178,
+        "line": 14,
         "column": 1
       },
       "endPos": {
-        "offset": 41,
-        "line": 2,
+        "offset": 178,
+        "line": 14,
         "column": 1
       },
       "value": "",
@@ -835,8 +3364,8 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 41,
-      "end": 41
+      "start": 178,
+      "end": 178
     },
     "symbol": {
       "symbolTable": {
@@ -851,6 +3380,42 @@
             }
           },
           "declaration": 13
+        },
+        "Table:B": {
+          "references": [],
+          "id": 3,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 4,
+              "declaration": 25
+            }
+          },
+          "declaration": 27
+        },
+        "Table:C": {
+          "references": [],
+          "id": 5,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 6,
+              "declaration": 39
+            }
+          },
+          "declaration": 41
+        },
+        "Table:D": {
+          "references": [],
+          "id": 7,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 8,
+              "declaration": 53
+            }
+          },
+          "declaration": 55
         }
       },
       "id": 0,

--- a/packages/dbml-parse/tests/validator/output/duplicate_alias_name.out.json
+++ b/packages/dbml-parse/tests/validator/output/duplicate_alias_name.out.json
@@ -1,0 +1,861 @@
+{
+  "value": {
+    "id": 14,
+    "kind": "<program>",
+    "startPos": {
+      "offset": 0,
+      "line": 0,
+      "column": 0
+    },
+    "fullStart": 0,
+    "endPos": {
+      "offset": 41,
+      "line": 2,
+      "column": 1
+    },
+    "fullEnd": 41,
+    "start": 0,
+    "end": 41,
+    "body": [
+      {
+        "id": 13,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 0,
+          "line": 0,
+          "column": 0
+        },
+        "fullStart": 0,
+        "endPos": {
+          "offset": 41,
+          "line": 2,
+          "column": 1
+        },
+        "fullEnd": 41,
+        "start": 0,
+        "end": 41,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 0,
+            "line": 0,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 5,
+            "line": 0,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 5,
+                "line": 0,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 5,
+              "end": 6
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 0,
+          "end": 5
+        },
+        "name": {
+          "id": 1,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 6,
+            "line": 0,
+            "column": 6
+          },
+          "fullStart": 6,
+          "endPos": {
+            "offset": 7,
+            "line": 0,
+            "column": 7
+          },
+          "fullEnd": 8,
+          "start": 6,
+          "end": 7,
+          "expression": {
+            "id": 0,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 6,
+              "line": 0,
+              "column": 6
+            },
+            "fullStart": 6,
+            "endPos": {
+              "offset": 7,
+              "line": 0,
+              "column": 7
+            },
+            "fullEnd": 8,
+            "start": 6,
+            "end": 7,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 7,
+                "line": 0,
+                "column": 7
+              },
+              "value": "A",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 7,
+                    "line": 0,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 8,
+                    "line": 0,
+                    "column": 8
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 7,
+                  "end": 8
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 6,
+              "end": 7
+            }
+          }
+        },
+        "as": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 8,
+            "line": 0,
+            "column": 8
+          },
+          "endPos": {
+            "offset": 10,
+            "line": 0,
+            "column": 10
+          },
+          "value": "as",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 10,
+                "line": 0,
+                "column": 10
+              },
+              "endPos": {
+                "offset": 11,
+                "line": 0,
+                "column": 11
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 10,
+              "end": 11
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 8,
+          "end": 10
+        },
+        "alias": {
+          "id": 3,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 11,
+            "line": 0,
+            "column": 11
+          },
+          "fullStart": 11,
+          "endPos": {
+            "offset": 12,
+            "line": 0,
+            "column": 12
+          },
+          "fullEnd": 13,
+          "start": 11,
+          "end": 12,
+          "expression": {
+            "id": 2,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 11,
+              "line": 0,
+              "column": 11
+            },
+            "fullStart": 11,
+            "endPos": {
+              "offset": 12,
+              "line": 0,
+              "column": 12
+            },
+            "fullEnd": 13,
+            "start": 11,
+            "end": 12,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 11,
+                "line": 0,
+                "column": 11
+              },
+              "endPos": {
+                "offset": 12,
+                "line": 0,
+                "column": 12
+              },
+              "value": "A",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 12,
+                    "line": 0,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 13,
+                    "line": 0,
+                    "column": 13
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 12,
+                  "end": 13
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 11,
+              "end": 12
+            }
+          }
+        },
+        "body": {
+          "id": 12,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 13,
+            "line": 0,
+            "column": 13
+          },
+          "fullStart": 13,
+          "endPos": {
+            "offset": 41,
+            "line": 2,
+            "column": 1
+          },
+          "fullEnd": 41,
+          "start": 13,
+          "end": 41,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 13,
+              "line": 0,
+              "column": 13
+            },
+            "endPos": {
+              "offset": 14,
+              "line": 0,
+              "column": 14
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 14,
+                  "line": 0,
+                  "column": 14
+                },
+                "endPos": {
+                  "offset": 15,
+                  "line": 1,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 14,
+                "end": 15
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 13,
+            "end": 14
+          },
+          "body": [
+            {
+              "id": 11,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 19,
+                "line": 1,
+                "column": 4
+              },
+              "fullStart": 15,
+              "endPos": {
+                "offset": 39,
+                "line": 1,
+                "column": 24
+              },
+              "fullEnd": 40,
+              "start": 19,
+              "end": 39,
+              "callee": {
+                "id": 5,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 19,
+                  "line": 1,
+                  "column": 4
+                },
+                "fullStart": 15,
+                "endPos": {
+                  "offset": 21,
+                  "line": 1,
+                  "column": 6
+                },
+                "fullEnd": 22,
+                "start": 19,
+                "end": 21,
+                "expression": {
+                  "id": 4,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 19,
+                    "line": 1,
+                    "column": 4
+                  },
+                  "fullStart": 15,
+                  "endPos": {
+                    "offset": 21,
+                    "line": 1,
+                    "column": 6
+                  },
+                  "fullEnd": 22,
+                  "start": 19,
+                  "end": 21,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 19,
+                      "line": 1,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 21,
+                      "line": 1,
+                      "column": 6
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 15,
+                          "line": 1,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 16,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 15,
+                        "end": 16
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 16,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 17,
+                          "line": 1,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 16,
+                        "end": 17
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 17,
+                          "line": 1,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 18,
+                          "line": 1,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 17,
+                        "end": 18
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 18,
+                          "line": 1,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 19,
+                          "line": 1,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 18,
+                        "end": 19
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 21,
+                          "line": 1,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 22,
+                          "line": 1,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 21,
+                        "end": 22
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 19,
+                    "end": 21
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 7,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 22,
+                    "line": 1,
+                    "column": 7
+                  },
+                  "fullStart": 22,
+                  "endPos": {
+                    "offset": 25,
+                    "line": 1,
+                    "column": 10
+                  },
+                  "fullEnd": 26,
+                  "start": 22,
+                  "end": 25,
+                  "expression": {
+                    "id": 6,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 22,
+                      "line": 1,
+                      "column": 7
+                    },
+                    "fullStart": 22,
+                    "endPos": {
+                      "offset": 25,
+                      "line": 1,
+                      "column": 10
+                    },
+                    "fullEnd": 26,
+                    "start": 22,
+                    "end": 25,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 22,
+                        "line": 1,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 25,
+                        "line": 1,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 25,
+                            "line": 1,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 26,
+                            "line": 1,
+                            "column": 11
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 25,
+                          "end": 26
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 22,
+                      "end": 25
+                    }
+                  }
+                },
+                {
+                  "id": 10,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 26,
+                    "line": 1,
+                    "column": 11
+                  },
+                  "fullStart": 26,
+                  "endPos": {
+                    "offset": 39,
+                    "line": 1,
+                    "column": 24
+                  },
+                  "fullEnd": 40,
+                  "start": 26,
+                  "end": 39,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 26,
+                      "line": 1,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 27,
+                      "line": 1,
+                      "column": 12
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 26,
+                    "end": 27
+                  },
+                  "elementList": [
+                    {
+                      "id": 9,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 27,
+                        "line": 1,
+                        "column": 12
+                      },
+                      "fullStart": 27,
+                      "endPos": {
+                        "offset": 38,
+                        "line": 1,
+                        "column": 23
+                      },
+                      "fullEnd": 38,
+                      "start": 27,
+                      "end": 38,
+                      "name": {
+                        "id": 8,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 27,
+                          "line": 1,
+                          "column": 12
+                        },
+                        "fullStart": 27,
+                        "endPos": {
+                          "offset": 38,
+                          "line": 1,
+                          "column": 23
+                        },
+                        "fullEnd": 38,
+                        "start": 27,
+                        "end": 38,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 27,
+                              "line": 1,
+                              "column": 12
+                            },
+                            "endPos": {
+                              "offset": 34,
+                              "line": 1,
+                              "column": 19
+                            },
+                            "value": "primary",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [
+                              {
+                                "kind": "<space>",
+                                "startPos": {
+                                  "offset": 34,
+                                  "line": 1,
+                                  "column": 19
+                                },
+                                "endPos": {
+                                  "offset": 35,
+                                  "line": 1,
+                                  "column": 20
+                                },
+                                "value": " ",
+                                "leadingTrivia": [],
+                                "trailingTrivia": [],
+                                "leadingInvalid": [],
+                                "trailingInvalid": [],
+                                "isInvalid": false,
+                                "start": 34,
+                                "end": 35
+                              }
+                            ],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 27,
+                            "end": 34
+                          },
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 35,
+                              "line": 1,
+                              "column": 20
+                            },
+                            "endPos": {
+                              "offset": 38,
+                              "line": 1,
+                              "column": 23
+                            },
+                            "value": "key",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 35,
+                            "end": 38
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 38,
+                      "line": 1,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 39,
+                      "line": 1,
+                      "column": 24
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 39,
+                          "line": 1,
+                          "column": 24
+                        },
+                        "endPos": {
+                          "offset": 40,
+                          "line": 2,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 39,
+                        "end": 40
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 38,
+                    "end": 39
+                  }
+                }
+              ],
+              "symbol": 2
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 40,
+              "line": 2,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 41,
+              "line": 2,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 40,
+            "end": 41
+          }
+        },
+        "parent": 14,
+        "symbol": 1
+      }
+    ],
+    "eof": {
+      "kind": "<eof>",
+      "startPos": {
+        "offset": 41,
+        "line": 2,
+        "column": 1
+      },
+      "endPos": {
+        "offset": 41,
+        "line": 2,
+        "column": 1
+      },
+      "value": "",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 41,
+      "end": 41
+    },
+    "symbol": {
+      "symbolTable": {
+        "Table:A": {
+          "references": [],
+          "id": 1,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 2,
+              "declaration": 11
+            }
+          },
+          "declaration": 13
+        }
+      },
+      "id": 0,
+      "references": []
+    }
+  },
+  "errors": []
+}


### PR DESCRIPTION
## Summary
* Fix error message when alias is a duplicate.
* Allow alias to be the same as the same table's name
* Interpret `primary key`
* No longer normalize note content, left as-is.

## Issue
(issue link here)

## Lasting Changes (Technical)

* Additional check in `TableValidator`.
* Additional logic in `TableInterpreter`.
* Remove `normalizeNoteContent`.
* Testcases for these.

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review