### PR TITLE
fix: support identifiers starting with numbers

### DIFF
--- a/packages/dbml-parse/tests/lexer/input/identifiers.in.dbml
+++ b/packages/dbml-parse/tests/lexer/input/identifiers.in.dbml
@@ -2,5 +2,3 @@ Table TableGroup
 as
 indexes Note
 _ab
-
-3a // invalid identifier

--- a/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
+++ b/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
@@ -1,6 +1,7 @@
 12_abc // Identifier
 226_abc // Identifier
 3a // Identifier
+3a.4a // Indentifier<dot>Identifier
 1.a // Invalid number
 1.3.a // Invalid number
 1.4.a.b // Invalid_number

--- a/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
+++ b/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
@@ -1,0 +1,6 @@
+12_abc // Identifier
+226_abc // Identifier
+3a // Identifier
+1.a // Invalid number
+1.3.a // Invalid number
+1.4.a.b // Invalid_number

--- a/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
+++ b/packages/dbml-parse/tests/lexer/input/identifiers_starting_with_digits.in.dbml
@@ -2,6 +2,7 @@
 226_abc // Identifier
 3a // Identifier
 3a.4a // Indentifier<dot>Identifier
+3a3 // Identifier
 1.a // Invalid number
 1.3.a // Invalid number
 1.4.a.b // Invalid_number

--- a/packages/dbml-parse/tests/lexer/output/identifiers.out.json
+++ b/packages/dbml-parse/tests/lexer/output/identifiers.out.json
@@ -229,118 +229,9 @@
       },
       "value": "_ab",
       "leadingTrivia": [],
-      "trailingTrivia": [
-        {
-          "kind": "<newline>",
-          "startPos": {
-            "offset": 40,
-            "line": 3,
-            "column": 4
-          },
-          "endPos": {
-            "offset": 41,
-            "line": 4,
-            "column": 0
-          },
-          "value": "\n",
-          "leadingTrivia": [],
-          "trailingTrivia": [],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 40,
-          "end": 41
-        }
-      ],
+      "trailingTrivia": [],
       "leadingInvalid": [],
-      "trailingInvalid": [
-        {
-          "kind": "<number>",
-          "startPos": {
-            "offset": 43,
-            "line": 5,
-            "column": 0
-          },
-          "endPos": {
-            "offset": 45,
-            "line": 5,
-            "column": 2
-          },
-          "value": "3a",
-          "leadingTrivia": [
-            {
-              "kind": "<newline>",
-              "startPos": {
-                "offset": 42,
-                "line": 4,
-                "column": 1
-              },
-              "endPos": {
-                "offset": 43,
-                "line": 5,
-                "column": 0
-              },
-              "value": "\n",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 42,
-              "end": 43
-            }
-          ],
-          "trailingTrivia": [
-            {
-              "kind": "<space>",
-              "startPos": {
-                "offset": 45,
-                "line": 5,
-                "column": 2
-              },
-              "endPos": {
-                "offset": 46,
-                "line": 5,
-                "column": 3
-              },
-              "value": " ",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 45,
-              "end": 46
-            },
-            {
-              "kind": "<single-line-comment>",
-              "startPos": {
-                "offset": 46,
-                "line": 5,
-                "column": 3
-              },
-              "endPos": {
-                "offset": 67,
-                "line": 5,
-                "column": 24
-              },
-              "value": " invalid identifier",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 46,
-              "end": 67
-            }
-          ],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": true,
-          "start": 43,
-          "end": 45
-        }
-      ],
+      "trailingInvalid": [],
       "isInvalid": false,
       "start": 36,
       "end": 39
@@ -348,14 +239,14 @@
     {
       "kind": "<eof>",
       "startPos": {
-        "offset": 67,
-        "line": 5,
-        "column": 24
+        "offset": 39,
+        "line": 3,
+        "column": 3
       },
       "endPos": {
-        "offset": 67,
-        "line": 5,
-        "column": 24
+        "offset": 39,
+        "line": 3,
+        "column": 3
       },
       "value": "",
       "leadingTrivia": [],
@@ -363,103 +254,9 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 67,
-      "end": 67
+      "start": 39,
+      "end": 39
     }
   ],
