### PR TITLE
fix: type errors and missing return

### DIFF
--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -347,7 +347,7 @@ function processColumnType(typeNode: SyntaxNode): Report<ColumnType, CompileErro
 
   const { name: typeName, schemaName: typeSchemaName } = extractElementName(typeNode);
   if (typeSchemaName.length > 1) {
-    new Report(
+    return new Report(
       {
         schemaName: typeSchemaName.length === 0 ? null : typeSchemaName[0],
         type_name: `${typeName}${typeIndexer}${typeArgs ? `(${typeArgs})` : ''}`,

--- a/packages/dbml-parse/src/services/suggestions/provider.ts
+++ b/packages/dbml-parse/src/services/suggestions/provider.ts
@@ -30,6 +30,7 @@ import {
   AttributeNode,
   ElementDeclarationNode,
   FunctionApplicationNode,
+  IdentiferStreamNode,
   InfixExpressionNode,
   ListExpressionNode,
   PrefixExpressionNode,
@@ -245,7 +246,7 @@ function suggestInAttribute(
     return suggestAttributeName(compiler, offset);
   }
 
-  if (container.name) {
+  if (container.name instanceof IdentiferStreamNode) {
     const res = suggestAttributeValue(
       compiler,
       offset,
@@ -673,7 +674,7 @@ function suggestColumnType(compiler: Compiler, offset: number): CompletionList {
 
 function suggestColumnNameInIndexes(compiler: Compiler, offset: number): CompletionList {
   const indexesNode = compiler.container.element(offset);
-  const tableNode = indexesNode.parent;
+  const tableNode = (indexesNode as any)?.parent;
   if (!(tableNode?.symbol instanceof TableSymbol)) {
     return noSuggestions();
   }


### PR DESCRIPTION
## Summary
Fix the problems as pointed out in: https://holistics.slack.com/archives/C0278BDLPK8/p1706870126558909.
NO breaking change is introduced!
* Add the missing return after creating the new Report, make that line meaningless
* Add the check whether `container.name` is an instance of an `IdentifierStream` node, otherwise, there will be an uncaught error when it's actually a `PrimaryExpresssionNode`.
* Add the `any` assertion.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review