-  "errors": [
-    {
-      "code": 1004,
-      "diagnostic": "Invalid number",
-      "nodeOrToken": {
-        "kind": "<number>",
-        "startPos": {
-          "offset": 43,
-          "line": 5,
-          "column": 0
-        },
-        "endPos": {
-          "offset": 45,
-          "line": 5,
-          "column": 2
-        },
-        "value": "3a",
-        "leadingTrivia": [
-          {
-            "kind": "<newline>",
-            "startPos": {
-              "offset": 42,
-              "line": 4,
-              "column": 1
-            },
-            "endPos": {
-              "offset": 43,
-              "line": 5,
-              "column": 0
-            },
-            "value": "\n",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 42,
-            "end": 43
-          }
-        ],
-        "trailingTrivia": [
-          {
-            "kind": "<space>",
-            "startPos": {
-              "offset": 45,
-              "line": 5,
-              "column": 2
-            },
-            "endPos": {
-              "offset": 46,
-              "line": 5,
-              "column": 3
-            },
-            "value": " ",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 45,
-            "end": 46
-          },
-          {
-            "kind": "<single-line-comment>",
-            "startPos": {
-              "offset": 46,
-              "line": 5,
-              "column": 3
-            },
-            "endPos": {
-              "offset": 67,
-              "line": 5,
-              "column": 24
-            },
-            "value": " invalid identifier",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 46,
-            "end": 67
-          }
-        ],
-        "leadingInvalid": [],
-        "trailingInvalid": [],
-        "isInvalid": true,
-        "start": 43,
-        "end": 45
-      },
-      "start": 43,
-      "end": 45,
-      "name": "CompileError"
-    }
-  ]
+  "errors": []
 }

--- a/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
+++ b/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
@@ -250,17 +250,144 @@
         }
       ],
       "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 43,
+      "end": 45
+    },
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 60,
+        "line": 3,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 62,
+        "line": 3,
+        "column": 2
+      },
+      "value": "3a",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 60,
+      "end": 62
+    },
+    {
+      "kind": "<op>",
+      "startPos": {
+        "offset": 62,
+        "line": 3,
+        "column": 2
+      },
+      "endPos": {
+        "offset": 63,
+        "line": 3,
+        "column": 3
+      },
+      "value": ".",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 62,
+      "end": 63
+    },
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 63,
+        "line": 3,
+        "column": 3
+      },
+      "endPos": {
+        "offset": 65,
+        "line": 3,
+        "column": 5
+      },
+      "value": "4a",
+      "leadingTrivia": [],
+      "trailingTrivia": [
+        {
+          "kind": "<space>",
+          "startPos": {
+            "offset": 65,
+            "line": 3,
+            "column": 5
+          },
+          "endPos": {
+            "offset": 66,
+            "line": 3,
+            "column": 6
+          },
+          "value": " ",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 65,
+          "end": 66
+        },
+        {
+          "kind": "<single-line-comment>",
+          "startPos": {
+            "offset": 66,
+            "line": 3,
+            "column": 6
+          },
+          "endPos": {
+            "offset": 95,
+            "line": 3,
+            "column": 35
+          },
+          "value": " Indentifier<dot>Identifier",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 66,
+          "end": 95
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 95,
+            "line": 3,
+            "column": 35
+          },
+          "endPos": {
+            "offset": 96,
+            "line": 4,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 95,
+          "end": 96
+        }
+      ],
+      "leadingInvalid": [],
       "trailingInvalid": [
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 60,
-            "line": 3,
+            "offset": 96,
+            "line": 4,
             "column": 0
           },
           "endPos": {
-            "offset": 63,
-            "line": 3,
+            "offset": 99,
+            "line": 4,
             "column": 3
           },
           "value": "1.a",
@@ -269,13 +396,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 63,
-                "line": 3,
+                "offset": 99,
+                "line": 4,
                 "column": 3
               },
               "endPos": {
-                "offset": 64,
-                "line": 3,
+                "offset": 100,
+                "line": 4,
                 "column": 4
               },
               "value": " ",
@@ -284,19 +411,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 63,
-              "end": 64
+              "start": 99,
+              "end": 100
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 64,
-                "line": 3,
+                "offset": 100,
+                "line": 4,
                 "column": 4
               },
               "endPos": {
-                "offset": 81,
-                "line": 3,
+                "offset": 117,
+                "line": 4,
                 "column": 21
               },
               "value": " Invalid number",
@@ -305,19 +432,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 64,
-              "end": 81
+              "start": 100,
+              "end": 117
             },
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 81,
-                "line": 3,
+                "offset": 117,
+                "line": 4,
                 "column": 21
               },
               "endPos": {
-                "offset": 82,
-                "line": 4,
+                "offset": 118,
+                "line": 5,
                 "column": 0
               },
               "value": "\n",
@@ -326,26 +453,26 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 81,
-              "end": 82
+              "start": 117,
+              "end": 118
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 60,
-          "end": 63
+          "start": 96,
+          "end": 99
         },
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 82,
-            "line": 4,
+            "offset": 118,
+            "line": 5,
             "column": 0
           },
           "endPos": {
-            "offset": 87,
-            "line": 4,
+            "offset": 123,
+            "line": 5,
             "column": 5
           },
           "value": "1.3.a",
@@ -354,13 +481,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 87,
-                "line": 4,
+                "offset": 123,
+                "line": 5,
                 "column": 5
               },
               "endPos": {
-                "offset": 88,
-                "line": 4,
+                "offset": 124,
+                "line": 5,
                 "column": 6
               },
               "value": " ",
@@ -369,19 +496,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 87,
-              "end": 88
+              "start": 123,
+              "end": 124
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 88,
-                "line": 4,
+                "offset": 124,
+                "line": 5,
                 "column": 6
               },
               "endPos": {
-                "offset": 105,
-                "line": 4,
+                "offset": 141,
+                "line": 5,
                 "column": 23
               },
               "value": " Invalid number",
@@ -390,19 +517,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 88,
-              "end": 105
+              "start": 124,
+              "end": 141
             },
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 105,
-                "line": 4,
+                "offset": 141,
+                "line": 5,
                 "column": 23
               },
               "endPos": {
-                "offset": 106,
-                "line": 5,
+                "offset": 142,
+                "line": 6,
                 "column": 0
               },
               "value": "\n",
@@ -411,26 +538,26 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 105,
-              "end": 106
+              "start": 141,
+              "end": 142
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 82,
-          "end": 87
+          "start": 118,
+          "end": 123
         },
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 106,
-            "line": 5,
+            "offset": 142,
+            "line": 6,
             "column": 0
           },
           "endPos": {
-            "offset": 113,
-            "line": 5,
+            "offset": 149,
+            "line": 6,
             "column": 7
           },
           "value": "1.4.a.b",
@@ -439,13 +566,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 113,
-                "line": 5,
+                "offset": 149,
+                "line": 6,
                 "column": 7
               },
               "endPos": {
-                "offset": 114,
-                "line": 5,
+                "offset": 150,
+                "line": 6,
                 "column": 8
               },
               "value": " ",
@@ -454,19 +581,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 113,
-              "end": 114
+              "start": 149,
+              "end": 150
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 114,
-                "line": 5,
+                "offset": 150,
+                "line": 6,
                 "column": 8
               },
               "endPos": {
-                "offset": 131,
-                "line": 5,
+                "offset": 167,
+                "line": 6,
                 "column": 25
               },
               "value": " Invalid_number",
@@ -475,31 +602,31 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 114,
-              "end": 131
+              "start": 150,
+              "end": 167
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 106,
-          "end": 113
+          "start": 142,
+          "end": 149
         }
       ],
       "isInvalid": false,
-      "start": 43,
-      "end": 45
+      "start": 63,
+      "end": 65
     },
     {
       "kind": "<eof>",
       "startPos": {
-        "offset": 131,
-        "line": 5,
+        "offset": 167,
+        "line": 6,
         "column": 25
       },
       "endPos": {
-        "offset": 131,
-        "line": 5,
+        "offset": 167,
+        "line": 6,
         "column": 25
       },
       "value": "",
@@ -508,8 +635,8 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 131,
-      "end": 131
+      "start": 167,
+      "end": 167
     }
   ],
   "errors": [
@@ -519,13 +646,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 60,
-          "line": 3,
+          "offset": 96,
+          "line": 4,
           "column": 0
         },
         "endPos": {
-          "offset": 63,
-          "line": 3,
+          "offset": 99,
+          "line": 4,
           "column": 3
         },
         "value": "1.a",
@@ -534,13 +661,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 63,
-              "line": 3,
+              "offset": 99,
+              "line": 4,
               "column": 3
             },
             "endPos": {
-              "offset": 64,
-              "line": 3,
+              "offset": 100,
+              "line": 4,
               "column": 4
             },
             "value": " ",
@@ -549,19 +676,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 63,
-            "end": 64
+            "start": 99,
+            "end": 100
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 64,
-              "line": 3,
+              "offset": 100,
+              "line": 4,
               "column": 4
             },
             "endPos": {
-              "offset": 81,
-              "line": 3,
+              "offset": 117,
+              "line": 4,
               "column": 21
             },
             "value": " Invalid number",
@@ -570,19 +697,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 64,
-            "end": 81
+            "start": 100,
+            "end": 117
           },
           {
             "kind": "<newline>",
             "startPos": {
-              "offset": 81,
-              "line": 3,
+              "offset": 117,
+              "line": 4,
               "column": 21
             },
             "endPos": {
-              "offset": 82,
-              "line": 4,
+              "offset": 118,
+              "line": 5,
               "column": 0
             },
             "value": "\n",
@@ -591,18 +718,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 81,
-            "end": 82
+            "start": 117,
+            "end": 118
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 60,
-        "end": 63
+        "start": 96,
+        "end": 99
       },
-      "start": 60,
-      "end": 63,
+      "start": 96,
+      "end": 99,
       "name": "CompileError"
     },
     {
@@ -611,13 +738,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 82,
-          "line": 4,
+          "offset": 118,
+          "line": 5,
           "column": 0
         },
         "endPos": {
-          "offset": 87,
-          "line": 4,
+          "offset": 123,
+          "line": 5,
           "column": 5
         },
         "value": "1.3.a",
@@ -626,13 +753,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 87,
-              "line": 4,
+              "offset": 123,
+              "line": 5,
               "column": 5
             },
             "endPos": {
-              "offset": 88,
-              "line": 4,
+              "offset": 124,
+              "line": 5,
               "column": 6
             },
             "value": " ",
@@ -641,19 +768,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 87,
-            "end": 88
+            "start": 123,
+            "end": 124
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 88,
-              "line": 4,
+              "offset": 124,
+              "line": 5,
               "column": 6
             },
             "endPos": {
-              "offset": 105,
-              "line": 4,
+              "offset": 141,
+              "line": 5,
               "column": 23
             },
             "value": " Invalid number",
@@ -662,19 +789,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 88,
-            "end": 105
+            "start": 124,
+            "end": 141
           },
           {
             "kind": "<newline>",
             "startPos": {
-              "offset": 105,
-              "line": 4,
+              "offset": 141,
+              "line": 5,
               "column": 23
             },
             "endPos": {
-              "offset": 106,
-              "line": 5,
+              "offset": 142,
+              "line": 6,
               "column": 0
             },
             "value": "\n",
@@ -683,18 +810,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 105,
-            "end": 106
+            "start": 141,
+            "end": 142
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 82,
-        "end": 87
+        "start": 118,
+        "end": 123
       },
-      "start": 82,
-      "end": 87,
+      "start": 118,
+      "end": 123,
       "name": "CompileError"
     },
     {
@@ -703,13 +830,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 106,
-          "line": 5,
+          "offset": 142,
+          "line": 6,
           "column": 0
         },
         "endPos": {
-          "offset": 113,
-          "line": 5,
+          "offset": 149,
+          "line": 6,
           "column": 7
         },
         "value": "1.4.a.b",
@@ -718,13 +845,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 113,
-              "line": 5,
+              "offset": 149,
+              "line": 6,
               "column": 7
             },
             "endPos": {
-              "offset": 114,
-              "line": 5,
+              "offset": 150,
+              "line": 6,
               "column": 8
             },
             "value": " ",
@@ -733,19 +860,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 113,
-            "end": 114
+            "start": 149,
+            "end": 150
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 114,
-              "line": 5,
+              "offset": 150,
+              "line": 6,
               "column": 8
             },
             "endPos": {
-              "offset": 131,
-              "line": 5,
+              "offset": 167,
+              "line": 6,
               "column": 25
             },
             "value": " Invalid_number",
@@ -754,18 +881,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 114,
-            "end": 131
+            "start": 150,
+            "end": 167
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 106,
-        "end": 113
+        "start": 142,
+        "end": 149
       },
-      "start": 106,
-      "end": 113,
+      "start": 142,
+      "end": 149,
       "name": "CompileError"
     }
   ]

--- a/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
+++ b/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
@@ -377,17 +377,102 @@
         }
       ],
       "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 63,
+      "end": 65
+    },
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 96,
+        "line": 4,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 99,
+        "line": 4,
+        "column": 3
+      },
+      "value": "3a3",
+      "leadingTrivia": [],
+      "trailingTrivia": [
+        {
+          "kind": "<space>",
+          "startPos": {
+            "offset": 99,
+            "line": 4,
+            "column": 3
+          },
+          "endPos": {
+            "offset": 100,
+            "line": 4,
+            "column": 4
+          },
+          "value": " ",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 99,
+          "end": 100
+        },
+        {
+          "kind": "<single-line-comment>",
+          "startPos": {
+            "offset": 100,
+            "line": 4,
+            "column": 4
+          },
+          "endPos": {
+            "offset": 113,
+            "line": 4,
+            "column": 17
+          },
+          "value": " Identifier",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 100,
+          "end": 113
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 113,
+            "line": 4,
+            "column": 17
+          },
+          "endPos": {
+            "offset": 114,
+            "line": 5,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 113,
+          "end": 114
+        }
+      ],
+      "leadingInvalid": [],
       "trailingInvalid": [
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 96,
-            "line": 4,
+            "offset": 114,
+            "line": 5,
             "column": 0
           },
           "endPos": {
-            "offset": 99,
-            "line": 4,
+            "offset": 117,
+            "line": 5,
             "column": 3
           },
           "value": "1.a",
@@ -396,13 +481,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 99,
-                "line": 4,
+                "offset": 117,
+                "line": 5,
                 "column": 3
               },
               "endPos": {
-                "offset": 100,
-                "line": 4,
+                "offset": 118,
+                "line": 5,
                 "column": 4
               },
               "value": " ",
@@ -411,19 +496,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 99,
-              "end": 100
+              "start": 117,
+              "end": 118
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 100,
-                "line": 4,
+                "offset": 118,
+                "line": 5,
                 "column": 4
               },
               "endPos": {
-                "offset": 117,
-                "line": 4,
+                "offset": 135,
+                "line": 5,
                 "column": 21
               },
               "value": " Invalid number",
@@ -432,19 +517,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 100,
-              "end": 117
+              "start": 118,
+              "end": 135
             },
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 117,
-                "line": 4,
+                "offset": 135,
+                "line": 5,
                 "column": 21
               },
               "endPos": {
-                "offset": 118,
-                "line": 5,
+                "offset": 136,
+                "line": 6,
                 "column": 0
               },
               "value": "\n",
@@ -453,26 +538,26 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 117,
-              "end": 118
+              "start": 135,
+              "end": 136
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 96,
-          "end": 99
+          "start": 114,
+          "end": 117
         },
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 118,
-            "line": 5,
+            "offset": 136,
+            "line": 6,
             "column": 0
           },
           "endPos": {
-            "offset": 123,
-            "line": 5,
+            "offset": 141,
+            "line": 6,
             "column": 5
           },
           "value": "1.3.a",
@@ -481,13 +566,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 123,
-                "line": 5,
+                "offset": 141,
+                "line": 6,
                 "column": 5
               },
               "endPos": {
-                "offset": 124,
-                "line": 5,
+                "offset": 142,
+                "line": 6,
                 "column": 6
               },
               "value": " ",
@@ -496,19 +581,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 123,
-              "end": 124
+              "start": 141,
+              "end": 142
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 124,
-                "line": 5,
+                "offset": 142,
+                "line": 6,
                 "column": 6
               },
               "endPos": {
-                "offset": 141,
-                "line": 5,
+                "offset": 159,
+                "line": 6,
                 "column": 23
               },
               "value": " Invalid number",
@@ -517,19 +602,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 124,
-              "end": 141
+              "start": 142,
+              "end": 159
             },
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 141,
-                "line": 5,
+                "offset": 159,
+                "line": 6,
                 "column": 23
               },
               "endPos": {
-                "offset": 142,
-                "line": 6,
+                "offset": 160,
+                "line": 7,
                 "column": 0
               },
               "value": "\n",
@@ -538,26 +623,26 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 141,
-              "end": 142
+              "start": 159,
+              "end": 160
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 118,
-          "end": 123
+          "start": 136,
+          "end": 141
         },
         {
           "kind": "<number>",
           "startPos": {
-            "offset": 142,
-            "line": 6,
+            "offset": 160,
+            "line": 7,
             "column": 0
           },
           "endPos": {
-            "offset": 149,
-            "line": 6,
+            "offset": 167,
+            "line": 7,
             "column": 7
           },
           "value": "1.4.a.b",
@@ -566,13 +651,13 @@
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 149,
-                "line": 6,
+                "offset": 167,
+                "line": 7,
                 "column": 7
               },
               "endPos": {
-                "offset": 150,
-                "line": 6,
+                "offset": 168,
+                "line": 7,
                 "column": 8
               },
               "value": " ",
@@ -581,19 +666,19 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 149,
-              "end": 150
+              "start": 167,
+              "end": 168
             },
             {
               "kind": "<single-line-comment>",
               "startPos": {
-                "offset": 150,
-                "line": 6,
+                "offset": 168,
+                "line": 7,
                 "column": 8
               },
               "endPos": {
-                "offset": 167,
-                "line": 6,
+                "offset": 185,
+                "line": 7,
                 "column": 25
               },
               "value": " Invalid_number",
@@ -602,31 +687,31 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 150,
-              "end": 167
+              "start": 168,
+              "end": 185
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": true,
-          "start": 142,
-          "end": 149
+          "start": 160,
+          "end": 167
         }
       ],
       "isInvalid": false,
-      "start": 63,
-      "end": 65
+      "start": 96,
+      "end": 99
     },
     {
       "kind": "<eof>",
       "startPos": {
-        "offset": 167,
-        "line": 6,
+        "offset": 185,
+        "line": 7,
         "column": 25
       },
       "endPos": {
-        "offset": 167,
-        "line": 6,
+        "offset": 185,
+        "line": 7,
         "column": 25
       },
       "value": "",
@@ -635,8 +720,8 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 167,
-      "end": 167
+      "start": 185,
+      "end": 185
     }
   ],
   "errors": [
@@ -646,13 +731,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 96,
-          "line": 4,
+          "offset": 114,
+          "line": 5,
           "column": 0
         },
         "endPos": {
-          "offset": 99,
-          "line": 4,
+          "offset": 117,
+          "line": 5,
           "column": 3
         },
         "value": "1.a",
@@ -661,13 +746,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 99,
-              "line": 4,
+              "offset": 117,
+              "line": 5,
               "column": 3
             },
             "endPos": {
-              "offset": 100,
-              "line": 4,
+              "offset": 118,
+              "line": 5,
               "column": 4
             },
             "value": " ",
@@ -676,19 +761,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 99,
-            "end": 100
+            "start": 117,
+            "end": 118
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 100,
-              "line": 4,
+              "offset": 118,
+              "line": 5,
               "column": 4
             },
             "endPos": {
-              "offset": 117,
-              "line": 4,
+              "offset": 135,
+              "line": 5,
               "column": 21
             },
             "value": " Invalid number",
@@ -697,19 +782,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 100,
-            "end": 117
+            "start": 118,
+            "end": 135
           },
           {
             "kind": "<newline>",
             "startPos": {
-              "offset": 117,
-              "line": 4,
+              "offset": 135,
+              "line": 5,
               "column": 21
             },
             "endPos": {
-              "offset": 118,
-              "line": 5,
+              "offset": 136,
+              "line": 6,
               "column": 0
             },
             "value": "\n",
@@ -718,18 +803,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 117,
-            "end": 118
+            "start": 135,
+            "end": 136
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 96,
-        "end": 99
+        "start": 114,
+        "end": 117
       },
-      "start": 96,
-      "end": 99,
+      "start": 114,
+      "end": 117,
       "name": "CompileError"
     },
     {
@@ -738,13 +823,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 118,
-          "line": 5,
+          "offset": 136,
+          "line": 6,
           "column": 0
         },
         "endPos": {
-          "offset": 123,
-          "line": 5,
+          "offset": 141,
+          "line": 6,
           "column": 5
         },
         "value": "1.3.a",
@@ -753,13 +838,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 123,
-              "line": 5,
+              "offset": 141,
+              "line": 6,
               "column": 5
             },
             "endPos": {
-              "offset": 124,
-              "line": 5,
+              "offset": 142,
+              "line": 6,
               "column": 6
             },
             "value": " ",
@@ -768,19 +853,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 123,
-            "end": 124
+            "start": 141,
+            "end": 142
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 124,
-              "line": 5,
+              "offset": 142,
+              "line": 6,
               "column": 6
             },
             "endPos": {
-              "offset": 141,
-              "line": 5,
+              "offset": 159,
+              "line": 6,
               "column": 23
             },
             "value": " Invalid number",
@@ -789,19 +874,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 124,
-            "end": 141
+            "start": 142,
+            "end": 159
           },
           {
             "kind": "<newline>",
             "startPos": {
-              "offset": 141,
-              "line": 5,
+              "offset": 159,
+              "line": 6,
               "column": 23
             },
             "endPos": {
-              "offset": 142,
-              "line": 6,
+              "offset": 160,
+              "line": 7,
               "column": 0
             },
             "value": "\n",
@@ -810,18 +895,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 141,
-            "end": 142
+            "start": 159,
+            "end": 160
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 118,
-        "end": 123
+        "start": 136,
+        "end": 141
       },
-      "start": 118,
-      "end": 123,
+      "start": 136,
+      "end": 141,
       "name": "CompileError"
     },
     {
@@ -830,13 +915,13 @@
       "nodeOrToken": {
         "kind": "<number>",
         "startPos": {
-          "offset": 142,
-          "line": 6,
+          "offset": 160,
+          "line": 7,
           "column": 0
         },
         "endPos": {
-          "offset": 149,
-          "line": 6,
+          "offset": 167,
+          "line": 7,
           "column": 7
         },
         "value": "1.4.a.b",
@@ -845,13 +930,13 @@
           {
             "kind": "<space>",
             "startPos": {
-              "offset": 149,
-              "line": 6,
+              "offset": 167,
+              "line": 7,
               "column": 7
             },
             "endPos": {
-              "offset": 150,
-              "line": 6,
+              "offset": 168,
+              "line": 7,
               "column": 8
             },
             "value": " ",
@@ -860,19 +945,19 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 149,
-            "end": 150
+            "start": 167,
+            "end": 168
           },
           {
             "kind": "<single-line-comment>",
             "startPos": {
-              "offset": 150,
-              "line": 6,
+              "offset": 168,
+              "line": 7,
               "column": 8
             },
             "endPos": {
-              "offset": 167,
-              "line": 6,
+              "offset": 185,
+              "line": 7,
               "column": 25
             },
             "value": " Invalid_number",
@@ -881,18 +966,18 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 150,
-            "end": 167
+            "start": 168,
+            "end": 185
           }
         ],
         "leadingInvalid": [],
         "trailingInvalid": [],
         "isInvalid": true,
-        "start": 142,
-        "end": 149
+        "start": 160,
+        "end": 167
       },
-      "start": 142,
-      "end": 149,
+      "start": 160,
+      "end": 167,
       "name": "CompileError"
     }
   ]

--- a/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
+++ b/packages/dbml-parse/tests/lexer/output/identifiers_starting_with_digits.out.json
@@ -1,0 +1,772 @@
+{
+  "value": [
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 0,
+        "line": 0,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 6,
+        "line": 0,
+        "column": 6
+      },
+      "value": "12_abc",
+      "leadingTrivia": [],
+      "trailingTrivia": [
+        {
+          "kind": "<space>",
+          "startPos": {
+            "offset": 6,
+            "line": 0,
+            "column": 6
+          },
+          "endPos": {
+            "offset": 7,
+            "line": 0,
+            "column": 7
+          },
+          "value": " ",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 6,
+          "end": 7
+        },
+        {
+          "kind": "<single-line-comment>",
+          "startPos": {
+            "offset": 7,
+            "line": 0,
+            "column": 7
+          },
+          "endPos": {
+            "offset": 20,
+            "line": 0,
+            "column": 20
+          },
+          "value": " Identifier",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 7,
+          "end": 20
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 20,
+            "line": 0,
+            "column": 20
+          },
+          "endPos": {
+            "offset": 21,
+            "line": 1,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 20,
+          "end": 21
+        }
+      ],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 0,
+      "end": 6
+    },
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 21,
+        "line": 1,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 28,
+        "line": 1,
+        "column": 7
+      },
+      "value": "226_abc",
+      "leadingTrivia": [],
+      "trailingTrivia": [
+        {
+          "kind": "<space>",
+          "startPos": {
+            "offset": 28,
+            "line": 1,
+            "column": 7
+          },
+          "endPos": {
+            "offset": 29,
+            "line": 1,
+            "column": 8
+          },
+          "value": " ",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 28,
+          "end": 29
+        },
+        {
+          "kind": "<single-line-comment>",
+          "startPos": {
+            "offset": 29,
+            "line": 1,
+            "column": 8
+          },
+          "endPos": {
+            "offset": 42,
+            "line": 1,
+            "column": 21
+          },
+          "value": " Identifier",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 29,
+          "end": 42
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 42,
+            "line": 1,
+            "column": 21
+          },
+          "endPos": {
+            "offset": 43,
+            "line": 2,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 42,
+          "end": 43
+        }
+      ],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 21,
+      "end": 28
+    },
+    {
+      "kind": "<identifier>",
+      "startPos": {
+        "offset": 43,
+        "line": 2,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 45,
+        "line": 2,
+        "column": 2
+      },
+      "value": "3a",
+      "leadingTrivia": [],
+      "trailingTrivia": [
+        {
+          "kind": "<space>",
+          "startPos": {
+            "offset": 45,
+            "line": 2,
+            "column": 2
+          },
+          "endPos": {
+            "offset": 46,
+            "line": 2,
+            "column": 3
+          },
+          "value": " ",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 45,
+          "end": 46
+        },
+        {
+          "kind": "<single-line-comment>",
+          "startPos": {
+            "offset": 46,
+            "line": 2,
+            "column": 3
+          },
+          "endPos": {
+            "offset": 59,
+            "line": 2,
+            "column": 16
+          },
+          "value": " Identifier",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 46,
+          "end": 59
+        },
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 59,
+            "line": 2,
+            "column": 16
+          },
+          "endPos": {
+            "offset": 60,
+            "line": 3,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 59,
+          "end": 60
+        }
+      ],
+      "leadingInvalid": [],
+      "trailingInvalid": [
+        {
+          "kind": "<number>",
+          "startPos": {
+            "offset": 60,
+            "line": 3,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 63,
+            "line": 3,
+            "column": 3
+          },
+          "value": "1.a",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 63,
+                "line": 3,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 64,
+                "line": 3,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "kind": "<single-line-comment>",
+              "startPos": {
+                "offset": 64,
+                "line": 3,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 81,
+                "line": 3,
+                "column": 21
+              },
+              "value": " Invalid number",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 64,
+              "end": 81
+            },
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 81,
+                "line": 3,
+                "column": 21
+              },
+              "endPos": {
+                "offset": 82,
+                "line": 4,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 81,
+              "end": 82
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": true,
+          "start": 60,
+          "end": 63
+        },
+        {
+          "kind": "<number>",
+          "startPos": {
+            "offset": 82,
+            "line": 4,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 87,
+            "line": 4,
+            "column": 5
+          },
+          "value": "1.3.a",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 87,
+                "line": 4,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 88,
+                "line": 4,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "kind": "<single-line-comment>",
+              "startPos": {
+                "offset": 88,
+                "line": 4,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 105,
+                "line": 4,
+                "column": 23
+              },
+              "value": " Invalid number",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 88,
+              "end": 105
+            },
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 105,
+                "line": 4,
+                "column": 23
+              },
+              "endPos": {
+                "offset": 106,
+                "line": 5,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 105,
+              "end": 106
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": true,
+          "start": 82,
+          "end": 87
+        },
+        {
+          "kind": "<number>",
+          "startPos": {
+            "offset": 106,
+            "line": 5,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 113,
+            "line": 5,
+            "column": 7
+          },
+          "value": "1.4.a.b",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 113,
+                "line": 5,
+                "column": 7
+              },
+              "endPos": {
+                "offset": 114,
+                "line": 5,
+                "column": 8
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "kind": "<single-line-comment>",
+              "startPos": {
+                "offset": 114,
+                "line": 5,
+                "column": 8
+              },
+              "endPos": {
+                "offset": 131,
+                "line": 5,
+                "column": 25
+              },
+              "value": " Invalid_number",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 114,
+              "end": 131
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": true,
+          "start": 106,
+          "end": 113
+        }
+      ],
+      "isInvalid": false,
+      "start": 43,
+      "end": 45
+    },
+    {
+      "kind": "<eof>",
+      "startPos": {
+        "offset": 131,
+        "line": 5,
+        "column": 25
+      },
+      "endPos": {
+        "offset": 131,
+        "line": 5,
+        "column": 25
+      },
+      "value": "",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 131,
+      "end": 131
+    }
+  ],
+  "errors": [
+    {
+      "code": 1004,
+      "diagnostic": "Invalid number",
+      "nodeOrToken": {
+        "kind": "<number>",
+        "startPos": {
+          "offset": 60,
+          "line": 3,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 63,
+          "line": 3,
+          "column": 3
+        },
+        "value": "1.a",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 63,
+              "line": 3,
+              "column": 3
+            },
+            "endPos": {
+              "offset": 64,
+              "line": 3,
+              "column": 4
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 63,
+            "end": 64
+          },
+          {
+            "kind": "<single-line-comment>",
+            "startPos": {
+              "offset": 64,
+              "line": 3,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 81,
+              "line": 3,
+              "column": 21
+            },
+            "value": " Invalid number",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 64,
+            "end": 81
+          },
+          {
+            "kind": "<newline>",
+            "startPos": {
+              "offset": 81,
+              "line": 3,
+              "column": 21
+            },
+            "endPos": {
+              "offset": 82,
+              "line": 4,
+              "column": 0
+            },
+            "value": "\n",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 81,
+            "end": 82
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": true,
+        "start": 60,
+        "end": 63
+      },
+      "start": 60,
+      "end": 63,
+      "name": "CompileError"
+    },
+    {
+      "code": 1004,
+      "diagnostic": "Invalid number",
+      "nodeOrToken": {
+        "kind": "<number>",
+        "startPos": {
+          "offset": 82,
+          "line": 4,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 87,
+          "line": 4,
+          "column": 5
+        },
+        "value": "1.3.a",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 87,
+              "line": 4,
+              "column": 5
+            },
+            "endPos": {
+              "offset": 88,
+              "line": 4,
+              "column": 6
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 87,
+            "end": 88
+          },
+          {
+            "kind": "<single-line-comment>",
+            "startPos": {
+              "offset": 88,
+              "line": 4,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 105,
+              "line": 4,
+              "column": 23
+            },
+            "value": " Invalid number",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 88,
+            "end": 105
+          },
+          {
+            "kind": "<newline>",
+            "startPos": {
+              "offset": 105,
+              "line": 4,
+              "column": 23
+            },
+            "endPos": {
+              "offset": 106,
+              "line": 5,
+              "column": 0
+            },
+            "value": "\n",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 105,
+            "end": 106
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": true,
+        "start": 82,
+        "end": 87
+      },
+      "start": 82,
+      "end": 87,
+      "name": "CompileError"
+    },
+    {
+      "code": 1004,
+      "diagnostic": "Invalid number",
+      "nodeOrToken": {
+        "kind": "<number>",
+        "startPos": {
+          "offset": 106,
+          "line": 5,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 113,
+          "line": 5,
+          "column": 7
+        },
+        "value": "1.4.a.b",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 113,
+              "line": 5,
+              "column": 7
+            },
+            "endPos": {
+              "offset": 114,
+              "line": 5,
+              "column": 8
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 113,
+            "end": 114
+          },
+          {
+            "kind": "<single-line-comment>",
+            "startPos": {
+              "offset": 114,
+              "line": 5,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 131,
+              "line": 5,
+              "column": 25
+            },
+            "value": " Invalid_number",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 114,
+            "end": 131
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": true,
+        "start": 106,
+        "end": 113
+      },
+      "start": 106,
+      "end": 113,
+      "name": "CompileError"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
* Identifiers like `234_abc` are now supported.
* Identifiers with digits only must be quoted.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [X] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review