### PR TITLE
Fix validate when redundant args & `getMemberChain`

### DIFF
--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
@@ -102,7 +102,7 @@ export default class EnumValidator implements ElementValidator {
       const errors: CompileError[] = [];
 
       if (field.callee && !isExpressionAVariableNode(field.callee)) {
-        errors.push(new CompileError(CompileErrorCode.INVALID_COLUMN_NAME, 'A column name must be an identifier or a quoted identifier', field.callee));
+        errors.push(new CompileError(CompileErrorCode.INVALID_ENUM_ELEMENT_NAME, 'An enum field must be an identifier or a quoted identifier', field.callee));
       }
       
       const args = [...field.args];

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
@@ -99,17 +99,23 @@ export default class EnumValidator implements ElementValidator {
     }
 
     return fields.flatMap((field) => {
-      const errors: CompileError[] = []
+      const errors: CompileError[] = [];
+
       if (field.callee && !isExpressionAVariableNode(field.callee)) {
         errors.push(new CompileError(CompileErrorCode.INVALID_COLUMN_NAME, 'A column name must be an identifier or a quoted identifier', field.callee));
       }
       
-      if (_.last(field.args) instanceof ListExpressionNode) {
-        errors.push(...this.validateFieldSetting(_.last(field.args) as ListExpressionNode));
+      const args = [...field.args];
+      if (_.last(args) instanceof ListExpressionNode) {
+        errors.push(...this.validateFieldSettings(_.last(args) as ListExpressionNode));
+        args.pop();
+      } else if (args[0] instanceof ListExpressionNode) {
+        errors.push(...this.validateFieldSettings(args[0]));
+        args.shift();
       }
 
-      if (field.args.length > 1) {
-        errors.push(...field.args.map((arg) => new CompileError(CompileErrorCode.INVALID_ENUM_ELEMENT, 'An Enum must have only a field and optionally a setting list', arg)));
+      if (args.length > 0) {
+        errors.push(...args.map((arg) => new CompileError(CompileErrorCode.INVALID_ENUM_ELEMENT, 'An Enum must have only a field and optionally a setting list', arg)));
       }
 
       errors.push(...this.registerField(field));
@@ -118,7 +124,7 @@ export default class EnumValidator implements ElementValidator {
     });
   }
 
-  validateFieldSetting(settings: ListExpressionNode): CompileError[] {
+  validateFieldSettings(settings: ListExpressionNode): CompileError[] {
     const aggReport = aggregateSettingList(settings);
     const errors = aggReport.getErrors();
     const settingMap = aggReport.getValue();

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -94,12 +94,17 @@ export default class RefValidator implements ElementValidator {
         errors.push(new CompileError(CompileErrorCode.UNEQUAL_FIELDS_BINARY_REF, 'Unequal fields in ref endpoints', field.callee));
       }
 
-      if (_.last(field.args) instanceof ListExpressionNode) {
-        this.validateFieldSettings(_.last(field.args) as ListExpressionNode);
-      }
+      const args = [...field.args];
+      if (_.last(args) instanceof ListExpressionNode) {
+        this.validateFieldSettings(_.last(args) as ListExpressionNode);
+        args.pop();
+      } else if (args[0] instanceof ListExpressionNode) {
+        errors.push(...this.validateFieldSettings(args[0]));
+        args.shift();
+      } 
 
-      if (field.args.length > 1) {
-        errors.push(...field.args.map((arg) => new CompileError(CompileErrorCode.INVALID_REF_FIELD, 'A Ref field should only have a single binary relationship', arg)));
+      if (args.length > 0) {
+        errors.push(...args.map((arg) => new CompileError(CompileErrorCode.INVALID_REF_FIELD, 'A Ref field should only have a single binary relationship', arg)));
       }
     });
 

--- a/packages/dbml-parse/src/lib/parser/utils.ts
+++ b/packages/dbml-parse/src/lib/parser/utils.ts
@@ -4,6 +4,7 @@ import { None, Option, Some } from '../option';
 import { alternateLists } from '../utils';
 import NodeFactory from './factory';
 import {
+  ArrayNode,
   AttributeNode,
   BlockExpressionNode,
   CallExpressionNode,
@@ -260,6 +261,13 @@ export function getMemberChain(node: SyntaxNode): Readonly<(SyntaxNode | SyntaxT
 
   if (node instanceof PrimaryExpressionNode) {
     return filterUndefined(node.expression);
+  }
+
+  if (node instanceof ArrayNode) {
+    return filterUndefined(
+      node.array,
+      node.indexer,
+    )
   }
 
   if (node instanceof GroupExpressionNode) {

--- a/packages/dbml-parse/tests/validator/input/invalid_args.in.dbml
+++ b/packages/dbml-parse/tests/validator/input/invalid_args.in.dbml
@@ -4,9 +4,10 @@ Table A {
 }
 
 Enum E {
-    a e [note: 'abc']
-    a [note: 'abc'] e
-    a e f
+    a1 e [note: 'abc']
+    a2 [note: 'abc'] e
+    a3 e f
+    a4 e
 }
 
 TableGroup G {
@@ -20,6 +21,10 @@ Ref {
 
 Ref {
     A.id > A.id a [delete: cascade]
+}
+
+Ref {
+    A.id > A.id a
 }
 
 Ref {

--- a/packages/dbml-parse/tests/validator/input/invalid_args.in.dbml
+++ b/packages/dbml-parse/tests/validator/input/invalid_args.in.dbml
@@ -1,0 +1,27 @@
+Table A {
+    id int
+    ssid
+}
+
+Enum E {
+    a e [note: 'abc']
+    a [note: 'abc'] e
+    a e f
+}
+
+TableGroup G {
+    A a
+    A a a
+}
+
+Ref {
+    A.id > A.id [delete: cascade] a
+}
+
+Ref {
+    A.id > A.id a [delete: cascade]
+}
+
+Ref {
+    A.id > A.id a a
+}

--- a/packages/dbml-parse/tests/validator/output/enum.out.json
+++ b/packages/dbml-parse/tests/validator/output/enum.out.json
@@ -3362,8 +3362,8 @@
       "name": "CompileError"
     },
     {
-      "code": 3020,
-      "diagnostic": "A column name must be an identifier or a quoted identifier",
+      "code": 3027,
+      "diagnostic": "An enum field must be an identifier or a quoted identifier",
       "nodeOrToken": {
         "id": 14,
         "kind": "<primary-expression>",

--- a/packages/dbml-parse/tests/validator/output/invalid_args.out.json
+++ b/packages/dbml-parse/tests/validator/output/invalid_args.out.json
@@ -1,0 +1,9206 @@
+{
+  "value": {
+    "id": 119,
+    "kind": "<program>",
+    "startPos": {
+      "offset": 0,
+      "line": 0,
+      "column": 0
+    },
+    "fullStart": 0,
+    "endPos": {
+      "offset": 252,
+      "line": 26,
+      "column": 1
+    },
+    "fullEnd": 252,
+    "start": 0,
+    "end": 252,
+    "body": [
+      {
+        "id": 11,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 0,
+          "line": 0,
+          "column": 0
+        },
+        "fullStart": 0,
+        "endPos": {
+          "offset": 31,
+          "line": 3,
+          "column": 1
+        },
+        "fullEnd": 32,
+        "start": 0,
+        "end": 31,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 0,
+            "line": 0,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 5,
+            "line": 0,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 5,
+                "line": 0,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 5,
+              "end": 6
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 0,
+          "end": 5
+        },
+        "name": {
+          "id": 1,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 6,
+            "line": 0,
+            "column": 6
+          },
+          "fullStart": 6,
+          "endPos": {
+            "offset": 7,
+            "line": 0,
+            "column": 7
+          },
+          "fullEnd": 8,
+          "start": 6,
+          "end": 7,
+          "expression": {
+            "id": 0,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 6,
+              "line": 0,
+              "column": 6
+            },
+            "fullStart": 6,
+            "endPos": {
+              "offset": 7,
+              "line": 0,
+              "column": 7
+            },
+            "fullEnd": 8,
+            "start": 6,
+            "end": 7,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 7,
+                "line": 0,
+                "column": 7
+              },
+              "value": "A",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 7,
+                    "line": 0,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 8,
+                    "line": 0,
+                    "column": 8
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 7,
+                  "end": 8
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 6,
+              "end": 7
+            }
+          }
+        },
+        "body": {
+          "id": 10,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 8,
+            "line": 0,
+            "column": 8
+          },
+          "fullStart": 8,
+          "endPos": {
+            "offset": 31,
+            "line": 3,
+            "column": 1
+          },
+          "fullEnd": 32,
+          "start": 8,
+          "end": 31,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 8,
+              "line": 0,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 9,
+              "line": 0,
+              "column": 9
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 9,
+                  "line": 0,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 10,
+                  "line": 1,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 9,
+                "end": 10
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 8,
+            "end": 9
+          },
+          "body": [
+            {
+              "id": 6,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 14,
+                "line": 1,
+                "column": 4
+              },
+              "fullStart": 10,
+              "endPos": {
+                "offset": 20,
+                "line": 1,
+                "column": 10
+              },
+              "fullEnd": 21,
+              "start": 14,
+              "end": 20,
+              "callee": {
+                "id": 3,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 14,
+                  "line": 1,
+                  "column": 4
+                },
+                "fullStart": 10,
+                "endPos": {
+                  "offset": 16,
+                  "line": 1,
+                  "column": 6
+                },
+                "fullEnd": 17,
+                "start": 14,
+                "end": 16,
+                "expression": {
+                  "id": 2,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 14,
+                    "line": 1,
+                    "column": 4
+                  },
+                  "fullStart": 10,
+                  "endPos": {
+                    "offset": 16,
+                    "line": 1,
+                    "column": 6
+                  },
+                  "fullEnd": 17,
+                  "start": 14,
+                  "end": 16,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 14,
+                      "line": 1,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 16,
+                      "line": 1,
+                      "column": 6
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 10,
+                          "line": 1,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 11,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 10,
+                        "end": 11
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 11,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 12,
+                          "line": 1,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 11,
+                        "end": 12
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 12,
+                          "line": 1,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 13,
+                          "line": 1,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 12,
+                        "end": 13
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 13,
+                          "line": 1,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 14,
+                          "line": 1,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 13,
+                        "end": 14
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 16,
+                          "line": 1,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 17,
+                          "line": 1,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 16,
+                        "end": 17
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 14,
+                    "end": 16
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 5,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 17,
+                    "line": 1,
+                    "column": 7
+                  },
+                  "fullStart": 17,
+                  "endPos": {
+                    "offset": 20,
+                    "line": 1,
+                    "column": 10
+                  },
+                  "fullEnd": 21,
+                  "start": 17,
+                  "end": 20,
+                  "expression": {
+                    "id": 4,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 17,
+                      "line": 1,
+                      "column": 7
+                    },
+                    "fullStart": 17,
+                    "endPos": {
+                      "offset": 20,
+                      "line": 1,
+                      "column": 10
+                    },
+                    "fullEnd": 21,
+                    "start": 17,
+                    "end": 20,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 17,
+                        "line": 1,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 20,
+                        "line": 1,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 20,
+                            "line": 1,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 21,
+                            "line": 2,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 20,
+                          "end": 21
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 17,
+                      "end": 20
+                    }
+                  }
+                }
+              ],
+              "symbol": 2
+            },
+            {
+              "id": 9,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 25,
+                "line": 2,
+                "column": 4
+              },
+              "fullStart": 21,
+              "endPos": {
+                "offset": 29,
+                "line": 2,
+                "column": 8
+              },
+              "fullEnd": 30,
+              "start": 25,
+              "end": 29,
+              "callee": {
+                "id": 8,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 25,
+                  "line": 2,
+                  "column": 4
+                },
+                "fullStart": 21,
+                "endPos": {
+                  "offset": 29,
+                  "line": 2,
+                  "column": 8
+                },
+                "fullEnd": 30,
+                "start": 25,
+                "end": 29,
+                "expression": {
+                  "id": 7,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 25,
+                    "line": 2,
+                    "column": 4
+                  },
+                  "fullStart": 21,
+                  "endPos": {
+                    "offset": 29,
+                    "line": 2,
+                    "column": 8
+                  },
+                  "fullEnd": 30,
+                  "start": 25,
+                  "end": 29,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 25,
+                      "line": 2,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 29,
+                      "line": 2,
+                      "column": 8
+                    },
+                    "value": "ssid",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 21,
+                          "line": 2,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 22,
+                          "line": 2,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 21,
+                        "end": 22
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 22,
+                          "line": 2,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 23,
+                          "line": 2,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 22,
+                        "end": 23
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 23,
+                          "line": 2,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 24,
+                          "line": 2,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 23,
+                        "end": 24
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 24,
+                          "line": 2,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 25,
+                          "line": 2,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 24,
+                        "end": 25
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 29,
+                          "line": 2,
+                          "column": 8
+                        },
+                        "endPos": {
+                          "offset": 30,
+                          "line": 3,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 29,
+                        "end": 30
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 25,
+                    "end": 29
+                  }
+                }
+              },
+              "args": [],
+              "symbol": 3
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 30,
+              "line": 3,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 31,
+              "line": 3,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 31,
+                  "line": 3,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 32,
+                  "line": 4,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 31,
+                "end": 32
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 30,
+            "end": 31
+          }
+        },
+        "parent": 119,
+        "symbol": 1
+      },
+      {
+        "id": 42,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 33,
+          "line": 5,
+          "column": 0
+        },
+        "fullStart": 32,
+        "endPos": {
+          "offset": 97,
+          "line": 9,
+          "column": 1
+        },
+        "fullEnd": 98,
+        "start": 33,
+        "end": 97,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 33,
+            "line": 5,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 37,
+            "line": 5,
+            "column": 4
+          },
+          "value": "Enum",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 32,
+                "line": 4,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 33,
+                "line": 5,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 32,
+              "end": 33
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 37,
+                "line": 5,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 38,
+                "line": 5,
+                "column": 5
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 37,
+              "end": 38
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 33,
+          "end": 37
+        },
+        "name": {
+          "id": 13,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 38,
+            "line": 5,
+            "column": 5
+          },
+          "fullStart": 38,
+          "endPos": {
+            "offset": 39,
+            "line": 5,
+            "column": 6
+          },
+          "fullEnd": 40,
+          "start": 38,
+          "end": 39,
+          "expression": {
+            "id": 12,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 38,
+              "line": 5,
+              "column": 5
+            },
+            "fullStart": 38,
+            "endPos": {
+              "offset": 39,
+              "line": 5,
+              "column": 6
+            },
+            "fullEnd": 40,
+            "start": 38,
+            "end": 39,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 38,
+                "line": 5,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 39,
+                "line": 5,
+                "column": 6
+              },
+              "value": "E",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 39,
+                    "line": 5,
+                    "column": 6
+                  },
+                  "endPos": {
+                    "offset": 40,
+                    "line": 5,
+                    "column": 7
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 39,
+                  "end": 40
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 38,
+              "end": 39
+            }
+          }
+        },
+        "body": {
+          "id": 41,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 40,
+            "line": 5,
+            "column": 7
+          },
+          "fullStart": 40,
+          "endPos": {
+            "offset": 97,
+            "line": 9,
+            "column": 1
+          },
+          "fullEnd": 98,
+          "start": 40,
+          "end": 97,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 40,
+              "line": 5,
+              "column": 7
+            },
+            "endPos": {
+              "offset": 41,
+              "line": 5,
+              "column": 8
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 41,
+                  "line": 5,
+                  "column": 8
+                },
+                "endPos": {
+                  "offset": 42,
+                  "line": 6,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 41,
+                "end": 42
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 40,
+            "end": 41
+          },
+          "body": [
+            {
+              "id": 23,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 46,
+                "line": 6,
+                "column": 4
+              },
+              "fullStart": 42,
+              "endPos": {
+                "offset": 63,
+                "line": 6,
+                "column": 21
+              },
+              "fullEnd": 64,
+              "start": 46,
+              "end": 63,
+              "callee": {
+                "id": 15,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 46,
+                  "line": 6,
+                  "column": 4
+                },
+                "fullStart": 42,
+                "endPos": {
+                  "offset": 47,
+                  "line": 6,
+                  "column": 5
+                },
+                "fullEnd": 48,
+                "start": 46,
+                "end": 47,
+                "expression": {
+                  "id": 14,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 46,
+                    "line": 6,
+                    "column": 4
+                  },
+                  "fullStart": 42,
+                  "endPos": {
+                    "offset": 47,
+                    "line": 6,
+                    "column": 5
+                  },
+                  "fullEnd": 48,
+                  "start": 46,
+                  "end": 47,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 46,
+                      "line": 6,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 47,
+                      "line": 6,
+                      "column": 5
+                    },
+                    "value": "a",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 42,
+                          "line": 6,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 43,
+                          "line": 6,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 42,
+                        "end": 43
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 43,
+                          "line": 6,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 44,
+                          "line": 6,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 43,
+                        "end": 44
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 44,
+                          "line": 6,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 45,
+                          "line": 6,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 44,
+                        "end": 45
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 45,
+                          "line": 6,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 46,
+                          "line": 6,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 45,
+                        "end": 46
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 47,
+                          "line": 6,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 48,
+                          "line": 6,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 47,
+                        "end": 48
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 46,
+                    "end": 47
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 17,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 48,
+                    "line": 6,
+                    "column": 6
+                  },
+                  "fullStart": 48,
+                  "endPos": {
+                    "offset": 49,
+                    "line": 6,
+                    "column": 7
+                  },
+                  "fullEnd": 50,
+                  "start": 48,
+                  "end": 49,
+                  "expression": {
+                    "id": 16,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 48,
+                      "line": 6,
+                      "column": 6
+                    },
+                    "fullStart": 48,
+                    "endPos": {
+                      "offset": 49,
+                      "line": 6,
+                      "column": 7
+                    },
+                    "fullEnd": 50,
+                    "start": 48,
+                    "end": 49,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 48,
+                        "line": 6,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 49,
+                        "line": 6,
+                        "column": 7
+                      },
+                      "value": "e",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 49,
+                            "line": 6,
+                            "column": 7
+                          },
+                          "endPos": {
+                            "offset": 50,
+                            "line": 6,
+                            "column": 8
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 49,
+                          "end": 50
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 48,
+                      "end": 49
+                    }
+                  }
+                },
+                {
+                  "id": 22,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 50,
+                    "line": 6,
+                    "column": 8
+                  },
+                  "fullStart": 50,
+                  "endPos": {
+                    "offset": 63,
+                    "line": 6,
+                    "column": 21
+                  },
+                  "fullEnd": 64,
+                  "start": 50,
+                  "end": 63,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 50,
+                      "line": 6,
+                      "column": 8
+                    },
+                    "endPos": {
+                      "offset": 51,
+                      "line": 6,
+                      "column": 9
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 50,
+                    "end": 51
+                  },
+                  "elementList": [
+                    {
+                      "id": 21,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 51,
+                        "line": 6,
+                        "column": 9
+                      },
+                      "fullStart": 51,
+                      "endPos": {
+                        "offset": 62,
+                        "line": 6,
+                        "column": 20
+                      },
+                      "fullEnd": 62,
+                      "start": 51,
+                      "end": 62,
+                      "name": {
+                        "id": 18,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 51,
+                          "line": 6,
+                          "column": 9
+                        },
+                        "fullStart": 51,
+                        "endPos": {
+                          "offset": 55,
+                          "line": 6,
+                          "column": 13
+                        },
+                        "fullEnd": 55,
+                        "start": 51,
+                        "end": 55,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 51,
+                              "line": 6,
+                              "column": 9
+                            },
+                            "endPos": {
+                              "offset": 55,
+                              "line": 6,
+                              "column": 13
+                            },
+                            "value": "note",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 51,
+                            "end": 55
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 20,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 57,
+                          "line": 6,
+                          "column": 15
+                        },
+                        "fullStart": 57,
+                        "endPos": {
+                          "offset": 62,
+                          "line": 6,
+                          "column": 20
+                        },
+                        "fullEnd": 62,
+                        "start": 57,
+                        "end": 62,
+                        "expression": {
+                          "id": 19,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 57,
+                            "line": 6,
+                            "column": 15
+                          },
+                          "fullStart": 57,
+                          "endPos": {
+                            "offset": 62,
+                            "line": 6,
+                            "column": 20
+                          },
+                          "fullEnd": 62,
+                          "start": 57,
+                          "end": 62,
+                          "literal": {
+                            "kind": "<string>",
+                            "startPos": {
+                              "offset": 57,
+                              "line": 6,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 62,
+                              "line": 6,
+                              "column": 20
+                            },
+                            "value": "abc",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 57,
+                            "end": 62
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 55,
+                          "line": 6,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 56,
+                          "line": 6,
+                          "column": 14
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 56,
+                              "line": 6,
+                              "column": 14
+                            },
+                            "endPos": {
+                              "offset": 57,
+                              "line": 6,
+                              "column": 15
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 56,
+                            "end": 57
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 55,
+                        "end": 56
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 62,
+                      "line": 6,
+                      "column": 20
+                    },
+                    "endPos": {
+                      "offset": 63,
+                      "line": 6,
+                      "column": 21
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 63,
+                          "line": 6,
+                          "column": 21
+                        },
+                        "endPos": {
+                          "offset": 64,
+                          "line": 7,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 63,
+                        "end": 64
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 62,
+                    "end": 63
+                  }
+                }
+              ],
+              "symbol": 5
+            },
+            {
+              "id": 33,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 68,
+                "line": 7,
+                "column": 4
+              },
+              "fullStart": 64,
+              "endPos": {
+                "offset": 85,
+                "line": 7,
+                "column": 21
+              },
+              "fullEnd": 86,
+              "start": 68,
+              "end": 85,
+              "callee": {
+                "id": 25,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 68,
+                  "line": 7,
+                  "column": 4
+                },
+                "fullStart": 64,
+                "endPos": {
+                  "offset": 69,
+                  "line": 7,
+                  "column": 5
+                },
+                "fullEnd": 70,
+                "start": 68,
+                "end": 69,
+                "expression": {
+                  "id": 24,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 68,
+                    "line": 7,
+                    "column": 4
+                  },
+                  "fullStart": 64,
+                  "endPos": {
+                    "offset": 69,
+                    "line": 7,
+                    "column": 5
+                  },
+                  "fullEnd": 70,
+                  "start": 68,
+                  "end": 69,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 68,
+                      "line": 7,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 69,
+                      "line": 7,
+                      "column": 5
+                    },
+                    "value": "a",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 64,
+                          "line": 7,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 65,
+                          "line": 7,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 64,
+                        "end": 65
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 65,
+                          "line": 7,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 66,
+                          "line": 7,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 65,
+                        "end": 66
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 66,
+                          "line": 7,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 67,
+                          "line": 7,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 66,
+                        "end": 67
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 67,
+                          "line": 7,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 68,
+                          "line": 7,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 67,
+                        "end": 68
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 69,
+                          "line": 7,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 70,
+                          "line": 7,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 69,
+                        "end": 70
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 68,
+                    "end": 69
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 30,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 70,
+                    "line": 7,
+                    "column": 6
+                  },
+                  "fullStart": 70,
+                  "endPos": {
+                    "offset": 83,
+                    "line": 7,
+                    "column": 19
+                  },
+                  "fullEnd": 84,
+                  "start": 70,
+                  "end": 83,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 70,
+                      "line": 7,
+                      "column": 6
+                    },
+                    "endPos": {
+                      "offset": 71,
+                      "line": 7,
+                      "column": 7
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 70,
+                    "end": 71
+                  },
+                  "elementList": [
+                    {
+                      "id": 29,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 71,
+                        "line": 7,
+                        "column": 7
+                      },
+                      "fullStart": 71,
+                      "endPos": {
+                        "offset": 82,
+                        "line": 7,
+                        "column": 18
+                      },
+                      "fullEnd": 82,
+                      "start": 71,
+                      "end": 82,
+                      "name": {
+                        "id": 26,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 71,
+                          "line": 7,
+                          "column": 7
+                        },
+                        "fullStart": 71,
+                        "endPos": {
+                          "offset": 75,
+                          "line": 7,
+                          "column": 11
+                        },
+                        "fullEnd": 75,
+                        "start": 71,
+                        "end": 75,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 71,
+                              "line": 7,
+                              "column": 7
+                            },
+                            "endPos": {
+                              "offset": 75,
+                              "line": 7,
+                              "column": 11
+                            },
+                            "value": "note",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 71,
+                            "end": 75
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 28,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 77,
+                          "line": 7,
+                          "column": 13
+                        },
+                        "fullStart": 77,
+                        "endPos": {
+                          "offset": 82,
+                          "line": 7,
+                          "column": 18
+                        },
+                        "fullEnd": 82,
+                        "start": 77,
+                        "end": 82,
+                        "expression": {
+                          "id": 27,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 77,
+                            "line": 7,
+                            "column": 13
+                          },
+                          "fullStart": 77,
+                          "endPos": {
+                            "offset": 82,
+                            "line": 7,
+                            "column": 18
+                          },
+                          "fullEnd": 82,
+                          "start": 77,
+                          "end": 82,
+                          "literal": {
+                            "kind": "<string>",
+                            "startPos": {
+                              "offset": 77,
+                              "line": 7,
+                              "column": 13
+                            },
+                            "endPos": {
+                              "offset": 82,
+                              "line": 7,
+                              "column": 18
+                            },
+                            "value": "abc",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 77,
+                            "end": 82
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 75,
+                          "line": 7,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 76,
+                          "line": 7,
+                          "column": 12
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 76,
+                              "line": 7,
+                              "column": 12
+                            },
+                            "endPos": {
+                              "offset": 77,
+                              "line": 7,
+                              "column": 13
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 76,
+                            "end": 77
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 75,
+                        "end": 76
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 82,
+                      "line": 7,
+                      "column": 18
+                    },
+                    "endPos": {
+                      "offset": 83,
+                      "line": 7,
+                      "column": 19
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 83,
+                          "line": 7,
+                          "column": 19
+                        },
+                        "endPos": {
+                          "offset": 84,
+                          "line": 7,
+                          "column": 20
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 83,
+                        "end": 84
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 82,
+                    "end": 83
+                  }
+                },
+                {
+                  "id": 32,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 84,
+                    "line": 7,
+                    "column": 20
+                  },
+                  "fullStart": 84,
+                  "endPos": {
+                    "offset": 85,
+                    "line": 7,
+                    "column": 21
+                  },
+                  "fullEnd": 86,
+                  "start": 84,
+                  "end": 85,
+                  "expression": {
+                    "id": 31,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 84,
+                      "line": 7,
+                      "column": 20
+                    },
+                    "fullStart": 84,
+                    "endPos": {
+                      "offset": 85,
+                      "line": 7,
+                      "column": 21
+                    },
+                    "fullEnd": 86,
+                    "start": 84,
+                    "end": 85,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 84,
+                        "line": 7,
+                        "column": 20
+                      },
+                      "endPos": {
+                        "offset": 85,
+                        "line": 7,
+                        "column": 21
+                      },
+                      "value": "e",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 85,
+                            "line": 7,
+                            "column": 21
+                          },
+                          "endPos": {
+                            "offset": 86,
+                            "line": 8,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 85,
+                          "end": 86
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 84,
+                      "end": 85
+                    }
+                  }
+                }
+              ],
+              "symbol": 6
+            },
+            {
+              "id": 40,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 90,
+                "line": 8,
+                "column": 4
+              },
+              "fullStart": 86,
+              "endPos": {
+                "offset": 95,
+                "line": 8,
+                "column": 9
+              },
+              "fullEnd": 96,
+              "start": 90,
+              "end": 95,
+              "callee": {
+                "id": 35,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 90,
+                  "line": 8,
+                  "column": 4
+                },
+                "fullStart": 86,
+                "endPos": {
+                  "offset": 91,
+                  "line": 8,
+                  "column": 5
+                },
+                "fullEnd": 92,
+                "start": 90,
+                "end": 91,
+                "expression": {
+                  "id": 34,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 90,
+                    "line": 8,
+                    "column": 4
+                  },
+                  "fullStart": 86,
+                  "endPos": {
+                    "offset": 91,
+                    "line": 8,
+                    "column": 5
+                  },
+                  "fullEnd": 92,
+                  "start": 90,
+                  "end": 91,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 90,
+                      "line": 8,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 91,
+                      "line": 8,
+                      "column": 5
+                    },
+                    "value": "a",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 86,
+                          "line": 8,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 87,
+                          "line": 8,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 86,
+                        "end": 87
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 87,
+                          "line": 8,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 88,
+                          "line": 8,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 87,
+                        "end": 88
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 88,
+                          "line": 8,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 89,
+                          "line": 8,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 88,
+                        "end": 89
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 89,
+                          "line": 8,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 90,
+                          "line": 8,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 89,
+                        "end": 90
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 91,
+                          "line": 8,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 92,
+                          "line": 8,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 91,
+                        "end": 92
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 90,
+                    "end": 91
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 37,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 92,
+                    "line": 8,
+                    "column": 6
+                  },
+                  "fullStart": 92,
+                  "endPos": {
+                    "offset": 93,
+                    "line": 8,
+                    "column": 7
+                  },
+                  "fullEnd": 94,
+                  "start": 92,
+                  "end": 93,
+                  "expression": {
+                    "id": 36,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 92,
+                      "line": 8,
+                      "column": 6
+                    },
+                    "fullStart": 92,
+                    "endPos": {
+                      "offset": 93,
+                      "line": 8,
+                      "column": 7
+                    },
+                    "fullEnd": 94,
+                    "start": 92,
+                    "end": 93,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 92,
+                        "line": 8,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 93,
+                        "line": 8,
+                        "column": 7
+                      },
+                      "value": "e",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 93,
+                            "line": 8,
+                            "column": 7
+                          },
+                          "endPos": {
+                            "offset": 94,
+                            "line": 8,
+                            "column": 8
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 93,
+                          "end": 94
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 92,
+                      "end": 93
+                    }
+                  }
+                },
+                {
+                  "id": 39,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 94,
+                    "line": 8,
+                    "column": 8
+                  },
+                  "fullStart": 94,
+                  "endPos": {
+                    "offset": 95,
+                    "line": 8,
+                    "column": 9
+                  },
+                  "fullEnd": 96,
+                  "start": 94,
+                  "end": 95,
+                  "expression": {
+                    "id": 38,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 94,
+                      "line": 8,
+                      "column": 8
+                    },
+                    "fullStart": 94,
+                    "endPos": {
+                      "offset": 95,
+                      "line": 8,
+                      "column": 9
+                    },
+                    "fullEnd": 96,
+                    "start": 94,
+                    "end": 95,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 94,
+                        "line": 8,
+                        "column": 8
+                      },
+                      "endPos": {
+                        "offset": 95,
+                        "line": 8,
+                        "column": 9
+                      },
+                      "value": "f",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 95,
+                            "line": 8,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 96,
+                            "line": 9,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 95,
+                          "end": 96
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 94,
+                      "end": 95
+                    }
+                  }
+                }
+              ],
+              "symbol": 7
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 96,
+              "line": 9,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 97,
+              "line": 9,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 97,
+                  "line": 9,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 98,
+                  "line": 10,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 97,
+                "end": 98
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 96,
+            "end": 97
+          }
+        },
+        "parent": 119,
+        "symbol": 4
+      },
+      {
+        "id": 58,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 99,
+          "line": 11,
+          "column": 0
+        },
+        "fullStart": 98,
+        "endPos": {
+          "offset": 133,
+          "line": 14,
+          "column": 1
+        },
+        "fullEnd": 134,
+        "start": 99,
+        "end": 133,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 99,
+            "line": 11,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 109,
+            "line": 11,
+            "column": 10
+          },
+          "value": "TableGroup",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 98,
+                "line": 10,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 99,
+                "line": 11,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 98,
+              "end": 99
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 109,
+                "line": 11,
+                "column": 10
+              },
+              "endPos": {
+                "offset": 110,
+                "line": 11,
+                "column": 11
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 109,
+              "end": 110
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 99,
+          "end": 109
+        },
+        "name": {
+          "id": 44,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 110,
+            "line": 11,
+            "column": 11
+          },
+          "fullStart": 110,
+          "endPos": {
+            "offset": 111,
+            "line": 11,
+            "column": 12
+          },
+          "fullEnd": 112,
+          "start": 110,
+          "end": 111,
+          "expression": {
+            "id": 43,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 110,
+              "line": 11,
+              "column": 11
+            },
+            "fullStart": 110,
+            "endPos": {
+              "offset": 111,
+              "line": 11,
+              "column": 12
+            },
+            "fullEnd": 112,
+            "start": 110,
+            "end": 111,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 110,
+                "line": 11,
+                "column": 11
+              },
+              "endPos": {
+                "offset": 111,
+                "line": 11,
+                "column": 12
+              },
+              "value": "G",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 111,
+                    "line": 11,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 112,
+                    "line": 11,
+                    "column": 13
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 111,
+                  "end": 112
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 110,
+              "end": 111
+            }
+          }
+        },
+        "body": {
+          "id": 57,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 112,
+            "line": 11,
+            "column": 13
+          },
+          "fullStart": 112,
+          "endPos": {
+            "offset": 133,
+            "line": 14,
+            "column": 1
+          },
+          "fullEnd": 134,
+          "start": 112,
+          "end": 133,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 112,
+              "line": 11,
+              "column": 13
+            },
+            "endPos": {
+              "offset": 113,
+              "line": 11,
+              "column": 14
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 113,
+                  "line": 11,
+                  "column": 14
+                },
+                "endPos": {
+                  "offset": 114,
+                  "line": 12,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 113,
+                "end": 114
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 112,
+            "end": 113
+          },
+          "body": [
+            {
+              "id": 49,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 118,
+                "line": 12,
+                "column": 4
+              },
+              "fullStart": 114,
+              "endPos": {
+                "offset": 121,
+                "line": 12,
+                "column": 7
+              },
+              "fullEnd": 122,
+              "start": 118,
+              "end": 121,
+              "callee": {
+                "id": 46,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 118,
+                  "line": 12,
+                  "column": 4
+                },
+                "fullStart": 114,
+                "endPos": {
+                  "offset": 119,
+                  "line": 12,
+                  "column": 5
+                },
+                "fullEnd": 120,
+                "start": 118,
+                "end": 119,
+                "expression": {
+                  "id": 45,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 118,
+                    "line": 12,
+                    "column": 4
+                  },
+                  "fullStart": 114,
+                  "endPos": {
+                    "offset": 119,
+                    "line": 12,
+                    "column": 5
+                  },
+                  "fullEnd": 120,
+                  "start": 118,
+                  "end": 119,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 118,
+                      "line": 12,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 119,
+                      "line": 12,
+                      "column": 5
+                    },
+                    "value": "A",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 114,
+                          "line": 12,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 115,
+                          "line": 12,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 114,
+                        "end": 115
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 115,
+                          "line": 12,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 116,
+                          "line": 12,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 115,
+                        "end": 116
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 116,
+                          "line": 12,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 117,
+                          "line": 12,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 116,
+                        "end": 117
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 117,
+                          "line": 12,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 118,
+                          "line": 12,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 117,
+                        "end": 118
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 119,
+                          "line": 12,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 120,
+                          "line": 12,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 119,
+                        "end": 120
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 118,
+                    "end": 119
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 48,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 120,
+                    "line": 12,
+                    "column": 6
+                  },
+                  "fullStart": 120,
+                  "endPos": {
+                    "offset": 121,
+                    "line": 12,
+                    "column": 7
+                  },
+                  "fullEnd": 122,
+                  "start": 120,
+                  "end": 121,
+                  "expression": {
+                    "id": 47,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 120,
+                      "line": 12,
+                      "column": 6
+                    },
+                    "fullStart": 120,
+                    "endPos": {
+                      "offset": 121,
+                      "line": 12,
+                      "column": 7
+                    },
+                    "fullEnd": 122,
+                    "start": 120,
+                    "end": 121,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 120,
+                        "line": 12,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 121,
+                        "line": 12,
+                        "column": 7
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 121,
+                            "line": 12,
+                            "column": 7
+                          },
+                          "endPos": {
+                            "offset": 122,
+                            "line": 13,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 121,
+                          "end": 122
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 120,
+                      "end": 121
+                    }
+                  }
+                }
+              ],
+              "symbol": 9
+            },
+            {
+              "id": 56,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 126,
+                "line": 13,
+                "column": 4
+              },
+              "fullStart": 122,
+              "endPos": {
+                "offset": 131,
+                "line": 13,
+                "column": 9
+              },
+              "fullEnd": 132,
+              "start": 126,
+              "end": 131,
+              "callee": {
+                "id": 51,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 126,
+                  "line": 13,
+                  "column": 4
+                },
+                "fullStart": 122,
+                "endPos": {
+                  "offset": 127,
+                  "line": 13,
+                  "column": 5
+                },
+                "fullEnd": 128,
+                "start": 126,
+                "end": 127,
+                "expression": {
+                  "id": 50,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 126,
+                    "line": 13,
+                    "column": 4
+                  },
+                  "fullStart": 122,
+                  "endPos": {
+                    "offset": 127,
+                    "line": 13,
+                    "column": 5
+                  },
+                  "fullEnd": 128,
+                  "start": 126,
+                  "end": 127,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 126,
+                      "line": 13,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 127,
+                      "line": 13,
+                      "column": 5
+                    },
+                    "value": "A",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 122,
+                          "line": 13,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 123,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 122,
+                        "end": 123
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 123,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 124,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 123,
+                        "end": 124
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 124,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 125,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 124,
+                        "end": 125
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 125,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 126,
+                          "line": 13,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 125,
+                        "end": 126
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 127,
+                          "line": 13,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 128,
+                          "line": 13,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 127,
+                        "end": 128
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 126,
+                    "end": 127
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 53,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 128,
+                    "line": 13,
+                    "column": 6
+                  },
+                  "fullStart": 128,
+                  "endPos": {
+                    "offset": 129,
+                    "line": 13,
+                    "column": 7
+                  },
+                  "fullEnd": 130,
+                  "start": 128,
+                  "end": 129,
+                  "expression": {
+                    "id": 52,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 128,
+                      "line": 13,
+                      "column": 6
+                    },
+                    "fullStart": 128,
+                    "endPos": {
+                      "offset": 129,
+                      "line": 13,
+                      "column": 7
+                    },
+                    "fullEnd": 130,
+                    "start": 128,
+                    "end": 129,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 128,
+                        "line": 13,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 129,
+                        "line": 13,
+                        "column": 7
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 129,
+                            "line": 13,
+                            "column": 7
+                          },
+                          "endPos": {
+                            "offset": 130,
+                            "line": 13,
+                            "column": 8
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 129,
+                          "end": 130
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 128,
+                      "end": 129
+                    }
+                  }
+                },
+                {
+                  "id": 55,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 130,
+                    "line": 13,
+                    "column": 8
+                  },
+                  "fullStart": 130,
+                  "endPos": {
+                    "offset": 131,
+                    "line": 13,
+                    "column": 9
+                  },
+                  "fullEnd": 132,
+                  "start": 130,
+                  "end": 131,
+                  "expression": {
+                    "id": 54,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 130,
+                      "line": 13,
+                      "column": 8
+                    },
+                    "fullStart": 130,
+                    "endPos": {
+                      "offset": 131,
+                      "line": 13,
+                      "column": 9
+                    },
+                    "fullEnd": 132,
+                    "start": 130,
+                    "end": 131,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 130,
+                        "line": 13,
+                        "column": 8
+                      },
+                      "endPos": {
+                        "offset": 131,
+                        "line": 13,
+                        "column": 9
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 131,
+                            "line": 13,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 132,
+                            "line": 14,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 131,
+                          "end": 132
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 130,
+                      "end": 131
+                    }
+                  }
+                }
+              ],
+              "symbol": 10
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 132,
+              "line": 14,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 133,
+              "line": 14,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 133,
+                  "line": 14,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 134,
+                  "line": 15,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 133,
+                "end": 134
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 132,
+            "end": 133
+          }
+        },
+        "parent": 119,
+        "symbol": 8
+      },
+      {
+        "id": 79,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 135,
+          "line": 16,
+          "column": 0
+        },
+        "fullStart": 134,
+        "endPos": {
+          "offset": 178,
+          "line": 18,
+          "column": 1
+        },
+        "fullEnd": 179,
+        "start": 135,
+        "end": 178,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 135,
+            "line": 16,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 138,
+            "line": 16,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 134,
+                "line": 15,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 135,
+                "line": 16,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 134,
+              "end": 135
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 138,
+                "line": 16,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 139,
+                "line": 16,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 138,
+              "end": 139
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 135,
+          "end": 138
+        },
+        "body": {
+          "id": 78,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 139,
+            "line": 16,
+            "column": 4
+          },
+          "fullStart": 139,
+          "endPos": {
+            "offset": 178,
+            "line": 18,
+            "column": 1
+          },
+          "fullEnd": 179,
+          "start": 139,
+          "end": 178,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 139,
+              "line": 16,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 140,
+              "line": 16,
+              "column": 5
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 140,
+                  "line": 16,
+                  "column": 5
+                },
+                "endPos": {
+                  "offset": 141,
+                  "line": 17,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 140,
+                "end": 141
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 139,
+            "end": 140
+          },
+          "body": [
+            {
+              "id": 77,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 145,
+                "line": 17,
+                "column": 4
+              },
+              "fullStart": 141,
+              "endPos": {
+                "offset": 176,
+                "line": 17,
+                "column": 35
+              },
+              "fullEnd": 177,
+              "start": 145,
+              "end": 176,
+              "callee": {
+                "id": 69,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 145,
+                  "line": 17,
+                  "column": 4
+                },
+                "fullStart": 141,
+                "endPos": {
+                  "offset": 156,
+                  "line": 17,
+                  "column": 15
+                },
+                "fullEnd": 157,
+                "start": 145,
+                "end": 156,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 150,
+                    "line": 17,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 151,
+                    "line": 17,
+                    "column": 10
+                  },
+                  "value": ">",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 151,
+                        "line": 17,
+                        "column": 10
+                      },
+                      "endPos": {
+                        "offset": 152,
+                        "line": 17,
+                        "column": 11
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 151,
+                      "end": 152
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 150,
+                  "end": 151
+                },
+                "leftExpression": {
+                  "id": 63,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 145,
+                    "line": 17,
+                    "column": 4
+                  },
+                  "fullStart": 141,
+                  "endPos": {
+                    "offset": 149,
+                    "line": 17,
+                    "column": 8
+                  },
+                  "fullEnd": 150,
+                  "start": 145,
+                  "end": 149,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 146,
+                      "line": 17,
+                      "column": 5
+                    },
+                    "endPos": {
+                      "offset": 147,
+                      "line": 17,
+                      "column": 6
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 146,
+                    "end": 147
+                  },
+                  "leftExpression": {
+                    "id": 60,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 145,
+                      "line": 17,
+                      "column": 4
+                    },
+                    "fullStart": 141,
+                    "endPos": {
+                      "offset": 146,
+                      "line": 17,
+                      "column": 5
+                    },
+                    "fullEnd": 146,
+                    "start": 145,
+                    "end": 146,
+                    "expression": {
+                      "id": 59,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 145,
+                        "line": 17,
+                        "column": 4
+                      },
+                      "fullStart": 141,
+                      "endPos": {
+                        "offset": 146,
+                        "line": 17,
+                        "column": 5
+                      },
+                      "fullEnd": 146,
+                      "start": 145,
+                      "end": 146,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 145,
+                          "line": 17,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 146,
+                          "line": 17,
+                          "column": 5
+                        },
+                        "value": "A",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 141,
+                              "line": 17,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 142,
+                              "line": 17,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 141,
+                            "end": 142
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 142,
+                              "line": 17,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 143,
+                              "line": 17,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 142,
+                            "end": 143
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 143,
+                              "line": 17,
+                              "column": 2
+                            },
+                            "endPos": {
+                              "offset": 144,
+                              "line": 17,
+                              "column": 3
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 143,
+                            "end": 144
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 144,
+                              "line": 17,
+                              "column": 3
+                            },
+                            "endPos": {
+                              "offset": 145,
+                              "line": 17,
+                              "column": 4
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 144,
+                            "end": 145
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 145,
+                        "end": 146
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 62,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 147,
+                      "line": 17,
+                      "column": 6
+                    },
+                    "fullStart": 147,
+                    "endPos": {
+                      "offset": 149,
+                      "line": 17,
+                      "column": 8
+                    },
+                    "fullEnd": 150,
+                    "start": 147,
+                    "end": 149,
+                    "expression": {
+                      "id": 61,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 147,
+                        "line": 17,
+                        "column": 6
+                      },
+                      "fullStart": 147,
+                      "endPos": {
+                        "offset": 149,
+                        "line": 17,
+                        "column": 8
+                      },
+                      "fullEnd": 150,
+                      "start": 147,
+                      "end": 149,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 147,
+                          "line": 17,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 149,
+                          "line": 17,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 149,
+                              "line": 17,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 150,
+                              "line": 17,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 149,
+                            "end": 150
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 147,
+                        "end": 149
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 68,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 152,
+                    "line": 17,
+                    "column": 11
+                  },
+                  "fullStart": 152,
+                  "endPos": {
+                    "offset": 156,
+                    "line": 17,
+                    "column": 15
+                  },
+                  "fullEnd": 157,
+                  "start": 152,
+                  "end": 156,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 153,
+                      "line": 17,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 154,
+                      "line": 17,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 153,
+                    "end": 154
+                  },
+                  "leftExpression": {
+                    "id": 65,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 152,
+                      "line": 17,
+                      "column": 11
+                    },
+                    "fullStart": 152,
+                    "endPos": {
+                      "offset": 153,
+                      "line": 17,
+                      "column": 12
+                    },
+                    "fullEnd": 153,
+                    "start": 152,
+                    "end": 153,
+                    "expression": {
+                      "id": 64,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 152,
+                        "line": 17,
+                        "column": 11
+                      },
+                      "fullStart": 152,
+                      "endPos": {
+                        "offset": 153,
+                        "line": 17,
+                        "column": 12
+                      },
+                      "fullEnd": 153,
+                      "start": 152,
+                      "end": 153,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 152,
+                          "line": 17,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 153,
+                          "line": 17,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 152,
+                        "end": 153
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 67,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 154,
+                      "line": 17,
+                      "column": 13
+                    },
+                    "fullStart": 154,
+                    "endPos": {
+                      "offset": 156,
+                      "line": 17,
+                      "column": 15
+                    },
+                    "fullEnd": 157,
+                    "start": 154,
+                    "end": 156,
+                    "expression": {
+                      "id": 66,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 154,
+                        "line": 17,
+                        "column": 13
+                      },
+                      "fullStart": 154,
+                      "endPos": {
+                        "offset": 156,
+                        "line": 17,
+                        "column": 15
+                      },
+                      "fullEnd": 157,
+                      "start": 154,
+                      "end": 156,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 154,
+                          "line": 17,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 156,
+                          "line": 17,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 156,
+                              "line": 17,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 157,
+                              "line": 17,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 156,
+                            "end": 157
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 154,
+                        "end": 156
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 74,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 157,
+                    "line": 17,
+                    "column": 16
+                  },
+                  "fullStart": 157,
+                  "endPos": {
+                    "offset": 174,
+                    "line": 17,
+                    "column": 33
+                  },
+                  "fullEnd": 175,
+                  "start": 157,
+                  "end": 174,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 157,
+                      "line": 17,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 158,
+                      "line": 17,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 157,
+                    "end": 158
+                  },
+                  "elementList": [
+                    {
+                      "id": 73,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 158,
+                        "line": 17,
+                        "column": 17
+                      },
+                      "fullStart": 158,
+                      "endPos": {
+                        "offset": 173,
+                        "line": 17,
+                        "column": 32
+                      },
+                      "fullEnd": 173,
+                      "start": 158,
+                      "end": 173,
+                      "name": {
+                        "id": 70,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 158,
+                          "line": 17,
+                          "column": 17
+                        },
+                        "fullStart": 158,
+                        "endPos": {
+                          "offset": 164,
+                          "line": 17,
+                          "column": 23
+                        },
+                        "fullEnd": 164,
+                        "start": 158,
+                        "end": 164,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 158,
+                              "line": 17,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 164,
+                              "line": 17,
+                              "column": 23
+                            },
+                            "value": "delete",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 158,
+                            "end": 164
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 72,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 166,
+                          "line": 17,
+                          "column": 25
+                        },
+                        "fullStart": 166,
+                        "endPos": {
+                          "offset": 173,
+                          "line": 17,
+                          "column": 32
+                        },
+                        "fullEnd": 173,
+                        "start": 166,
+                        "end": 173,
+                        "expression": {
+                          "id": 71,
+                          "kind": "<variable>",
+                          "startPos": {
+                            "offset": 166,
+                            "line": 17,
+                            "column": 25
+                          },
+                          "fullStart": 166,
+                          "endPos": {
+                            "offset": 173,
+                            "line": 17,
+                            "column": 32
+                          },
+                          "fullEnd": 173,
+                          "start": 166,
+                          "end": 173,
+                          "variable": {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 166,
+                              "line": 17,
+                              "column": 25
+                            },
+                            "endPos": {
+                              "offset": 173,
+                              "line": 17,
+                              "column": 32
+                            },
+                            "value": "cascade",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 166,
+                            "end": 173
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 164,
+                          "line": 17,
+                          "column": 23
+                        },
+                        "endPos": {
+                          "offset": 165,
+                          "line": 17,
+                          "column": 24
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 165,
+                              "line": 17,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 166,
+                              "line": 17,
+                              "column": 25
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 165,
+                            "end": 166
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 164,
+                        "end": 165
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 173,
+                      "line": 17,
+                      "column": 32
+                    },
+                    "endPos": {
+                      "offset": 174,
+                      "line": 17,
+                      "column": 33
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 174,
+                          "line": 17,
+                          "column": 33
+                        },
+                        "endPos": {
+                          "offset": 175,
+                          "line": 17,
+                          "column": 34
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 174,
+                        "end": 175
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 173,
+                    "end": 174
+                  }
+                },
+                {
+                  "id": 76,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 175,
+                    "line": 17,
+                    "column": 34
+                  },
+                  "fullStart": 175,
+                  "endPos": {
+                    "offset": 176,
+                    "line": 17,
+                    "column": 35
+                  },
+                  "fullEnd": 177,
+                  "start": 175,
+                  "end": 176,
+                  "expression": {
+                    "id": 75,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 175,
+                      "line": 17,
+                      "column": 34
+                    },
+                    "fullStart": 175,
+                    "endPos": {
+                      "offset": 176,
+                      "line": 17,
+                      "column": 35
+                    },
+                    "fullEnd": 177,
+                    "start": 175,
+                    "end": 176,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 175,
+                        "line": 17,
+                        "column": 34
+                      },
+                      "endPos": {
+                        "offset": 176,
+                        "line": 17,
+                        "column": 35
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 176,
+                            "line": 17,
+                            "column": 35
+                          },
+                          "endPos": {
+                            "offset": 177,
+                            "line": 18,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 176,
+                          "end": 177
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 175,
+                      "end": 176
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 177,
+              "line": 18,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 178,
+              "line": 18,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 178,
+                  "line": 18,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 179,
+                  "line": 19,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 178,
+                "end": 179
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 177,
+            "end": 178
+          }
+        },
+        "parent": 119
+      },
+      {
+        "id": 100,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 180,
+          "line": 20,
+          "column": 0
+        },
+        "fullStart": 179,
+        "endPos": {
+          "offset": 223,
+          "line": 22,
+          "column": 1
+        },
+        "fullEnd": 224,
+        "start": 180,
+        "end": 223,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 180,
+            "line": 20,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 183,
+            "line": 20,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 179,
+                "line": 19,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 180,
+                "line": 20,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 179,
+              "end": 180
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 183,
+                "line": 20,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 184,
+                "line": 20,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 183,
+              "end": 184
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 180,
+          "end": 183
+        },
+        "body": {
+          "id": 99,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 184,
+            "line": 20,
+            "column": 4
+          },
+          "fullStart": 184,
+          "endPos": {
+            "offset": 223,
+            "line": 22,
+            "column": 1
+          },
+          "fullEnd": 224,
+          "start": 184,
+          "end": 223,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 184,
+              "line": 20,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 185,
+              "line": 20,
+              "column": 5
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 185,
+                  "line": 20,
+                  "column": 5
+                },
+                "endPos": {
+                  "offset": 186,
+                  "line": 21,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 185,
+                "end": 186
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 184,
+            "end": 185
+          },
+          "body": [
+            {
+              "id": 98,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 190,
+                "line": 21,
+                "column": 4
+              },
+              "fullStart": 186,
+              "endPos": {
+                "offset": 221,
+                "line": 21,
+                "column": 35
+              },
+              "fullEnd": 222,
+              "start": 190,
+              "end": 221,
+              "callee": {
+                "id": 90,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 190,
+                  "line": 21,
+                  "column": 4
+                },
+                "fullStart": 186,
+                "endPos": {
+                  "offset": 201,
+                  "line": 21,
+                  "column": 15
+                },
+                "fullEnd": 202,
+                "start": 190,
+                "end": 201,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 195,
+                    "line": 21,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 196,
+                    "line": 21,
+                    "column": 10
+                  },
+                  "value": ">",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 196,
+                        "line": 21,
+                        "column": 10
+                      },
+                      "endPos": {
+                        "offset": 197,
+                        "line": 21,
+                        "column": 11
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 196,
+                      "end": 197
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 195,
+                  "end": 196
+                },
+                "leftExpression": {
+                  "id": 84,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 190,
+                    "line": 21,
+                    "column": 4
+                  },
+                  "fullStart": 186,
+                  "endPos": {
+                    "offset": 194,
+                    "line": 21,
+                    "column": 8
+                  },
+                  "fullEnd": 195,
+                  "start": 190,
+                  "end": 194,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 191,
+                      "line": 21,
+                      "column": 5
+                    },
+                    "endPos": {
+                      "offset": 192,
+                      "line": 21,
+                      "column": 6
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 191,
+                    "end": 192
+                  },
+                  "leftExpression": {
+                    "id": 81,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 190,
+                      "line": 21,
+                      "column": 4
+                    },
+                    "fullStart": 186,
+                    "endPos": {
+                      "offset": 191,
+                      "line": 21,
+                      "column": 5
+                    },
+                    "fullEnd": 191,
+                    "start": 190,
+                    "end": 191,
+                    "expression": {
+                      "id": 80,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 190,
+                        "line": 21,
+                        "column": 4
+                      },
+                      "fullStart": 186,
+                      "endPos": {
+                        "offset": 191,
+                        "line": 21,
+                        "column": 5
+                      },
+                      "fullEnd": 191,
+                      "start": 190,
+                      "end": 191,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 190,
+                          "line": 21,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 191,
+                          "line": 21,
+                          "column": 5
+                        },
+                        "value": "A",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 186,
+                              "line": 21,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 187,
+                              "line": 21,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 186,
+                            "end": 187
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 187,
+                              "line": 21,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 188,
+                              "line": 21,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 187,
+                            "end": 188
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 188,
+                              "line": 21,
+                              "column": 2
+                            },
+                            "endPos": {
+                              "offset": 189,
+                              "line": 21,
+                              "column": 3
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 188,
+                            "end": 189
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 189,
+                              "line": 21,
+                              "column": 3
+                            },
+                            "endPos": {
+                              "offset": 190,
+                              "line": 21,
+                              "column": 4
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 189,
+                            "end": 190
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 190,
+                        "end": 191
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 83,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 192,
+                      "line": 21,
+                      "column": 6
+                    },
+                    "fullStart": 192,
+                    "endPos": {
+                      "offset": 194,
+                      "line": 21,
+                      "column": 8
+                    },
+                    "fullEnd": 195,
+                    "start": 192,
+                    "end": 194,
+                    "expression": {
+                      "id": 82,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 192,
+                        "line": 21,
+                        "column": 6
+                      },
+                      "fullStart": 192,
+                      "endPos": {
+                        "offset": 194,
+                        "line": 21,
+                        "column": 8
+                      },
+                      "fullEnd": 195,
+                      "start": 192,
+                      "end": 194,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 192,
+                          "line": 21,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 194,
+                          "line": 21,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 194,
+                              "line": 21,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 195,
+                              "line": 21,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 194,
+                            "end": 195
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 192,
+                        "end": 194
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 89,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 197,
+                    "line": 21,
+                    "column": 11
+                  },
+                  "fullStart": 197,
+                  "endPos": {
+                    "offset": 201,
+                    "line": 21,
+                    "column": 15
+                  },
+                  "fullEnd": 202,
+                  "start": 197,
+                  "end": 201,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 198,
+                      "line": 21,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 199,
+                      "line": 21,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 198,
+                    "end": 199
+                  },
+                  "leftExpression": {
+                    "id": 86,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 197,
+                      "line": 21,
+                      "column": 11
+                    },
+                    "fullStart": 197,
+                    "endPos": {
+                      "offset": 198,
+                      "line": 21,
+                      "column": 12
+                    },
+                    "fullEnd": 198,
+                    "start": 197,
+                    "end": 198,
+                    "expression": {
+                      "id": 85,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 197,
+                        "line": 21,
+                        "column": 11
+                      },
+                      "fullStart": 197,
+                      "endPos": {
+                        "offset": 198,
+                        "line": 21,
+                        "column": 12
+                      },
+                      "fullEnd": 198,
+                      "start": 197,
+                      "end": 198,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 197,
+                          "line": 21,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 198,
+                          "line": 21,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 197,
+                        "end": 198
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 88,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 199,
+                      "line": 21,
+                      "column": 13
+                    },
+                    "fullStart": 199,
+                    "endPos": {
+                      "offset": 201,
+                      "line": 21,
+                      "column": 15
+                    },
+                    "fullEnd": 202,
+                    "start": 199,
+                    "end": 201,
+                    "expression": {
+                      "id": 87,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 199,
+                        "line": 21,
+                        "column": 13
+                      },
+                      "fullStart": 199,
+                      "endPos": {
+                        "offset": 201,
+                        "line": 21,
+                        "column": 15
+                      },
+                      "fullEnd": 202,
+                      "start": 199,
+                      "end": 201,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 199,
+                          "line": 21,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 201,
+                          "line": 21,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 201,
+                              "line": 21,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 202,
+                              "line": 21,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 201,
+                            "end": 202
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 199,
+                        "end": 201
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 92,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 202,
+                    "line": 21,
+                    "column": 16
+                  },
+                  "fullStart": 202,
+                  "endPos": {
+                    "offset": 203,
+                    "line": 21,
+                    "column": 17
+                  },
+                  "fullEnd": 204,
+                  "start": 202,
+                  "end": 203,
+                  "expression": {
+                    "id": 91,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 202,
+                      "line": 21,
+                      "column": 16
+                    },
+                    "fullStart": 202,
+                    "endPos": {
+                      "offset": 203,
+                      "line": 21,
+                      "column": 17
+                    },
+                    "fullEnd": 204,
+                    "start": 202,
+                    "end": 203,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 202,
+                        "line": 21,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 203,
+                        "line": 21,
+                        "column": 17
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 203,
+                            "line": 21,
+                            "column": 17
+                          },
+                          "endPos": {
+                            "offset": 204,
+                            "line": 21,
+                            "column": 18
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 203,
+                          "end": 204
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 202,
+                      "end": 203
+                    }
+                  }
+                },
+                {
+                  "id": 97,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 204,
+                    "line": 21,
+                    "column": 18
+                  },
+                  "fullStart": 204,
+                  "endPos": {
+                    "offset": 221,
+                    "line": 21,
+                    "column": 35
+                  },
+                  "fullEnd": 222,
+                  "start": 204,
+                  "end": 221,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 204,
+                      "line": 21,
+                      "column": 18
+                    },
+                    "endPos": {
+                      "offset": 205,
+                      "line": 21,
+                      "column": 19
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 204,
+                    "end": 205
+                  },
+                  "elementList": [
+                    {
+                      "id": 96,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 205,
+                        "line": 21,
+                        "column": 19
+                      },
+                      "fullStart": 205,
+                      "endPos": {
+                        "offset": 220,
+                        "line": 21,
+                        "column": 34
+                      },
+                      "fullEnd": 220,
+                      "start": 205,
+                      "end": 220,
+                      "name": {
+                        "id": 93,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 205,
+                          "line": 21,
+                          "column": 19
+                        },
+                        "fullStart": 205,
+                        "endPos": {
+                          "offset": 211,
+                          "line": 21,
+                          "column": 25
+                        },
+                        "fullEnd": 211,
+                        "start": 205,
+                        "end": 211,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 205,
+                              "line": 21,
+                              "column": 19
+                            },
+                            "endPos": {
+                              "offset": 211,
+                              "line": 21,
+                              "column": 25
+                            },
+                            "value": "delete",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 205,
+                            "end": 211
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 95,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 213,
+                          "line": 21,
+                          "column": 27
+                        },
+                        "fullStart": 213,
+                        "endPos": {
+                          "offset": 220,
+                          "line": 21,
+                          "column": 34
+                        },
+                        "fullEnd": 220,
+                        "start": 213,
+                        "end": 220,
+                        "expression": {
+                          "id": 94,
+                          "kind": "<variable>",
+                          "startPos": {
+                            "offset": 213,
+                            "line": 21,
+                            "column": 27
+                          },
+                          "fullStart": 213,
+                          "endPos": {
+                            "offset": 220,
+                            "line": 21,
+                            "column": 34
+                          },
+                          "fullEnd": 220,
+                          "start": 213,
+                          "end": 220,
+                          "variable": {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 213,
+                              "line": 21,
+                              "column": 27
+                            },
+                            "endPos": {
+                              "offset": 220,
+                              "line": 21,
+                              "column": 34
+                            },
+                            "value": "cascade",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 213,
+                            "end": 220
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 211,
+                          "line": 21,
+                          "column": 25
+                        },
+                        "endPos": {
+                          "offset": 212,
+                          "line": 21,
+                          "column": 26
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 212,
+                              "line": 21,
+                              "column": 26
+                            },
+                            "endPos": {
+                              "offset": 213,
+                              "line": 21,
+                              "column": 27
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 212,
+                            "end": 213
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 211,
+                        "end": 212
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 220,
+                      "line": 21,
+                      "column": 34
+                    },
+                    "endPos": {
+                      "offset": 221,
+                      "line": 21,
+                      "column": 35
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 221,
+                          "line": 21,
+                          "column": 35
+                        },
+                        "endPos": {
+                          "offset": 222,
+                          "line": 22,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 221,
+                        "end": 222
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 220,
+                    "end": 221
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 222,
+              "line": 22,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 223,
+              "line": 22,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 223,
+                  "line": 22,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 224,
+                  "line": 23,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 223,
+                "end": 224
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 222,
+            "end": 223
+          }
+        },
+        "parent": 119
+      },
+      {
+        "id": 118,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 225,
+          "line": 24,
+          "column": 0
+        },
+        "fullStart": 224,
+        "endPos": {
+          "offset": 252,
+          "line": 26,
+          "column": 1
+        },
+        "fullEnd": 252,
+        "start": 225,
+        "end": 252,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 225,
+            "line": 24,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 228,
+            "line": 24,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 224,
+                "line": 23,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 225,
+                "line": 24,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 224,
+              "end": 225
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 228,
+                "line": 24,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 229,
+                "line": 24,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 228,
+              "end": 229
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 225,
+          "end": 228
+        },
+        "body": {
+          "id": 117,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 229,
+            "line": 24,
+            "column": 4
+          },
+          "fullStart": 229,
+          "endPos": {
+            "offset": 252,
+            "line": 26,
+            "column": 1
+          },
+          "fullEnd": 252,
+          "start": 229,
+          "end": 252,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 229,
+              "line": 24,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 230,
+              "line": 24,
+              "column": 5
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 230,
+                  "line": 24,
+                  "column": 5
+                },
+                "endPos": {
+                  "offset": 231,
+                  "line": 25,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 230,
+                "end": 231
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 229,
+            "end": 230
+          },
+          "body": [
+            {
+              "id": 116,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 235,
+                "line": 25,
+                "column": 4
+              },
+              "fullStart": 231,
+              "endPos": {
+                "offset": 250,
+                "line": 25,
+                "column": 19
+              },
+              "fullEnd": 251,
+              "start": 235,
+              "end": 250,
+              "callee": {
+                "id": 111,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 235,
+                  "line": 25,
+                  "column": 4
+                },
+                "fullStart": 231,
+                "endPos": {
+                  "offset": 246,
+                  "line": 25,
+                  "column": 15
+                },
+                "fullEnd": 247,
+                "start": 235,
+                "end": 246,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 240,
+                    "line": 25,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 241,
+                    "line": 25,
+                    "column": 10
+                  },
+                  "value": ">",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 241,
+                        "line": 25,
+                        "column": 10
+                      },
+                      "endPos": {
+                        "offset": 242,
+                        "line": 25,
+                        "column": 11
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 241,
+                      "end": 242
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 240,
+                  "end": 241
+                },
+                "leftExpression": {
+                  "id": 105,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 235,
+                    "line": 25,
+                    "column": 4
+                  },
+                  "fullStart": 231,
+                  "endPos": {
+                    "offset": 239,
+                    "line": 25,
+                    "column": 8
+                  },
+                  "fullEnd": 240,
+                  "start": 235,
+                  "end": 239,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 236,
+                      "line": 25,
+                      "column": 5
+                    },
+                    "endPos": {
+                      "offset": 237,
+                      "line": 25,
+                      "column": 6
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 236,
+                    "end": 237
+                  },
+                  "leftExpression": {
+                    "id": 102,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 235,
+                      "line": 25,
+                      "column": 4
+                    },
+                    "fullStart": 231,
+                    "endPos": {
+                      "offset": 236,
+                      "line": 25,
+                      "column": 5
+                    },
+                    "fullEnd": 236,
+                    "start": 235,
+                    "end": 236,
+                    "expression": {
+                      "id": 101,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 235,
+                        "line": 25,
+                        "column": 4
+                      },
+                      "fullStart": 231,
+                      "endPos": {
+                        "offset": 236,
+                        "line": 25,
+                        "column": 5
+                      },
+                      "fullEnd": 236,
+                      "start": 235,
+                      "end": 236,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 235,
+                          "line": 25,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 236,
+                          "line": 25,
+                          "column": 5
+                        },
+                        "value": "A",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 231,
+                              "line": 25,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 232,
+                              "line": 25,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 231,
+                            "end": 232
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 232,
+                              "line": 25,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 233,
+                              "line": 25,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 232,
+                            "end": 233
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 233,
+                              "line": 25,
+                              "column": 2
+                            },
+                            "endPos": {
+                              "offset": 234,
+                              "line": 25,
+                              "column": 3
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 233,
+                            "end": 234
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 234,
+                              "line": 25,
+                              "column": 3
+                            },
+                            "endPos": {
+                              "offset": 235,
+                              "line": 25,
+                              "column": 4
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 234,
+                            "end": 235
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 235,
+                        "end": 236
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 104,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 237,
+                      "line": 25,
+                      "column": 6
+                    },
+                    "fullStart": 237,
+                    "endPos": {
+                      "offset": 239,
+                      "line": 25,
+                      "column": 8
+                    },
+                    "fullEnd": 240,
+                    "start": 237,
+                    "end": 239,
+                    "expression": {
+                      "id": 103,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 237,
+                        "line": 25,
+                        "column": 6
+                      },
+                      "fullStart": 237,
+                      "endPos": {
+                        "offset": 239,
+                        "line": 25,
+                        "column": 8
+                      },
+                      "fullEnd": 240,
+                      "start": 237,
+                      "end": 239,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 237,
+                          "line": 25,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 239,
+                          "line": 25,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 239,
+                              "line": 25,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 240,
+                              "line": 25,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 239,
+                            "end": 240
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 237,
+                        "end": 239
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 110,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 242,
+                    "line": 25,
+                    "column": 11
+                  },
+                  "fullStart": 242,
+                  "endPos": {
+                    "offset": 246,
+                    "line": 25,
+                    "column": 15
+                  },
+                  "fullEnd": 247,
+                  "start": 242,
+                  "end": 246,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 243,
+                      "line": 25,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 244,
+                      "line": 25,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 243,
+                    "end": 244
+                  },
+                  "leftExpression": {
+                    "id": 107,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 242,
+                      "line": 25,
+                      "column": 11
+                    },
+                    "fullStart": 242,
+                    "endPos": {
+                      "offset": 243,
+                      "line": 25,
+                      "column": 12
+                    },
+                    "fullEnd": 243,
+                    "start": 242,
+                    "end": 243,
+                    "expression": {
+                      "id": 106,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 242,
+                        "line": 25,
+                        "column": 11
+                      },
+                      "fullStart": 242,
+                      "endPos": {
+                        "offset": 243,
+                        "line": 25,
+                        "column": 12
+                      },
+                      "fullEnd": 243,
+                      "start": 242,
+                      "end": 243,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 242,
+                          "line": 25,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 243,
+                          "line": 25,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 242,
+                        "end": 243
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 109,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 244,
+                      "line": 25,
+                      "column": 13
+                    },
+                    "fullStart": 244,
+                    "endPos": {
+                      "offset": 246,
+                      "line": 25,
+                      "column": 15
+                    },
+                    "fullEnd": 247,
+                    "start": 244,
+                    "end": 246,
+                    "expression": {
+                      "id": 108,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 244,
+                        "line": 25,
+                        "column": 13
+                      },
+                      "fullStart": 244,
+                      "endPos": {
+                        "offset": 246,
+                        "line": 25,
+                        "column": 15
+                      },
+                      "fullEnd": 247,
+                      "start": 244,
+                      "end": 246,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 244,
+                          "line": 25,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 246,
+                          "line": 25,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 246,
+                              "line": 25,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 247,
+                              "line": 25,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 246,
+                            "end": 247
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 244,
+                        "end": 246
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 113,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 247,
+                    "line": 25,
+                    "column": 16
+                  },
+                  "fullStart": 247,
+                  "endPos": {
+                    "offset": 248,
+                    "line": 25,
+                    "column": 17
+                  },
+                  "fullEnd": 249,
+                  "start": 247,
+                  "end": 248,
+                  "expression": {
+                    "id": 112,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 247,
+                      "line": 25,
+                      "column": 16
+                    },
+                    "fullStart": 247,
+                    "endPos": {
+                      "offset": 248,
+                      "line": 25,
+                      "column": 17
+                    },
+                    "fullEnd": 249,
+                    "start": 247,
+                    "end": 248,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 247,
+                        "line": 25,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 248,
+                        "line": 25,
+                        "column": 17
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 248,
+                            "line": 25,
+                            "column": 17
+                          },
+                          "endPos": {
+                            "offset": 249,
+                            "line": 25,
+                            "column": 18
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 248,
+                          "end": 249
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 247,
+                      "end": 248
+                    }
+                  }
+                },
+                {
+                  "id": 115,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 249,
+                    "line": 25,
+                    "column": 18
+                  },
+                  "fullStart": 249,
+                  "endPos": {
+                    "offset": 250,
+                    "line": 25,
+                    "column": 19
+                  },
+                  "fullEnd": 251,
+                  "start": 249,
+                  "end": 250,
+                  "expression": {
+                    "id": 114,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 249,
+                      "line": 25,
+                      "column": 18
+                    },
+                    "fullStart": 249,
+                    "endPos": {
+                      "offset": 250,
+                      "line": 25,
+                      "column": 19
+                    },
+                    "fullEnd": 251,
+                    "start": 249,
+                    "end": 250,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 249,
+                        "line": 25,
+                        "column": 18
+                      },
+                      "endPos": {
+                        "offset": 250,
+                        "line": 25,
+                        "column": 19
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 250,
+                            "line": 25,
+                            "column": 19
+                          },
+                          "endPos": {
+                            "offset": 251,
+                            "line": 26,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 250,
+                          "end": 251
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 249,
+                      "end": 250
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 251,
+              "line": 26,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 252,
+              "line": 26,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 251,
+            "end": 252
+          }
+        },
+        "parent": 119
+      }
+    ],
+    "eof": {
+      "kind": "<eof>",
+      "startPos": {
+        "offset": 252,
+        "line": 26,
+        "column": 1
+      },
+      "endPos": {
+        "offset": 252,
+        "line": 26,
+        "column": 1
+      },
+      "value": "",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 252,
+      "end": 252
+    },
+    "symbol": {
+      "symbolTable": {
+        "Table:A": {
+          "references": [],
+          "id": 1,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 2,
+              "declaration": 6
+            },
+            "Column:ssid": {
+              "references": [],
+              "id": 3,
+              "declaration": 9
+            }
+          },
+          "declaration": 11
+        },
+        "Enum:E": {
+          "references": [],
+          "id": 4,
+          "symbolTable": {
+            "Enum field:a": {
+              "references": [],
+              "id": 5,
+              "declaration": 23
+            }
+          },
+          "declaration": 42
+        },
+        "TableGroup:G": {
+          "references": [],
+          "id": 8,
+          "symbolTable": {
+            "TableGroup field:A": {
+              "references": [],
+              "id": 9,
+              "declaration": 49
+            }
+          },
+          "declaration": 58
+        }
+      },
+      "id": 0,
+      "references": []
+    }
+  },
+  "errors": [
+    {
+      "code": 3019,
+      "diagnostic": "A column must have a type",
+      "nodeOrToken": {
+        "id": 8,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 25,
+          "line": 2,
+          "column": 4
+        },
+        "fullStart": 21,
+        "endPos": {
+          "offset": 29,
+          "line": 2,
+          "column": 8
+        },
+        "fullEnd": 30,
+        "start": 25,
+        "end": 29,
+        "expression": {
+          "id": 7,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 25,
+            "line": 2,
+            "column": 4
+          },
+          "fullStart": 21,
+          "endPos": {
+            "offset": 29,
+            "line": 2,
+            "column": 8
+          },
+          "fullEnd": 30,
+          "start": 25,
+          "end": 29,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 25,
+              "line": 2,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 29,
+              "line": 2,
+              "column": 8
+            },
+            "value": "ssid",
+            "leadingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 21,
+                  "line": 2,
+                  "column": 0
+                },
+                "endPos": {
+                  "offset": 22,
+                  "line": 2,
+                  "column": 1
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 21,
+                "end": 22
+              },
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 22,
+                  "line": 2,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 23,
+                  "line": 2,
+                  "column": 2
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 22,
+                "end": 23
+              },
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 23,
+                  "line": 2,
+                  "column": 2
+                },
+                "endPos": {
+                  "offset": 24,
+                  "line": 2,
+                  "column": 3
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 23,
+                "end": 24
+              },
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 24,
+                  "line": 2,
+                  "column": 3
+                },
+                "endPos": {
+                  "offset": 25,
+                  "line": 2,
+                  "column": 4
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 24,
+                "end": 25
+              }
+            ],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 29,
+                  "line": 2,
+                  "column": 8
+                },
+                "endPos": {
+                  "offset": 30,
+                  "line": 3,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 29,
+                "end": 30
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 25,
+            "end": 29
+          }
+        }
+      },
+      "start": 25,
+      "end": 29,
+      "name": "CompileError"
+    },
+    {
+      "code": 3028,
+      "diagnostic": "An Enum must have only a field and optionally a setting list",
+      "nodeOrToken": {
+        "id": 17,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 48,
+          "line": 6,
+          "column": 6
+        },
+        "fullStart": 48,
+        "endPos": {
+          "offset": 49,
+          "line": 6,
+          "column": 7
+        },
+        "fullEnd": 50,
+        "start": 48,
+        "end": 49,
+        "expression": {
+          "id": 16,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 48,
+            "line": 6,
+            "column": 6
+          },
+          "fullStart": 48,
+          "endPos": {
+            "offset": 49,
+            "line": 6,
+            "column": 7
+          },
+          "fullEnd": 50,
+          "start": 48,
+          "end": 49,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 48,
+              "line": 6,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 49,
+              "line": 6,
+              "column": 7
+            },
+            "value": "e",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 49,
+                  "line": 6,
+                  "column": 7
+                },
+                "endPos": {
+                  "offset": 50,
+                  "line": 6,
+                  "column": 8
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 49,
+                "end": 50
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 48,
+            "end": 49
+          }
+        }
+      },
+      "start": 48,
+      "end": 49,
+      "name": "CompileError"
+    },
+    {
+      "code": 3028,
+      "diagnostic": "An Enum must have only a field and optionally a setting list",
+      "nodeOrToken": {
+        "id": 32,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 84,
+          "line": 7,
+          "column": 20
+        },
+        "fullStart": 84,
+        "endPos": {
+          "offset": 85,
+          "line": 7,
+          "column": 21
+        },
+        "fullEnd": 86,
+        "start": 84,
+        "end": 85,
+        "expression": {
+          "id": 31,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 84,
+            "line": 7,
+            "column": 20
+          },
+          "fullStart": 84,
+          "endPos": {
+            "offset": 85,
+            "line": 7,
+            "column": 21
+          },
+          "fullEnd": 86,
+          "start": 84,
+          "end": 85,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 84,
+              "line": 7,
+              "column": 20
+            },
+            "endPos": {
+              "offset": 85,
+              "line": 7,
+              "column": 21
+            },
+            "value": "e",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 85,
+                  "line": 7,
+                  "column": 21
+                },
+                "endPos": {
+                  "offset": 86,
+                  "line": 8,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 85,
+                "end": 86
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 84,
+            "end": 85
+          }
+        }
+      },
+      "start": 84,
+      "end": 85,
+      "name": "CompileError"
+    },
+    {
+      "code": 3023,
+      "diagnostic": "Duplicate enum field a",
+      "nodeOrToken": {
+        "id": 33,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 68,
+          "line": 7,
+          "column": 4
+        },
+        "fullStart": 64,
+        "endPos": {
+          "offset": 85,
+          "line": 7,
+          "column": 21
+        },
+        "fullEnd": 86,
+        "start": 68,
+        "end": 85,
+        "callee": {
+          "id": 25,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 68,
+            "line": 7,
+            "column": 4
+          },
+          "fullStart": 64,
+          "endPos": {
+            "offset": 69,
+            "line": 7,
+            "column": 5
+          },
+          "fullEnd": 70,
+          "start": 68,
+          "end": 69,
+          "expression": {
+            "id": 24,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 68,
+              "line": 7,
+              "column": 4
+            },
+            "fullStart": 64,
+            "endPos": {
+              "offset": 69,
+              "line": 7,
+              "column": 5
+            },
+            "fullEnd": 70,
+            "start": 68,
+            "end": 69,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 68,
+                "line": 7,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 69,
+                "line": 7,
+                "column": 5
+              },
+              "value": "a",
+              "leadingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 64,
+                    "line": 7,
+                    "column": 0
+                  },
+                  "endPos": {
+                    "offset": 65,
+                    "line": 7,
+                    "column": 1
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 64,
+                  "end": 65
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 65,
+                    "line": 7,
+                    "column": 1
+                  },
+                  "endPos": {
+                    "offset": 66,
+                    "line": 7,
+                    "column": 2
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 65,
+                  "end": 66
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 66,
+                    "line": 7,
+                    "column": 2
+                  },
+                  "endPos": {
+                    "offset": 67,
+                    "line": 7,
+                    "column": 3
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 66,
+                  "end": 67
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 67,
+                    "line": 7,
+                    "column": 3
+                  },
+                  "endPos": {
+                    "offset": 68,
+                    "line": 7,
+                    "column": 4
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 67,
+                  "end": 68
+                }
+              ],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 69,
+                    "line": 7,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 70,
+                    "line": 7,
+                    "column": 6
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 69,
+                  "end": 70
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 68,
+              "end": 69
+            }
+          }
+        },
+        "args": [
+          {
+            "id": 30,
+            "kind": "<list-expression>",
+            "startPos": {
+              "offset": 70,
+              "line": 7,
+              "column": 6
+            },
+            "fullStart": 70,
+            "endPos": {
+              "offset": 83,
+              "line": 7,
+              "column": 19
+            },
+            "fullEnd": 84,
+            "start": 70,
+            "end": 83,
+            "listOpenBracket": {
+              "kind": "<lbracket>",
+              "startPos": {
+                "offset": 70,
+                "line": 7,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 71,
+                "line": 7,
+                "column": 7
+              },
+              "value": "[",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 70,
+              "end": 71
+            },
+            "elementList": [
+              {
+                "id": 29,
+                "kind": "<attribute>",
+                "startPos": {
+                  "offset": 71,
+                  "line": 7,
+                  "column": 7
+                },
+                "fullStart": 71,
+                "endPos": {
+                  "offset": 82,
+                  "line": 7,
+                  "column": 18
+                },
+                "fullEnd": 82,
+                "start": 71,
+                "end": 82,
+                "name": {
+                  "id": 26,
+                  "kind": "<identifer-stream>",
+                  "startPos": {
+                    "offset": 71,
+                    "line": 7,
+                    "column": 7
+                  },
+                  "fullStart": 71,
+                  "endPos": {
+                    "offset": 75,
+                    "line": 7,
+                    "column": 11
+                  },
+                  "fullEnd": 75,
+                  "start": 71,
+                  "end": 75,
+                  "identifiers": [
+                    {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 71,
+                        "line": 7,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 75,
+                        "line": 7,
+                        "column": 11
+                      },
+                      "value": "note",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 71,
+                      "end": 75
+                    }
+                  ]
+                },
+                "value": {
+                  "id": 28,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 77,
+                    "line": 7,
+                    "column": 13
+                  },
+                  "fullStart": 77,
+                  "endPos": {
+                    "offset": 82,
+                    "line": 7,
+                    "column": 18
+                  },
+                  "fullEnd": 82,
+                  "start": 77,
+                  "end": 82,
+                  "expression": {
+                    "id": 27,
+                    "kind": "<literal>",
+                    "startPos": {
+                      "offset": 77,
+                      "line": 7,
+                      "column": 13
+                    },
+                    "fullStart": 77,
+                    "endPos": {
+                      "offset": 82,
+                      "line": 7,
+                      "column": 18
+                    },
+                    "fullEnd": 82,
+                    "start": 77,
+                    "end": 82,
+                    "literal": {
+                      "kind": "<string>",
+                      "startPos": {
+                        "offset": 77,
+                        "line": 7,
+                        "column": 13
+                      },
+                      "endPos": {
+                        "offset": 82,
+                        "line": 7,
+                        "column": 18
+                      },
+                      "value": "abc",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 77,
+                      "end": 82
+                    }
+                  }
+                },
+                "colon": {
+                  "kind": "<colon>",
+                  "startPos": {
+                    "offset": 75,
+                    "line": 7,
+                    "column": 11
+                  },
+                  "endPos": {
+                    "offset": 76,
+                    "line": 7,
+                    "column": 12
+                  },
+                  "value": ":",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 76,
+                        "line": 7,
+                        "column": 12
+                      },
+                      "endPos": {
+                        "offset": 77,
+                        "line": 7,
+                        "column": 13
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 76,
+                      "end": 77
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 75,
+                  "end": 76
+                }
+              }
+            ],
+            "commaList": [],
+            "listCloseBracket": {
+              "kind": "<rbracket>",
+              "startPos": {
+                "offset": 82,
+                "line": 7,
+                "column": 18
+              },
+              "endPos": {
+                "offset": 83,
+                "line": 7,
+                "column": 19
+              },
+              "value": "]",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 83,
+                    "line": 7,
+                    "column": 19
+                  },
+                  "endPos": {
+                    "offset": 84,
+                    "line": 7,
+                    "column": 20
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 83,
+                  "end": 84
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 82,
+              "end": 83
+            }
+          },
+          {
+            "id": 32,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 84,
+              "line": 7,
+              "column": 20
+            },
+            "fullStart": 84,
+            "endPos": {
+              "offset": 85,
+              "line": 7,
+              "column": 21
+            },
+            "fullEnd": 86,
+            "start": 84,
+            "end": 85,
+            "expression": {
+              "id": 31,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 84,
+                "line": 7,
+                "column": 20
+              },
+              "fullStart": 84,
+              "endPos": {
+                "offset": 85,
+                "line": 7,
+                "column": 21
+              },
+              "fullEnd": 86,
+              "start": 84,
+              "end": 85,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 84,
+                  "line": 7,
+                  "column": 20
+                },
+                "endPos": {
+                  "offset": 85,
+                  "line": 7,
+                  "column": 21
+                },
+                "value": "e",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 85,
+                      "line": 7,
+                      "column": 21
+                    },
+                    "endPos": {
+                      "offset": 86,
+                      "line": 8,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 85,
+                    "end": 86
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 84,
+                "end": 85
+              }
+            }
+          }
+        ],
+        "symbol": 6
+      },
+      "start": 68,
+      "end": 85,
+      "name": "CompileError"
+    },
+    {
+      "code": 3023,
+      "diagnostic": "Duplicate enum field a",
+      "nodeOrToken": {
+        "id": 23,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 46,
+          "line": 6,
+          "column": 4
+        },
+        "fullStart": 42,
+        "endPos": {
+          "offset": 63,
+          "line": 6,
+          "column": 21
+        },
+        "fullEnd": 64,
+        "start": 46,
+        "end": 63,
+        "callee": {
+          "id": 15,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 46,
+            "line": 6,
+            "column": 4
+          },
+          "fullStart": 42,
+          "endPos": {
+            "offset": 47,
+            "line": 6,
+            "column": 5
+          },
+          "fullEnd": 48,
+          "start": 46,
+          "end": 47,
+          "expression": {
+            "id": 14,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 46,
+              "line": 6,
+              "column": 4
+            },
+            "fullStart": 42,
+            "endPos": {
+              "offset": 47,
+              "line": 6,
+              "column": 5
+            },
+            "fullEnd": 48,
+            "start": 46,
+            "end": 47,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 46,
+                "line": 6,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 47,
+                "line": 6,
+                "column": 5
+              },
+              "value": "a",
+              "leadingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 42,
+                    "line": 6,
+                    "column": 0
+                  },
+                  "endPos": {
+                    "offset": 43,
+                    "line": 6,
+                    "column": 1
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 42,
+                  "end": 43
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 43,
+                    "line": 6,
+                    "column": 1
+                  },
+                  "endPos": {
+                    "offset": 44,
+                    "line": 6,
+                    "column": 2
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 43,
+                  "end": 44
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 44,
+                    "line": 6,
+                    "column": 2
+                  },
+                  "endPos": {
+                    "offset": 45,
+                    "line": 6,
+                    "column": 3
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 44,
+                  "end": 45
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 45,
+                    "line": 6,
+                    "column": 3
+                  },
+                  "endPos": {
+                    "offset": 46,
+                    "line": 6,
+                    "column": 4
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 45,
+                  "end": 46
+                }
+              ],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 47,
+                    "line": 6,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 48,
+                    "line": 6,
+                    "column": 6
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 47,
+                  "end": 48
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 46,
+              "end": 47
+            }
+          }
+        },
+        "args": [
+          {
+            "id": 17,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 48,
+              "line": 6,
+              "column": 6
+            },
+            "fullStart": 48,
+            "endPos": {
+              "offset": 49,
+              "line": 6,
+              "column": 7
+            },
+            "fullEnd": 50,
+            "start": 48,
+            "end": 49,
+            "expression": {
+              "id": 16,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 48,
+                "line": 6,
+                "column": 6
+              },
+              "fullStart": 48,
+              "endPos": {
+                "offset": 49,
+                "line": 6,
+                "column": 7
+              },
+              "fullEnd": 50,
+              "start": 48,
+              "end": 49,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 48,
+                  "line": 6,
+                  "column": 6
+                },
+                "endPos": {
+                  "offset": 49,
+                  "line": 6,
+                  "column": 7
+                },
+                "value": "e",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 49,
+                      "line": 6,
+                      "column": 7
+                    },
+                    "endPos": {
+                      "offset": 50,
+                      "line": 6,
+                      "column": 8
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 49,
+                    "end": 50
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 48,
+                "end": 49
+              }
+            }
+          },
+          {
+            "id": 22,
+            "kind": "<list-expression>",
+            "startPos": {
+              "offset": 50,
+              "line": 6,
+              "column": 8
+            },
+            "fullStart": 50,
+            "endPos": {
+              "offset": 63,
+              "line": 6,
+              "column": 21
+            },
+            "fullEnd": 64,
+            "start": 50,
+            "end": 63,
+            "listOpenBracket": {
+              "kind": "<lbracket>",
+              "startPos": {
+                "offset": 50,
+                "line": 6,
+                "column": 8
+              },
+              "endPos": {
+                "offset": 51,
+                "line": 6,
+                "column": 9
+              },
+              "value": "[",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 50,
+              "end": 51
+            },
+            "elementList": [
+              {
+                "id": 21,
+                "kind": "<attribute>",
+                "startPos": {
+                  "offset": 51,
+                  "line": 6,
+                  "column": 9
+                },
+                "fullStart": 51,
+                "endPos": {
+                  "offset": 62,
+                  "line": 6,
+                  "column": 20
+                },
+                "fullEnd": 62,
+                "start": 51,
+                "end": 62,
+                "name": {
+                  "id": 18,
+                  "kind": "<identifer-stream>",
+                  "startPos": {
+                    "offset": 51,
+                    "line": 6,
+                    "column": 9
+                  },
+                  "fullStart": 51,
+                  "endPos": {
+                    "offset": 55,
+                    "line": 6,
+                    "column": 13
+                  },
+                  "fullEnd": 55,
+                  "start": 51,
+                  "end": 55,
+                  "identifiers": [
+                    {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 51,
+                        "line": 6,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 55,
+                        "line": 6,
+                        "column": 13
+                      },
+                      "value": "note",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 51,
+                      "end": 55
+                    }
+                  ]
+                },
+                "value": {
+                  "id": 20,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 57,
+                    "line": 6,
+                    "column": 15
+                  },
+                  "fullStart": 57,
+                  "endPos": {
+                    "offset": 62,
+                    "line": 6,
+                    "column": 20
+                  },
+                  "fullEnd": 62,
+                  "start": 57,
+                  "end": 62,
+                  "expression": {
+                    "id": 19,
+                    "kind": "<literal>",
+                    "startPos": {
+                      "offset": 57,
+                      "line": 6,
+                      "column": 15
+                    },
+                    "fullStart": 57,
+                    "endPos": {
+                      "offset": 62,
+                      "line": 6,
+                      "column": 20
+                    },
+                    "fullEnd": 62,
+                    "start": 57,
+                    "end": 62,
+                    "literal": {
+                      "kind": "<string>",
+                      "startPos": {
+                        "offset": 57,
+                        "line": 6,
+                        "column": 15
+                      },
+                      "endPos": {
+                        "offset": 62,
+                        "line": 6,
+                        "column": 20
+                      },
+                      "value": "abc",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 57,
+                      "end": 62
+                    }
+                  }
+                },
+                "colon": {
+                  "kind": "<colon>",
+                  "startPos": {
+                    "offset": 55,
+                    "line": 6,
+                    "column": 13
+                  },
+                  "endPos": {
+                    "offset": 56,
+                    "line": 6,
+                    "column": 14
+                  },
+                  "value": ":",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 56,
+                        "line": 6,
+                        "column": 14
+                      },
+                      "endPos": {
+                        "offset": 57,
+                        "line": 6,
+                        "column": 15
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 56,
+                      "end": 57
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 55,
+                  "end": 56
+                }
+              }
+            ],
+            "commaList": [],
+            "listCloseBracket": {
+              "kind": "<rbracket>",
+              "startPos": {
+                "offset": 62,
+                "line": 6,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 63,
+                "line": 6,
+                "column": 21
+              },
+              "value": "]",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<newline>",
+                  "startPos": {
+                    "offset": 63,
+                    "line": 6,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 64,
+                    "line": 7,
+                    "column": 0
+                  },
+                  "value": "\n",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 63,
+                  "end": 64
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 62,
+              "end": 63
+            }
+          }
+        ],
+        "symbol": 5
+      },
+      "start": 46,
+      "end": 63,
+      "name": "CompileError"
+    },
+    {
+      "code": 3028,
+      "diagnostic": "An Enum must have only a field and optionally a setting list",
+      "nodeOrToken": {
+        "id": 37,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 92,
+          "line": 8,
+          "column": 6
+        },
+        "fullStart": 92,
+        "endPos": {
+          "offset": 93,
+          "line": 8,
+          "column": 7
+        },
+        "fullEnd": 94,
+        "start": 92,
+        "end": 93,
+        "expression": {
+          "id": 36,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 92,
+            "line": 8,
+            "column": 6
+          },
+          "fullStart": 92,
+          "endPos": {
+            "offset": 93,
+            "line": 8,
+            "column": 7
+          },
+          "fullEnd": 94,
+          "start": 92,
+          "end": 93,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 92,
+              "line": 8,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 93,
+              "line": 8,
+              "column": 7
+            },
+            "value": "e",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 93,
+                  "line": 8,
+                  "column": 7
+                },
+                "endPos": {
+                  "offset": 94,
+                  "line": 8,
+                  "column": 8
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 93,
+                "end": 94
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 92,
+            "end": 93
+          }
+        }
+      },
+      "start": 92,
+      "end": 93,
+      "name": "CompileError"
+    },
+    {
+      "code": 3028,
+      "diagnostic": "An Enum must have only a field and optionally a setting list",
+      "nodeOrToken": {
+        "id": 39,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 94,
+          "line": 8,
+          "column": 8
+        },
+        "fullStart": 94,
+        "endPos": {
+          "offset": 95,
+          "line": 8,
+          "column": 9
+        },
+        "fullEnd": 96,
+        "start": 94,
+        "end": 95,
+        "expression": {
+          "id": 38,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 94,
+            "line": 8,
+            "column": 8
+          },
+          "fullStart": 94,
+          "endPos": {
+            "offset": 95,
+            "line": 8,
+            "column": 9
+          },
+          "fullEnd": 96,
+          "start": 94,
+          "end": 95,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 94,
+              "line": 8,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 95,
+              "line": 8,
+              "column": 9
+            },
+            "value": "f",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 95,
+                  "line": 8,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 96,
+                  "line": 9,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 95,
+                "end": 96
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 94,
+            "end": 95
+          }
+        }
+      },
+      "start": 94,
+      "end": 95,
+      "name": "CompileError"
+    },
+    {
+      "code": 3023,
+      "diagnostic": "Duplicate enum field a",
+      "nodeOrToken": {
+        "id": 40,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 90,
+          "line": 8,
+          "column": 4
+        },
+        "fullStart": 86,
+        "endPos": {
+          "offset": 95,
+          "line": 8,
+          "column": 9
+        },
+        "fullEnd": 96,
+        "start": 90,
+        "end": 95,
+        "callee": {
+          "id": 35,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 90,
+            "line": 8,
+            "column": 4
+          },
+          "fullStart": 86,
+          "endPos": {
+            "offset": 91,
+            "line": 8,
+            "column": 5
+          },
+          "fullEnd": 92,
+          "start": 90,
+          "end": 91,
+          "expression": {
+            "id": 34,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 90,
+              "line": 8,
+              "column": 4
+            },
+            "fullStart": 86,
+            "endPos": {
+              "offset": 91,
+              "line": 8,
+              "column": 5
+            },
+            "fullEnd": 92,
+            "start": 90,
+            "end": 91,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 90,
+                "line": 8,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 91,
+                "line": 8,
+                "column": 5
+              },
+              "value": "a",
+              "leadingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 86,
+                    "line": 8,
+                    "column": 0
+                  },
+                  "endPos": {
+                    "offset": 87,
+                    "line": 8,
+                    "column": 1
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 86,
+                  "end": 87
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 87,
+                    "line": 8,
+                    "column": 1
+                  },
+                  "endPos": {
+                    "offset": 88,
+                    "line": 8,
+                    "column": 2
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 87,
+                  "end": 88
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 88,
+                    "line": 8,
+                    "column": 2
+                  },
+                  "endPos": {
+                    "offset": 89,
+                    "line": 8,
+                    "column": 3
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 88,
+                  "end": 89
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 89,
+                    "line": 8,
+                    "column": 3
+                  },
+                  "endPos": {
+                    "offset": 90,
+                    "line": 8,
+                    "column": 4
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 89,
+                  "end": 90
+                }
+              ],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 91,
+                    "line": 8,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 92,
+                    "line": 8,
+                    "column": 6
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 91,
+                  "end": 92
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 90,
+              "end": 91
+            }
+          }
+        },
+        "args": [
+          {
+            "id": 37,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 92,
+              "line": 8,
+              "column": 6
+            },
+            "fullStart": 92,
+            "endPos": {
+              "offset": 93,
+              "line": 8,
+              "column": 7
+            },
+            "fullEnd": 94,
+            "start": 92,
+            "end": 93,
+            "expression": {
+              "id": 36,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 92,
+                "line": 8,
+                "column": 6
+              },
+              "fullStart": 92,
+              "endPos": {
+                "offset": 93,
+                "line": 8,
+                "column": 7
+              },
+              "fullEnd": 94,
+              "start": 92,
+              "end": 93,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 92,
+                  "line": 8,
+                  "column": 6
+                },
+                "endPos": {
+                  "offset": 93,
+                  "line": 8,
+                  "column": 7
+                },
+                "value": "e",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 93,
+                      "line": 8,
+                      "column": 7
+                    },
+                    "endPos": {
+                      "offset": 94,
+                      "line": 8,
+                      "column": 8
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 93,
+                    "end": 94
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 92,
+                "end": 93
+              }
+            }
+          },
+          {
+            "id": 39,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 94,
+              "line": 8,
+              "column": 8
+            },
+            "fullStart": 94,
+            "endPos": {
+              "offset": 95,
+              "line": 8,
+              "column": 9
+            },
+            "fullEnd": 96,
+            "start": 94,
+            "end": 95,
+            "expression": {
+              "id": 38,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 94,
+                "line": 8,
+                "column": 8
+              },
+              "fullStart": 94,
+              "endPos": {
+                "offset": 95,
+                "line": 8,
+                "column": 9
+              },
+              "fullEnd": 96,
+              "start": 94,
+              "end": 95,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 94,
+                  "line": 8,
+                  "column": 8
+                },
+                "endPos": {
+                  "offset": 95,
+                  "line": 8,
+                  "column": 9
+                },
+                "value": "f",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 95,
+                      "line": 8,
+                      "column": 9
+                    },
+                    "endPos": {
+                      "offset": 96,
+                      "line": 9,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 95,
+                    "end": 96
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 94,
+                "end": 95
+              }
+            }
+          }
+        ],
+        "symbol": 7
+      },
+      "start": 90,
+      "end": 95,
+      "name": "CompileError"
+    },
+    {
+      "code": 3023,
+      "diagnostic": "Duplicate enum field a",
+      "nodeOrToken": {
+        "id": 23,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 46,
+          "line": 6,
+          "column": 4
+        },
+        "fullStart": 42,
+        "endPos": {
+          "offset": 63,
+          "line": 6,
+          "column": 21
+        },
+        "fullEnd": 64,
+        "start": 46,
+        "end": 63,
+        "callee": {
+          "id": 15,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 46,
+            "line": 6,
+            "column": 4
+          },
+          "fullStart": 42,
+          "endPos": {
+            "offset": 47,
+            "line": 6,
+            "column": 5
+          },
+          "fullEnd": 48,
+          "start": 46,
+          "end": 47,
+          "expression": {
+            "id": 14,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 46,
+              "line": 6,
+              "column": 4
+            },
+            "fullStart": 42,
+            "endPos": {
+              "offset": 47,
+              "line": 6,
+              "column": 5
+            },
+            "fullEnd": 48,
+            "start": 46,
+            "end": 47,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 46,
+                "line": 6,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 47,
+                "line": 6,
+                "column": 5
+              },
+              "value": "a",
+              "leadingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 42,
+                    "line": 6,
+                    "column": 0
+                  },
+                  "endPos": {
+                    "offset": 43,
+                    "line": 6,
+                    "column": 1
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 42,
+                  "end": 43
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 43,
+                    "line": 6,
+                    "column": 1
+                  },
+                  "endPos": {
+                    "offset": 44,
+                    "line": 6,
+                    "column": 2
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 43,
+                  "end": 44
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 44,
+                    "line": 6,
+                    "column": 2
+                  },
+                  "endPos": {
+                    "offset": 45,
+                    "line": 6,
+                    "column": 3
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 44,
+                  "end": 45
+                },
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 45,
+                    "line": 6,
+                    "column": 3
+                  },
+                  "endPos": {
+                    "offset": 46,
+                    "line": 6,
+                    "column": 4
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 45,
+                  "end": 46
+                }
+              ],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 47,
+                    "line": 6,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 48,
+                    "line": 6,
+                    "column": 6
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 47,
+                  "end": 48
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 46,
+              "end": 47
+            }
+          }
+        },
+        "args": [
+          {
+            "id": 17,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 48,
+              "line": 6,
+              "column": 6
+            },
+            "fullStart": 48,
+            "endPos": {
+              "offset": 49,
+              "line": 6,
+              "column": 7
+            },
+            "fullEnd": 50,
+            "start": 48,
+            "end": 49,
+            "expression": {
+              "id": 16,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 48,
+                "line": 6,
+                "column": 6
+              },
+              "fullStart": 48,
+              "endPos": {
+                "offset": 49,
+                "line": 6,
+                "column": 7
+              },
+              "fullEnd": 50,
+              "start": 48,
+              "end": 49,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 48,
+                  "line": 6,
+                  "column": 6
+                },
+                "endPos": {
+                  "offset": 49,
+                  "line": 6,
+                  "column": 7
+                },
+                "value": "e",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 49,
+                      "line": 6,
+                      "column": 7
+                    },
+                    "endPos": {
+                      "offset": 50,
+                      "line": 6,
+                      "column": 8
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 49,
+                    "end": 50
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 48,
+                "end": 49
+              }
+            }
+          },
+          {
+            "id": 22,
+            "kind": "<list-expression>",
+            "startPos": {
+              "offset": 50,
+              "line": 6,
+              "column": 8
+            },
+            "fullStart": 50,
+            "endPos": {
+              "offset": 63,
+              "line": 6,
+              "column": 21
+            },
+            "fullEnd": 64,
+            "start": 50,
+            "end": 63,
+            "listOpenBracket": {
+              "kind": "<lbracket>",
+              "startPos": {
+                "offset": 50,
+                "line": 6,
+                "column": 8
+              },
+              "endPos": {
+                "offset": 51,
+                "line": 6,
+                "column": 9
+              },
+              "value": "[",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 50,
+              "end": 51
+            },
+            "elementList": [
+              {
+                "id": 21,
+                "kind": "<attribute>",
+                "startPos": {
+                  "offset": 51,
+                  "line": 6,
+                  "column": 9
+                },
+                "fullStart": 51,
+                "endPos": {
+                  "offset": 62,
+                  "line": 6,
+                  "column": 20
+                },
+                "fullEnd": 62,
+                "start": 51,
+                "end": 62,
+                "name": {
+                  "id": 18,
+                  "kind": "<identifer-stream>",
+                  "startPos": {
+                    "offset": 51,
+                    "line": 6,
+                    "column": 9
+                  },
+                  "fullStart": 51,
+                  "endPos": {
+                    "offset": 55,
+                    "line": 6,
+                    "column": 13
+                  },
+                  "fullEnd": 55,
+                  "start": 51,
+                  "end": 55,
+                  "identifiers": [
+                    {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 51,
+                        "line": 6,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 55,
+                        "line": 6,
+                        "column": 13
+                      },
+                      "value": "note",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 51,
+                      "end": 55
+                    }
+                  ]
+                },
+                "value": {
+                  "id": 20,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 57,
+                    "line": 6,
+                    "column": 15
+                  },
+                  "fullStart": 57,
+                  "endPos": {
+                    "offset": 62,
+                    "line": 6,
+                    "column": 20
+                  },
+                  "fullEnd": 62,
+                  "start": 57,
+                  "end": 62,
+                  "expression": {
+                    "id": 19,
+                    "kind": "<literal>",
+                    "startPos": {
+                      "offset": 57,
+                      "line": 6,
+                      "column": 15
+                    },
+                    "fullStart": 57,
+                    "endPos": {
+                      "offset": 62,
+                      "line": 6,
+                      "column": 20
+                    },
+                    "fullEnd": 62,
+                    "start": 57,
+                    "end": 62,
+                    "literal": {
+                      "kind": "<string>",
+                      "startPos": {
+                        "offset": 57,
+                        "line": 6,
+                        "column": 15
+                      },
+                      "endPos": {
+                        "offset": 62,
+                        "line": 6,
+                        "column": 20
+                      },
+                      "value": "abc",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 57,
+                      "end": 62
+                    }
+                  }
+                },
+                "colon": {
+                  "kind": "<colon>",
+                  "startPos": {
+                    "offset": 55,
+                    "line": 6,
+                    "column": 13
+                  },
+                  "endPos": {
+                    "offset": 56,
+                    "line": 6,
+                    "column": 14
+                  },
+                  "value": ":",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 56,
+                        "line": 6,
+                        "column": 14
+                      },
+                      "endPos": {
+                        "offset": 57,
+                        "line": 6,
+                        "column": 15
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 56,
+                      "end": 57
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 55,
+                  "end": 56
+                }
+              }
+            ],
+            "commaList": [],
+            "listCloseBracket": {
+              "kind": "<rbracket>",
+              "startPos": {
+                "offset": 62,
+                "line": 6,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 63,
+                "line": 6,
+                "column": 21
+              },
+              "value": "]",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<newline>",
+                  "startPos": {
+                    "offset": 63,
+                    "line": 6,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 64,
+                    "line": 7,
+                    "column": 0
+                  },
+                  "value": "\n",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 63,
+                  "end": 64
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 62,
+              "end": 63
+            }
+          }
+        ],
+        "symbol": 5
+      },
+      "start": 46,
+      "end": 63,
+      "name": "CompileError"
+    },
+    {
+      "code": 3017,
+      "diagnostic": "A TableGroup field should only have a single Table name",
+      "nodeOrToken": {
+        "id": 48,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 120,
+          "line": 12,
+          "column": 6
+        },
+        "fullStart": 120,
+        "endPos": {
+          "offset": 121,
+          "line": 12,
+          "column": 7
+        },
+        "fullEnd": 122,
+        "start": 120,
+        "end": 121,
+        "expression": {
+          "id": 47,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 120,
+            "line": 12,
+            "column": 6
+          },
+          "fullStart": 120,
+          "endPos": {
+            "offset": 121,
+            "line": 12,
+            "column": 7
+          },
+          "fullEnd": 122,
+          "start": 120,
+          "end": 121,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 120,
+              "line": 12,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 121,
+              "line": 12,
+              "column": 7
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 121,
+                  "line": 12,
+                  "column": 7
+                },
+                "endPos": {
+                  "offset": 122,
+                  "line": 13,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 121,
+                "end": 122
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 120,
+            "end": 121
+          }
+        }
+      },
+      "start": 120,
+      "end": 121,
+      "name": "CompileError"
+    },
+    {
+      "code": 3017,
+      "diagnostic": "A TableGroup field should only have a single Table name",
+      "nodeOrToken": {
+        "id": 53,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 128,
+          "line": 13,
+          "column": 6
+        },
+        "fullStart": 128,
+        "endPos": {
+          "offset": 129,
+          "line": 13,
+          "column": 7
+        },
+        "fullEnd": 130,
+        "start": 128,
+        "end": 129,
+        "expression": {
+          "id": 52,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 128,
+            "line": 13,
+            "column": 6
+          },
+          "fullStart": 128,
+          "endPos": {
+            "offset": 129,
+            "line": 13,
+            "column": 7
+          },
+          "fullEnd": 130,
+          "start": 128,
+          "end": 129,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 128,
+              "line": 13,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 129,
+              "line": 13,
+              "column": 7
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 129,
+                  "line": 13,
+                  "column": 7
+                },
+                "endPos": {
+                  "offset": 130,
+                  "line": 13,
+                  "column": 8
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 129,
+                "end": 130
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 128,
+            "end": 129
+          }
+        }
+      },
+      "start": 128,
+      "end": 129,
+      "name": "CompileError"
+    },
+    {
+      "code": 3017,
+      "diagnostic": "A TableGroup field should only have a single Table name",
+      "nodeOrToken": {
+        "id": 55,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 130,
+          "line": 13,
+          "column": 8
+        },
+        "fullStart": 130,
+        "endPos": {
+          "offset": 131,
+          "line": 13,
+          "column": 9
+        },
+        "fullEnd": 132,
+        "start": 130,
+        "end": 131,
+        "expression": {
+          "id": 54,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 130,
+            "line": 13,
+            "column": 8
+          },
+          "fullStart": 130,
+          "endPos": {
+            "offset": 131,
+            "line": 13,
+            "column": 9
+          },
+          "fullEnd": 132,
+          "start": 130,
+          "end": 131,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 130,
+              "line": 13,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 131,
+              "line": 13,
+              "column": 9
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 131,
+                  "line": 13,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 132,
+                  "line": 14,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 131,
+                "end": 132
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 130,
+            "end": 131
+          }
+        }
+      },
+      "start": 130,
+      "end": 131,
+      "name": "CompileError"
+    },
+    {
+      "code": 3039,
+      "diagnostic": "A Ref field should only have a single binary relationship",
+      "nodeOrToken": {
+        "id": 76,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 175,
+          "line": 17,
+          "column": 34
+        },
+        "fullStart": 175,
+        "endPos": {
+          "offset": 176,
+          "line": 17,
+          "column": 35
+        },
+        "fullEnd": 177,
+        "start": 175,
+        "end": 176,
+        "expression": {
+          "id": 75,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 175,
+            "line": 17,
+            "column": 34
+          },
+          "fullStart": 175,
+          "endPos": {
+            "offset": 176,
+            "line": 17,
+            "column": 35
+          },
+          "fullEnd": 177,
+          "start": 175,
+          "end": 176,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 175,
+              "line": 17,
+              "column": 34
+            },
+            "endPos": {
+              "offset": 176,
+              "line": 17,
+              "column": 35
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 176,
+                  "line": 17,
+                  "column": 35
+                },
+                "endPos": {
+                  "offset": 177,
+                  "line": 18,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 176,
+                "end": 177
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 175,
+            "end": 176
+          }
+        }
+      },
+      "start": 175,
+      "end": 176,
+      "name": "CompileError"
+    },
+    {
+      "code": 3039,
+      "diagnostic": "A Ref field should only have a single binary relationship",
+      "nodeOrToken": {
+        "id": 92,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 202,
+          "line": 21,
+          "column": 16
+        },
+        "fullStart": 202,
+        "endPos": {
+          "offset": 203,
+          "line": 21,
+          "column": 17
+        },
+        "fullEnd": 204,
+        "start": 202,
+        "end": 203,
+        "expression": {
+          "id": 91,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 202,
+            "line": 21,
+            "column": 16
+          },
+          "fullStart": 202,
+          "endPos": {
+            "offset": 203,
+            "line": 21,
+            "column": 17
+          },
+          "fullEnd": 204,
+          "start": 202,
+          "end": 203,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 202,
+              "line": 21,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 203,
+              "line": 21,
+              "column": 17
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 203,
+                  "line": 21,
+                  "column": 17
+                },
+                "endPos": {
+                  "offset": 204,
+                  "line": 21,
+                  "column": 18
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 203,
+                "end": 204
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 202,
+            "end": 203
+          }
+        }
+      },
+      "start": 202,
+      "end": 203,
+      "name": "CompileError"
+    },
+    {
+      "code": 3039,
+      "diagnostic": "A Ref field should only have a single binary relationship",
+      "nodeOrToken": {
+        "id": 113,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 247,
+          "line": 25,
+          "column": 16
+        },
+        "fullStart": 247,
+        "endPos": {
+          "offset": 248,
+          "line": 25,
+          "column": 17
+        },
+        "fullEnd": 249,
+        "start": 247,
+        "end": 248,
+        "expression": {
+          "id": 112,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 247,
+            "line": 25,
+            "column": 16
+          },
+          "fullStart": 247,
+          "endPos": {
+            "offset": 248,
+            "line": 25,
+            "column": 17
+          },
+          "fullEnd": 249,
+          "start": 247,
+          "end": 248,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 247,
+              "line": 25,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 248,
+              "line": 25,
+              "column": 17
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 248,
+                  "line": 25,
+                  "column": 17
+                },
+                "endPos": {
+                  "offset": 249,
+                  "line": 25,
+                  "column": 18
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 248,
+                "end": 249
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 247,
+            "end": 248
+          }
+        }
+      },
+      "start": 247,
+      "end": 248,
+      "name": "CompileError"
+    },
+    {
+      "code": 3039,
+      "diagnostic": "A Ref field should only have a single binary relationship",
+      "nodeOrToken": {
+        "id": 115,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 249,
+          "line": 25,
+          "column": 18
+        },
+        "fullStart": 249,
+        "endPos": {
+          "offset": 250,
+          "line": 25,
+          "column": 19
+        },
+        "fullEnd": 251,
+        "start": 249,
+        "end": 250,
+        "expression": {
+          "id": 114,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 249,
+            "line": 25,
+            "column": 18
+          },
+          "fullStart": 249,
+          "endPos": {
+            "offset": 250,
+            "line": 25,
+            "column": 19
+          },
+          "fullEnd": 251,
+          "start": 249,
+          "end": 250,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 249,
+              "line": 25,
+              "column": 18
+            },
+            "endPos": {
+              "offset": 250,
+              "line": 25,
+              "column": 19
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 250,
+                  "line": 25,
+                  "column": 19
+                },
+                "endPos": {
+                  "offset": 251,
+                  "line": 26,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 250,
+                "end": 251
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 249,
+            "end": 250
+          }
+        }
+      },
+      "start": 249,
+      "end": 250,
+      "name": "CompileError"
+    }
+  ]
+}

--- a/packages/dbml-parse/tests/validator/output/invalid_args.out.json
+++ b/packages/dbml-parse/tests/validator/output/invalid_args.out.json
@@ -1,6 +1,6 @@
 {
   "value": {
-    "id": 119,
+    "id": 140,
     "kind": "<program>",
     "startPos": {
       "offset": 0,
@@ -9,13 +9,13 @@
     },
     "fullStart": 0,
     "endPos": {
-      "offset": 252,
-      "line": 26,
+      "offset": 291,
+      "line": 31,
       "column": 1
     },
-    "fullEnd": 252,
+    "fullEnd": 291,
     "start": 0,
-    "end": 252,
+    "end": 291,
     "body": [
       {
         "id": 11,
@@ -710,11 +710,11 @@
             "end": 31
           }
         },
-        "parent": 119,
+        "parent": 140,
         "symbol": 1
       },
       {
-        "id": 42,
+        "id": 47,
         "kind": "<element-declaration>",
         "startPos": {
           "offset": 33,
@@ -723,13 +723,13 @@
         },
         "fullStart": 32,
         "endPos": {
-          "offset": 97,
-          "line": 9,
+          "offset": 109,
+          "line": 10,
           "column": 1
         },
-        "fullEnd": 98,
+        "fullEnd": 110,
         "start": 33,
-        "end": 97,
+        "end": 109,
         "type": {
           "kind": "<identifier>",
           "startPos": {
@@ -875,7 +875,7 @@
           }
         },
         "body": {
-          "id": 41,
+          "id": 46,
           "kind": "<block-expression>",
           "startPos": {
             "offset": 40,
@@ -884,13 +884,13 @@
           },
           "fullStart": 40,
           "endPos": {
-            "offset": 97,
-            "line": 9,
+            "offset": 109,
+            "line": 10,
             "column": 1
           },
-          "fullEnd": 98,
+          "fullEnd": 110,
           "start": 40,
-          "end": 97,
+          "end": 109,
           "blockOpenBrace": {
             "kind": "<lbrace>",
             "startPos": {
@@ -945,13 +945,13 @@
               },
               "fullStart": 42,
               "endPos": {
-                "offset": 63,
+                "offset": 64,
                 "line": 6,
-                "column": 21
+                "column": 22
               },
-              "fullEnd": 64,
+              "fullEnd": 65,
               "start": 46,
-              "end": 63,
+              "end": 64,
               "callee": {
                 "id": 15,
                 "kind": "<primary-expression>",
@@ -962,13 +962,13 @@
                 },
                 "fullStart": 42,
                 "endPos": {
-                  "offset": 47,
+                  "offset": 48,
                   "line": 6,
-                  "column": 5
+                  "column": 6
                 },
-                "fullEnd": 48,
+                "fullEnd": 49,
                 "start": 46,
-                "end": 47,
+                "end": 48,
                 "expression": {
                   "id": 14,
                   "kind": "<variable>",
@@ -979,13 +979,13 @@
                   },
                   "fullStart": 42,
                   "endPos": {
-                    "offset": 47,
+                    "offset": 48,
                     "line": 6,
-                    "column": 5
+                    "column": 6
                   },
-                  "fullEnd": 48,
+                  "fullEnd": 49,
                   "start": 46,
-                  "end": 47,
+                  "end": 48,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
@@ -994,11 +994,11 @@
                       "column": 4
                     },
                     "endPos": {
-                      "offset": 47,
+                      "offset": 48,
                       "line": 6,
-                      "column": 5
+                      "column": 6
                     },
-                    "value": "a",
+                    "value": "a1",
                     "leadingTrivia": [
                       {
                         "kind": "<space>",
@@ -1089,14 +1089,14 @@
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 47,
-                          "line": 6,
-                          "column": 5
-                        },
-                        "endPos": {
                           "offset": 48,
                           "line": 6,
                           "column": 6
+                        },
+                        "endPos": {
+                          "offset": 49,
+                          "line": 6,
+                          "column": 7
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1104,15 +1104,15 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 47,
-                        "end": 48
+                        "start": 48,
+                        "end": 49
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
                     "start": 46,
-                    "end": 47
+                    "end": 48
                   }
                 }
               },
@@ -1121,47 +1121,47 @@
                   "id": 17,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 48,
-                    "line": 6,
-                    "column": 6
-                  },
-                  "fullStart": 48,
-                  "endPos": {
                     "offset": 49,
                     "line": 6,
                     "column": 7
                   },
-                  "fullEnd": 50,
-                  "start": 48,
-                  "end": 49,
+                  "fullStart": 49,
+                  "endPos": {
+                    "offset": 50,
+                    "line": 6,
+                    "column": 8
+                  },
+                  "fullEnd": 51,
+                  "start": 49,
+                  "end": 50,
                   "expression": {
                     "id": 16,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 48,
-                      "line": 6,
-                      "column": 6
-                    },
-                    "fullStart": 48,
-                    "endPos": {
                       "offset": 49,
                       "line": 6,
                       "column": 7
                     },
-                    "fullEnd": 50,
-                    "start": 48,
-                    "end": 49,
+                    "fullStart": 49,
+                    "endPos": {
+                      "offset": 50,
+                      "line": 6,
+                      "column": 8
+                    },
+                    "fullEnd": 51,
+                    "start": 49,
+                    "end": 50,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 48,
-                        "line": 6,
-                        "column": 6
-                      },
-                      "endPos": {
                         "offset": 49,
                         "line": 6,
                         "column": 7
+                      },
+                      "endPos": {
+                        "offset": 50,
+                        "line": 6,
+                        "column": 8
                       },
                       "value": "e",
                       "leadingTrivia": [],
@@ -1169,14 +1169,14 @@
                         {
                           "kind": "<space>",
                           "startPos": {
-                            "offset": 49,
-                            "line": 6,
-                            "column": 7
-                          },
-                          "endPos": {
                             "offset": 50,
                             "line": 6,
                             "column": 8
+                          },
+                          "endPos": {
+                            "offset": 51,
+                            "line": 6,
+                            "column": 9
                           },
                           "value": " ",
                           "leadingTrivia": [],
@@ -1184,15 +1184,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 49,
-                          "end": 50
+                          "start": 50,
+                          "end": 51
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 48,
-                      "end": 49
+                      "start": 49,
+                      "end": 50
                     }
                   }
                 },
@@ -1200,30 +1200,30 @@
                   "id": 22,
                   "kind": "<list-expression>",
                   "startPos": {
-                    "offset": 50,
+                    "offset": 51,
                     "line": 6,
-                    "column": 8
+                    "column": 9
                   },
-                  "fullStart": 50,
+                  "fullStart": 51,
                   "endPos": {
-                    "offset": 63,
+                    "offset": 64,
                     "line": 6,
-                    "column": 21
+                    "column": 22
                   },
-                  "fullEnd": 64,
-                  "start": 50,
-                  "end": 63,
+                  "fullEnd": 65,
+                  "start": 51,
+                  "end": 64,
                   "listOpenBracket": {
                     "kind": "<lbracket>",
                     "startPos": {
-                      "offset": 50,
-                      "line": 6,
-                      "column": 8
-                    },
-                    "endPos": {
                       "offset": 51,
                       "line": 6,
                       "column": 9
+                    },
+                    "endPos": {
+                      "offset": 52,
+                      "line": 6,
+                      "column": 10
                     },
                     "value": "[",
                     "leadingTrivia": [],
@@ -1231,56 +1231,56 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 50,
-                    "end": 51
+                    "start": 51,
+                    "end": 52
                   },
                   "elementList": [
                     {
                       "id": 21,
                       "kind": "<attribute>",
                       "startPos": {
-                        "offset": 51,
+                        "offset": 52,
                         "line": 6,
-                        "column": 9
+                        "column": 10
                       },
-                      "fullStart": 51,
+                      "fullStart": 52,
                       "endPos": {
-                        "offset": 62,
+                        "offset": 63,
                         "line": 6,
-                        "column": 20
+                        "column": 21
                       },
-                      "fullEnd": 62,
-                      "start": 51,
-                      "end": 62,
+                      "fullEnd": 63,
+                      "start": 52,
+                      "end": 63,
                       "name": {
                         "id": 18,
                         "kind": "<identifer-stream>",
                         "startPos": {
-                          "offset": 51,
+                          "offset": 52,
                           "line": 6,
-                          "column": 9
+                          "column": 10
                         },
-                        "fullStart": 51,
+                        "fullStart": 52,
                         "endPos": {
-                          "offset": 55,
+                          "offset": 56,
                           "line": 6,
-                          "column": 13
+                          "column": 14
                         },
-                        "fullEnd": 55,
-                        "start": 51,
-                        "end": 55,
+                        "fullEnd": 56,
+                        "start": 52,
+                        "end": 56,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
                             "startPos": {
-                              "offset": 51,
+                              "offset": 52,
                               "line": 6,
-                              "column": 9
+                              "column": 10
                             },
                             "endPos": {
-                              "offset": 55,
+                              "offset": 56,
                               "line": 6,
-                              "column": 13
+                              "column": 14
                             },
                             "value": "note",
                             "leadingTrivia": [],
@@ -1288,8 +1288,8 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 51,
-                            "end": 55
+                            "start": 52,
+                            "end": 56
                           }
                         ]
                       },
@@ -1297,47 +1297,47 @@
                         "id": 20,
                         "kind": "<primary-expression>",
                         "startPos": {
-                          "offset": 57,
+                          "offset": 58,
                           "line": 6,
-                          "column": 15
+                          "column": 16
                         },
-                        "fullStart": 57,
+                        "fullStart": 58,
                         "endPos": {
-                          "offset": 62,
+                          "offset": 63,
                           "line": 6,
-                          "column": 20
+                          "column": 21
                         },
-                        "fullEnd": 62,
-                        "start": 57,
-                        "end": 62,
+                        "fullEnd": 63,
+                        "start": 58,
+                        "end": 63,
                         "expression": {
                           "id": 19,
                           "kind": "<literal>",
                           "startPos": {
-                            "offset": 57,
+                            "offset": 58,
                             "line": 6,
-                            "column": 15
+                            "column": 16
                           },
-                          "fullStart": 57,
+                          "fullStart": 58,
                           "endPos": {
-                            "offset": 62,
+                            "offset": 63,
                             "line": 6,
-                            "column": 20
+                            "column": 21
                           },
-                          "fullEnd": 62,
-                          "start": 57,
-                          "end": 62,
+                          "fullEnd": 63,
+                          "start": 58,
+                          "end": 63,
                           "literal": {
                             "kind": "<string>",
                             "startPos": {
-                              "offset": 57,
+                              "offset": 58,
                               "line": 6,
-                              "column": 15
+                              "column": 16
                             },
                             "endPos": {
-                              "offset": 62,
+                              "offset": 63,
                               "line": 6,
-                              "column": 20
+                              "column": 21
                             },
                             "value": "abc",
                             "leadingTrivia": [],
@@ -1345,22 +1345,22 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 57,
-                            "end": 62
+                            "start": 58,
+                            "end": 63
                           }
                         }
                       },
                       "colon": {
                         "kind": "<colon>",
                         "startPos": {
-                          "offset": 55,
-                          "line": 6,
-                          "column": 13
-                        },
-                        "endPos": {
                           "offset": 56,
                           "line": 6,
                           "column": 14
+                        },
+                        "endPos": {
+                          "offset": 57,
+                          "line": 6,
+                          "column": 15
                         },
                         "value": ":",
                         "leadingTrivia": [],
@@ -1368,14 +1368,14 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 56,
-                              "line": 6,
-                              "column": 14
-                            },
-                            "endPos": {
                               "offset": 57,
                               "line": 6,
                               "column": 15
+                            },
+                            "endPos": {
+                              "offset": 58,
+                              "line": 6,
+                              "column": 16
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -1383,15 +1383,15 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 56,
-                            "end": 57
+                            "start": 57,
+                            "end": 58
                           }
                         ],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 55,
-                        "end": 56
+                        "start": 56,
+                        "end": 57
                       }
                     }
                   ],
@@ -1399,14 +1399,14 @@
                   "listCloseBracket": {
                     "kind": "<rbracket>",
                     "startPos": {
-                      "offset": 62,
-                      "line": 6,
-                      "column": 20
-                    },
-                    "endPos": {
                       "offset": 63,
                       "line": 6,
                       "column": 21
+                    },
+                    "endPos": {
+                      "offset": 64,
+                      "line": 6,
+                      "column": 22
                     },
                     "value": "]",
                     "leadingTrivia": [],
@@ -1414,12 +1414,12 @@
                       {
                         "kind": "<newline>",
                         "startPos": {
-                          "offset": 63,
+                          "offset": 64,
                           "line": 6,
-                          "column": 21
+                          "column": 22
                         },
                         "endPos": {
-                          "offset": 64,
+                          "offset": 65,
                           "line": 7,
                           "column": 0
                         },
@@ -1429,15 +1429,15 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 63,
-                        "end": 64
+                        "start": 64,
+                        "end": 65
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 62,
-                    "end": 63
+                    "start": 63,
+                    "end": 64
                   }
                 }
               ],
@@ -1447,99 +1447,78 @@
               "id": 33,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 68,
+                "offset": 69,
                 "line": 7,
                 "column": 4
               },
-              "fullStart": 64,
+              "fullStart": 65,
               "endPos": {
-                "offset": 85,
+                "offset": 87,
                 "line": 7,
-                "column": 21
+                "column": 22
               },
-              "fullEnd": 86,
-              "start": 68,
-              "end": 85,
+              "fullEnd": 88,
+              "start": 69,
+              "end": 87,
               "callee": {
                 "id": 25,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 68,
+                  "offset": 69,
                   "line": 7,
                   "column": 4
                 },
-                "fullStart": 64,
+                "fullStart": 65,
                 "endPos": {
-                  "offset": 69,
+                  "offset": 71,
                   "line": 7,
-                  "column": 5
+                  "column": 6
                 },
-                "fullEnd": 70,
-                "start": 68,
-                "end": 69,
+                "fullEnd": 72,
+                "start": 69,
+                "end": 71,
                 "expression": {
                   "id": 24,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 68,
+                    "offset": 69,
                     "line": 7,
                     "column": 4
                   },
-                  "fullStart": 64,
+                  "fullStart": 65,
                   "endPos": {
-                    "offset": 69,
+                    "offset": 71,
                     "line": 7,
-                    "column": 5
+                    "column": 6
                   },
-                  "fullEnd": 70,
-                  "start": 68,
-                  "end": 69,
+                  "fullEnd": 72,
+                  "start": 69,
+                  "end": 71,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 68,
+                      "offset": 69,
                       "line": 7,
                       "column": 4
                     },
                     "endPos": {
-                      "offset": 69,
+                      "offset": 71,
                       "line": 7,
-                      "column": 5
+                      "column": 6
                     },
-                    "value": "a",
+                    "value": "a2",
                     "leadingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 64,
+                          "offset": 65,
                           "line": 7,
                           "column": 0
                         },
                         "endPos": {
-                          "offset": 65,
-                          "line": 7,
-                          "column": 1
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 64,
-                        "end": 65
-                      },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 65,
-                          "line": 7,
-                          "column": 1
-                        },
-                        "endPos": {
                           "offset": 66,
                           "line": 7,
-                          "column": 2
+                          "column": 1
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1555,12 +1534,12 @@
                         "startPos": {
                           "offset": 66,
                           "line": 7,
-                          "column": 2
+                          "column": 1
                         },
                         "endPos": {
                           "offset": 67,
                           "line": 7,
-                          "column": 3
+                          "column": 2
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1576,12 +1555,12 @@
                         "startPos": {
                           "offset": 67,
                           "line": 7,
-                          "column": 3
+                          "column": 2
                         },
                         "endPos": {
                           "offset": 68,
                           "line": 7,
-                          "column": 4
+                          "column": 3
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1591,20 +1570,18 @@
                         "isInvalid": false,
                         "start": 67,
                         "end": 68
-                      }
-                    ],
-                    "trailingTrivia": [
+                      },
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 69,
+                          "offset": 68,
                           "line": 7,
-                          "column": 5
+                          "column": 3
                         },
                         "endPos": {
-                          "offset": 70,
+                          "offset": 69,
                           "line": 7,
-                          "column": 6
+                          "column": 4
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1612,15 +1589,38 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 69,
-                        "end": 70
+                        "start": 68,
+                        "end": 69
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 71,
+                          "line": 7,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 72,
+                          "line": 7,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 71,
+                        "end": 72
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 68,
-                    "end": 69
+                    "start": 69,
+                    "end": 71
                   }
                 }
               },
@@ -1629,30 +1629,30 @@
                   "id": 30,
                   "kind": "<list-expression>",
                   "startPos": {
-                    "offset": 70,
+                    "offset": 72,
                     "line": 7,
-                    "column": 6
+                    "column": 7
                   },
-                  "fullStart": 70,
+                  "fullStart": 72,
                   "endPos": {
-                    "offset": 83,
+                    "offset": 85,
                     "line": 7,
-                    "column": 19
+                    "column": 20
                   },
-                  "fullEnd": 84,
-                  "start": 70,
-                  "end": 83,
+                  "fullEnd": 86,
+                  "start": 72,
+                  "end": 85,
                   "listOpenBracket": {
                     "kind": "<lbracket>",
                     "startPos": {
-                      "offset": 70,
-                      "line": 7,
-                      "column": 6
-                    },
-                    "endPos": {
-                      "offset": 71,
+                      "offset": 72,
                       "line": 7,
                       "column": 7
+                    },
+                    "endPos": {
+                      "offset": 73,
+                      "line": 7,
+                      "column": 8
                     },
                     "value": "[",
                     "leadingTrivia": [],
@@ -1660,56 +1660,56 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 70,
-                    "end": 71
+                    "start": 72,
+                    "end": 73
                   },
                   "elementList": [
                     {
                       "id": 29,
                       "kind": "<attribute>",
                       "startPos": {
-                        "offset": 71,
+                        "offset": 73,
                         "line": 7,
-                        "column": 7
+                        "column": 8
                       },
-                      "fullStart": 71,
+                      "fullStart": 73,
                       "endPos": {
-                        "offset": 82,
+                        "offset": 84,
                         "line": 7,
-                        "column": 18
+                        "column": 19
                       },
-                      "fullEnd": 82,
-                      "start": 71,
-                      "end": 82,
+                      "fullEnd": 84,
+                      "start": 73,
+                      "end": 84,
                       "name": {
                         "id": 26,
                         "kind": "<identifer-stream>",
                         "startPos": {
-                          "offset": 71,
+                          "offset": 73,
                           "line": 7,
-                          "column": 7
+                          "column": 8
                         },
-                        "fullStart": 71,
+                        "fullStart": 73,
                         "endPos": {
-                          "offset": 75,
+                          "offset": 77,
                           "line": 7,
-                          "column": 11
+                          "column": 12
                         },
-                        "fullEnd": 75,
-                        "start": 71,
-                        "end": 75,
+                        "fullEnd": 77,
+                        "start": 73,
+                        "end": 77,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
                             "startPos": {
-                              "offset": 71,
+                              "offset": 73,
                               "line": 7,
-                              "column": 7
+                              "column": 8
                             },
                             "endPos": {
-                              "offset": 75,
+                              "offset": 77,
                               "line": 7,
-                              "column": 11
+                              "column": 12
                             },
                             "value": "note",
                             "leadingTrivia": [],
@@ -1717,8 +1717,8 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 71,
-                            "end": 75
+                            "start": 73,
+                            "end": 77
                           }
                         ]
                       },
@@ -1726,47 +1726,47 @@
                         "id": 28,
                         "kind": "<primary-expression>",
                         "startPos": {
-                          "offset": 77,
+                          "offset": 79,
                           "line": 7,
-                          "column": 13
+                          "column": 14
                         },
-                        "fullStart": 77,
+                        "fullStart": 79,
                         "endPos": {
-                          "offset": 82,
+                          "offset": 84,
                           "line": 7,
-                          "column": 18
+                          "column": 19
                         },
-                        "fullEnd": 82,
-                        "start": 77,
-                        "end": 82,
+                        "fullEnd": 84,
+                        "start": 79,
+                        "end": 84,
                         "expression": {
                           "id": 27,
                           "kind": "<literal>",
                           "startPos": {
-                            "offset": 77,
+                            "offset": 79,
                             "line": 7,
-                            "column": 13
+                            "column": 14
                           },
-                          "fullStart": 77,
+                          "fullStart": 79,
                           "endPos": {
-                            "offset": 82,
+                            "offset": 84,
                             "line": 7,
-                            "column": 18
+                            "column": 19
                           },
-                          "fullEnd": 82,
-                          "start": 77,
-                          "end": 82,
+                          "fullEnd": 84,
+                          "start": 79,
+                          "end": 84,
                           "literal": {
                             "kind": "<string>",
                             "startPos": {
-                              "offset": 77,
+                              "offset": 79,
                               "line": 7,
-                              "column": 13
+                              "column": 14
                             },
                             "endPos": {
-                              "offset": 82,
+                              "offset": 84,
                               "line": 7,
-                              "column": 18
+                              "column": 19
                             },
                             "value": "abc",
                             "leadingTrivia": [],
@@ -1774,22 +1774,22 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 77,
-                            "end": 82
+                            "start": 79,
+                            "end": 84
                           }
                         }
                       },
                       "colon": {
                         "kind": "<colon>",
                         "startPos": {
-                          "offset": 75,
-                          "line": 7,
-                          "column": 11
-                        },
-                        "endPos": {
-                          "offset": 76,
+                          "offset": 77,
                           "line": 7,
                           "column": 12
+                        },
+                        "endPos": {
+                          "offset": 78,
+                          "line": 7,
+                          "column": 13
                         },
                         "value": ":",
                         "leadingTrivia": [],
@@ -1797,14 +1797,14 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 76,
-                              "line": 7,
-                              "column": 12
-                            },
-                            "endPos": {
-                              "offset": 77,
+                              "offset": 78,
                               "line": 7,
                               "column": 13
+                            },
+                            "endPos": {
+                              "offset": 79,
+                              "line": 7,
+                              "column": 14
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -1812,15 +1812,15 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 76,
-                            "end": 77
+                            "start": 78,
+                            "end": 79
                           }
                         ],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 75,
-                        "end": 76
+                        "start": 77,
+                        "end": 78
                       }
                     }
                   ],
@@ -1828,14 +1828,14 @@
                   "listCloseBracket": {
                     "kind": "<rbracket>",
                     "startPos": {
-                      "offset": 82,
-                      "line": 7,
-                      "column": 18
-                    },
-                    "endPos": {
-                      "offset": 83,
+                      "offset": 84,
                       "line": 7,
                       "column": 19
+                    },
+                    "endPos": {
+                      "offset": 85,
+                      "line": 7,
+                      "column": 20
                     },
                     "value": "]",
                     "leadingTrivia": [],
@@ -1843,14 +1843,14 @@
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 83,
-                          "line": 7,
-                          "column": 19
-                        },
-                        "endPos": {
-                          "offset": 84,
+                          "offset": 85,
                           "line": 7,
                           "column": 20
+                        },
+                        "endPos": {
+                          "offset": 86,
+                          "line": 7,
+                          "column": 21
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -1858,62 +1858,62 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 83,
-                        "end": 84
+                        "start": 85,
+                        "end": 86
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 82,
-                    "end": 83
+                    "start": 84,
+                    "end": 85
                   }
                 },
                 {
                   "id": 32,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 84,
-                    "line": 7,
-                    "column": 20
-                  },
-                  "fullStart": 84,
-                  "endPos": {
-                    "offset": 85,
+                    "offset": 86,
                     "line": 7,
                     "column": 21
                   },
-                  "fullEnd": 86,
-                  "start": 84,
-                  "end": 85,
+                  "fullStart": 86,
+                  "endPos": {
+                    "offset": 87,
+                    "line": 7,
+                    "column": 22
+                  },
+                  "fullEnd": 88,
+                  "start": 86,
+                  "end": 87,
                   "expression": {
                     "id": 31,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 84,
-                      "line": 7,
-                      "column": 20
-                    },
-                    "fullStart": 84,
-                    "endPos": {
-                      "offset": 85,
+                      "offset": 86,
                       "line": 7,
                       "column": 21
                     },
-                    "fullEnd": 86,
-                    "start": 84,
-                    "end": 85,
+                    "fullStart": 86,
+                    "endPos": {
+                      "offset": 87,
+                      "line": 7,
+                      "column": 22
+                    },
+                    "fullEnd": 88,
+                    "start": 86,
+                    "end": 87,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 84,
-                        "line": 7,
-                        "column": 20
-                      },
-                      "endPos": {
-                        "offset": 85,
+                        "offset": 86,
                         "line": 7,
                         "column": 21
+                      },
+                      "endPos": {
+                        "offset": 87,
+                        "line": 7,
+                        "column": 22
                       },
                       "value": "e",
                       "leadingTrivia": [],
@@ -1921,12 +1921,12 @@
                         {
                           "kind": "<newline>",
                           "startPos": {
-                            "offset": 85,
+                            "offset": 87,
                             "line": 7,
-                            "column": 21
+                            "column": 22
                           },
                           "endPos": {
-                            "offset": 86,
+                            "offset": 88,
                             "line": 8,
                             "column": 0
                           },
@@ -1936,15 +1936,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 85,
-                          "end": 86
+                          "start": 87,
+                          "end": 88
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 84,
-                      "end": 85
+                      "start": 86,
+                      "end": 87
                     }
                   }
                 }
@@ -1955,120 +1955,78 @@
               "id": 40,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 90,
+                "offset": 92,
                 "line": 8,
                 "column": 4
               },
-              "fullStart": 86,
+              "fullStart": 88,
               "endPos": {
-                "offset": 95,
+                "offset": 98,
                 "line": 8,
-                "column": 9
+                "column": 10
               },
-              "fullEnd": 96,
-              "start": 90,
-              "end": 95,
+              "fullEnd": 99,
+              "start": 92,
+              "end": 98,
               "callee": {
                 "id": 35,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 90,
+                  "offset": 92,
                   "line": 8,
                   "column": 4
                 },
-                "fullStart": 86,
+                "fullStart": 88,
                 "endPos": {
-                  "offset": 91,
+                  "offset": 94,
                   "line": 8,
-                  "column": 5
+                  "column": 6
                 },
-                "fullEnd": 92,
-                "start": 90,
-                "end": 91,
+                "fullEnd": 95,
+                "start": 92,
+                "end": 94,
                 "expression": {
                   "id": 34,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 90,
+                    "offset": 92,
                     "line": 8,
                     "column": 4
                   },
-                  "fullStart": 86,
+                  "fullStart": 88,
                   "endPos": {
-                    "offset": 91,
+                    "offset": 94,
                     "line": 8,
-                    "column": 5
+                    "column": 6
                   },
-                  "fullEnd": 92,
-                  "start": 90,
-                  "end": 91,
+                  "fullEnd": 95,
+                  "start": 92,
+                  "end": 94,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 90,
+                      "offset": 92,
                       "line": 8,
                       "column": 4
                     },
                     "endPos": {
-                      "offset": 91,
+                      "offset": 94,
                       "line": 8,
-                      "column": 5
+                      "column": 6
                     },
-                    "value": "a",
+                    "value": "a3",
                     "leadingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 86,
+                          "offset": 88,
                           "line": 8,
                           "column": 0
                         },
                         "endPos": {
-                          "offset": 87,
-                          "line": 8,
-                          "column": 1
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 86,
-                        "end": 87
-                      },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 87,
-                          "line": 8,
-                          "column": 1
-                        },
-                        "endPos": {
-                          "offset": 88,
-                          "line": 8,
-                          "column": 2
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 87,
-                        "end": 88
-                      },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 88,
-                          "line": 8,
-                          "column": 2
-                        },
-                        "endPos": {
                           "offset": 89,
                           "line": 8,
-                          "column": 3
+                          "column": 1
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -2084,12 +2042,12 @@
                         "startPos": {
                           "offset": 89,
                           "line": 8,
-                          "column": 3
+                          "column": 1
                         },
                         "endPos": {
                           "offset": 90,
                           "line": 8,
-                          "column": 4
+                          "column": 2
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -2099,20 +2057,39 @@
                         "isInvalid": false,
                         "start": 89,
                         "end": 90
-                      }
-                    ],
-                    "trailingTrivia": [
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 90,
+                          "line": 8,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 91,
+                          "line": 8,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 90,
+                        "end": 91
+                      },
                       {
                         "kind": "<space>",
                         "startPos": {
                           "offset": 91,
                           "line": 8,
-                          "column": 5
+                          "column": 3
                         },
                         "endPos": {
                           "offset": 92,
                           "line": 8,
-                          "column": 6
+                          "column": 4
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -2124,11 +2101,34 @@
                         "end": 92
                       }
                     ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 94,
+                          "line": 8,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 95,
+                          "line": 8,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 94,
+                        "end": 95
+                      }
+                    ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 90,
-                    "end": 91
+                    "start": 92,
+                    "end": 94
                   }
                 }
               },
@@ -2137,47 +2137,47 @@
                   "id": 37,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 92,
-                    "line": 8,
-                    "column": 6
-                  },
-                  "fullStart": 92,
-                  "endPos": {
-                    "offset": 93,
+                    "offset": 95,
                     "line": 8,
                     "column": 7
                   },
-                  "fullEnd": 94,
-                  "start": 92,
-                  "end": 93,
+                  "fullStart": 95,
+                  "endPos": {
+                    "offset": 96,
+                    "line": 8,
+                    "column": 8
+                  },
+                  "fullEnd": 97,
+                  "start": 95,
+                  "end": 96,
                   "expression": {
                     "id": 36,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 92,
-                      "line": 8,
-                      "column": 6
-                    },
-                    "fullStart": 92,
-                    "endPos": {
-                      "offset": 93,
+                      "offset": 95,
                       "line": 8,
                       "column": 7
                     },
-                    "fullEnd": 94,
-                    "start": 92,
-                    "end": 93,
+                    "fullStart": 95,
+                    "endPos": {
+                      "offset": 96,
+                      "line": 8,
+                      "column": 8
+                    },
+                    "fullEnd": 97,
+                    "start": 95,
+                    "end": 96,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 92,
-                        "line": 8,
-                        "column": 6
-                      },
-                      "endPos": {
-                        "offset": 93,
+                        "offset": 95,
                         "line": 8,
                         "column": 7
+                      },
+                      "endPos": {
+                        "offset": 96,
+                        "line": 8,
+                        "column": 8
                       },
                       "value": "e",
                       "leadingTrivia": [],
@@ -2185,14 +2185,14 @@
                         {
                           "kind": "<space>",
                           "startPos": {
-                            "offset": 93,
-                            "line": 8,
-                            "column": 7
-                          },
-                          "endPos": {
-                            "offset": 94,
+                            "offset": 96,
                             "line": 8,
                             "column": 8
+                          },
+                          "endPos": {
+                            "offset": 97,
+                            "line": 8,
+                            "column": 9
                           },
                           "value": " ",
                           "leadingTrivia": [],
@@ -2200,15 +2200,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 93,
-                          "end": 94
+                          "start": 96,
+                          "end": 97
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 92,
-                      "end": 93
+                      "start": 95,
+                      "end": 96
                     }
                   }
                 },
@@ -2216,47 +2216,47 @@
                   "id": 39,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 94,
-                    "line": 8,
-                    "column": 8
-                  },
-                  "fullStart": 94,
-                  "endPos": {
-                    "offset": 95,
+                    "offset": 97,
                     "line": 8,
                     "column": 9
                   },
-                  "fullEnd": 96,
-                  "start": 94,
-                  "end": 95,
+                  "fullStart": 97,
+                  "endPos": {
+                    "offset": 98,
+                    "line": 8,
+                    "column": 10
+                  },
+                  "fullEnd": 99,
+                  "start": 97,
+                  "end": 98,
                   "expression": {
                     "id": 38,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 94,
-                      "line": 8,
-                      "column": 8
-                    },
-                    "fullStart": 94,
-                    "endPos": {
-                      "offset": 95,
+                      "offset": 97,
                       "line": 8,
                       "column": 9
                     },
-                    "fullEnd": 96,
-                    "start": 94,
-                    "end": 95,
+                    "fullStart": 97,
+                    "endPos": {
+                      "offset": 98,
+                      "line": 8,
+                      "column": 10
+                    },
+                    "fullEnd": 99,
+                    "start": 97,
+                    "end": 98,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 94,
-                        "line": 8,
-                        "column": 8
-                      },
-                      "endPos": {
-                        "offset": 95,
+                        "offset": 97,
                         "line": 8,
                         "column": 9
+                      },
+                      "endPos": {
+                        "offset": 98,
+                        "line": 8,
+                        "column": 10
                       },
                       "value": "f",
                       "leadingTrivia": [],
@@ -2264,12 +2264,12 @@
                         {
                           "kind": "<newline>",
                           "startPos": {
-                            "offset": 95,
+                            "offset": 98,
                             "line": 8,
-                            "column": 9
+                            "column": 10
                           },
                           "endPos": {
-                            "offset": 96,
+                            "offset": 99,
                             "line": 9,
                             "column": 0
                           },
@@ -2279,366 +2279,96 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 95,
-                          "end": 96
+                          "start": 98,
+                          "end": 99
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 94,
-                      "end": 95
+                      "start": 97,
+                      "end": 98
                     }
                   }
                 }
               ],
               "symbol": 7
-            }
-          ],
-          "blockCloseBrace": {
-            "kind": "<rbrace>",
-            "startPos": {
-              "offset": 96,
-              "line": 9,
-              "column": 0
             },
-            "endPos": {
-              "offset": 97,
-              "line": 9,
-              "column": 1
-            },
-            "value": "}",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<newline>",
-                "startPos": {
-                  "offset": 97,
-                  "line": 9,
-                  "column": 1
-                },
-                "endPos": {
-                  "offset": 98,
-                  "line": 10,
-                  "column": 0
-                },
-                "value": "\n",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 97,
-                "end": 98
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 96,
-            "end": 97
-          }
-        },
-        "parent": 119,
-        "symbol": 4
-      },
-      {
-        "id": 58,
-        "kind": "<element-declaration>",
-        "startPos": {
-          "offset": 99,
-          "line": 11,
-          "column": 0
-        },
-        "fullStart": 98,
-        "endPos": {
-          "offset": 133,
-          "line": 14,
-          "column": 1
-        },
-        "fullEnd": 134,
-        "start": 99,
-        "end": 133,
-        "type": {
-          "kind": "<identifier>",
-          "startPos": {
-            "offset": 99,
-            "line": 11,
-            "column": 0
-          },
-          "endPos": {
-            "offset": 109,
-            "line": 11,
-            "column": 10
-          },
-          "value": "TableGroup",
-          "leadingTrivia": [
             {
-              "kind": "<newline>",
-              "startPos": {
-                "offset": 98,
-                "line": 10,
-                "column": 0
-              },
-              "endPos": {
-                "offset": 99,
-                "line": 11,
-                "column": 0
-              },
-              "value": "\n",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 98,
-              "end": 99
-            }
-          ],
-          "trailingTrivia": [
-            {
-              "kind": "<space>",
-              "startPos": {
-                "offset": 109,
-                "line": 11,
-                "column": 10
-              },
-              "endPos": {
-                "offset": 110,
-                "line": 11,
-                "column": 11
-              },
-              "value": " ",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 109,
-              "end": 110
-            }
-          ],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 99,
-          "end": 109
-        },
-        "name": {
-          "id": 44,
-          "kind": "<primary-expression>",
-          "startPos": {
-            "offset": 110,
-            "line": 11,
-            "column": 11
-          },
-          "fullStart": 110,
-          "endPos": {
-            "offset": 111,
-            "line": 11,
-            "column": 12
-          },
-          "fullEnd": 112,
-          "start": 110,
-          "end": 111,
-          "expression": {
-            "id": 43,
-            "kind": "<variable>",
-            "startPos": {
-              "offset": 110,
-              "line": 11,
-              "column": 11
-            },
-            "fullStart": 110,
-            "endPos": {
-              "offset": 111,
-              "line": 11,
-              "column": 12
-            },
-            "fullEnd": 112,
-            "start": 110,
-            "end": 111,
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 110,
-                "line": 11,
-                "column": 11
-              },
-              "endPos": {
-                "offset": 111,
-                "line": 11,
-                "column": 12
-              },
-              "value": "G",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 111,
-                    "line": 11,
-                    "column": 12
-                  },
-                  "endPos": {
-                    "offset": 112,
-                    "line": 11,
-                    "column": 13
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 111,
-                  "end": 112
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 110,
-              "end": 111
-            }
-          }
-        },
-        "body": {
-          "id": 57,
-          "kind": "<block-expression>",
-          "startPos": {
-            "offset": 112,
-            "line": 11,
-            "column": 13
-          },
-          "fullStart": 112,
-          "endPos": {
-            "offset": 133,
-            "line": 14,
-            "column": 1
-          },
-          "fullEnd": 134,
-          "start": 112,
-          "end": 133,
-          "blockOpenBrace": {
-            "kind": "<lbrace>",
-            "startPos": {
-              "offset": 112,
-              "line": 11,
-              "column": 13
-            },
-            "endPos": {
-              "offset": 113,
-              "line": 11,
-              "column": 14
-            },
-            "value": "{",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<newline>",
-                "startPos": {
-                  "offset": 113,
-                  "line": 11,
-                  "column": 14
-                },
-                "endPos": {
-                  "offset": 114,
-                  "line": 12,
-                  "column": 0
-                },
-                "value": "\n",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 113,
-                "end": 114
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 112,
-            "end": 113
-          },
-          "body": [
-            {
-              "id": 49,
+              "id": 45,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 118,
-                "line": 12,
+                "offset": 103,
+                "line": 9,
                 "column": 4
               },
-              "fullStart": 114,
+              "fullStart": 99,
               "endPos": {
-                "offset": 121,
-                "line": 12,
-                "column": 7
+                "offset": 107,
+                "line": 9,
+                "column": 8
               },
-              "fullEnd": 122,
-              "start": 118,
-              "end": 121,
+              "fullEnd": 108,
+              "start": 103,
+              "end": 107,
               "callee": {
-                "id": 46,
+                "id": 42,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 118,
-                  "line": 12,
+                  "offset": 103,
+                  "line": 9,
                   "column": 4
                 },
-                "fullStart": 114,
+                "fullStart": 99,
                 "endPos": {
-                  "offset": 119,
-                  "line": 12,
-                  "column": 5
+                  "offset": 105,
+                  "line": 9,
+                  "column": 6
                 },
-                "fullEnd": 120,
-                "start": 118,
-                "end": 119,
+                "fullEnd": 106,
+                "start": 103,
+                "end": 105,
                 "expression": {
-                  "id": 45,
+                  "id": 41,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 118,
-                    "line": 12,
+                    "offset": 103,
+                    "line": 9,
                     "column": 4
                   },
-                  "fullStart": 114,
+                  "fullStart": 99,
                   "endPos": {
-                    "offset": 119,
-                    "line": 12,
-                    "column": 5
+                    "offset": 105,
+                    "line": 9,
+                    "column": 6
                   },
-                  "fullEnd": 120,
-                  "start": 118,
-                  "end": 119,
+                  "fullEnd": 106,
+                  "start": 103,
+                  "end": 105,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 118,
-                      "line": 12,
+                      "offset": 103,
+                      "line": 9,
                       "column": 4
                     },
                     "endPos": {
-                      "offset": 119,
-                      "line": 12,
-                      "column": 5
+                      "offset": 105,
+                      "line": 9,
+                      "column": 6
                     },
-                    "value": "A",
+                    "value": "a4",
                     "leadingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 114,
-                          "line": 12,
+                          "offset": 99,
+                          "line": 9,
                           "column": 0
                         },
                         "endPos": {
-                          "offset": 115,
-                          "line": 12,
+                          "offset": 100,
+                          "line": 9,
                           "column": 1
                         },
                         "value": " ",
@@ -2647,19 +2377,19 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 114,
-                        "end": 115
+                        "start": 99,
+                        "end": 100
                       },
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 115,
-                          "line": 12,
+                          "offset": 100,
+                          "line": 9,
                           "column": 1
                         },
                         "endPos": {
-                          "offset": 116,
-                          "line": 12,
+                          "offset": 101,
+                          "line": 9,
                           "column": 2
                         },
                         "value": " ",
@@ -2668,19 +2398,19 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 115,
-                        "end": 116
+                        "start": 100,
+                        "end": 101
                       },
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 116,
-                          "line": 12,
+                          "offset": 101,
+                          "line": 9,
                           "column": 2
                         },
                         "endPos": {
-                          "offset": 117,
-                          "line": 12,
+                          "offset": 102,
+                          "line": 9,
                           "column": 3
                         },
                         "value": " ",
@@ -2689,19 +2419,19 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 116,
-                        "end": 117
+                        "start": 101,
+                        "end": 102
                       },
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 117,
-                          "line": 12,
+                          "offset": 102,
+                          "line": 9,
                           "column": 3
                         },
                         "endPos": {
-                          "offset": 118,
-                          "line": 12,
+                          "offset": 103,
+                          "line": 9,
                           "column": 4
                         },
                         "value": " ",
@@ -2710,22 +2440,22 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 117,
-                        "end": 118
+                        "start": 102,
+                        "end": 103
                       }
                     ],
                     "trailingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 119,
-                          "line": 12,
-                          "column": 5
+                          "offset": 105,
+                          "line": 9,
+                          "column": 6
                         },
                         "endPos": {
-                          "offset": 120,
-                          "line": 12,
-                          "column": 6
+                          "offset": 106,
+                          "line": 9,
+                          "column": 7
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -2733,78 +2463,78 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 119,
-                        "end": 120
+                        "start": 105,
+                        "end": 106
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 118,
-                    "end": 119
+                    "start": 103,
+                    "end": 105
                   }
                 }
               },
               "args": [
                 {
-                  "id": 48,
+                  "id": 44,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 120,
-                    "line": 12,
-                    "column": 6
-                  },
-                  "fullStart": 120,
-                  "endPos": {
-                    "offset": 121,
-                    "line": 12,
+                    "offset": 106,
+                    "line": 9,
                     "column": 7
                   },
-                  "fullEnd": 122,
-                  "start": 120,
-                  "end": 121,
+                  "fullStart": 106,
+                  "endPos": {
+                    "offset": 107,
+                    "line": 9,
+                    "column": 8
+                  },
+                  "fullEnd": 108,
+                  "start": 106,
+                  "end": 107,
                   "expression": {
-                    "id": 47,
+                    "id": 43,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 120,
-                      "line": 12,
-                      "column": 6
-                    },
-                    "fullStart": 120,
-                    "endPos": {
-                      "offset": 121,
-                      "line": 12,
+                      "offset": 106,
+                      "line": 9,
                       "column": 7
                     },
-                    "fullEnd": 122,
-                    "start": 120,
-                    "end": 121,
+                    "fullStart": 106,
+                    "endPos": {
+                      "offset": 107,
+                      "line": 9,
+                      "column": 8
+                    },
+                    "fullEnd": 108,
+                    "start": 106,
+                    "end": 107,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 120,
-                        "line": 12,
-                        "column": 6
-                      },
-                      "endPos": {
-                        "offset": 121,
-                        "line": 12,
+                        "offset": 106,
+                        "line": 9,
                         "column": 7
                       },
-                      "value": "a",
+                      "endPos": {
+                        "offset": 107,
+                        "line": 9,
+                        "column": 8
+                      },
+                      "value": "e",
                       "leadingTrivia": [],
                       "trailingTrivia": [
                         {
                           "kind": "<newline>",
                           "startPos": {
-                            "offset": 121,
-                            "line": 12,
-                            "column": 7
+                            "offset": 107,
+                            "line": 9,
+                            "column": 8
                           },
                           "endPos": {
-                            "offset": 122,
-                            "line": 13,
+                            "offset": 108,
+                            "line": 10,
                             "column": 0
                           },
                           "value": "\n",
@@ -2813,81 +2543,351 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 121,
-                          "end": 122
+                          "start": 107,
+                          "end": 108
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 120,
-                      "end": 121
+                      "start": 106,
+                      "end": 107
                     }
                   }
                 }
               ],
-              "symbol": 9
+              "symbol": 8
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 108,
+              "line": 10,
+              "column": 0
             },
+            "endPos": {
+              "offset": 109,
+              "line": 10,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 109,
+                  "line": 10,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 110,
+                  "line": 11,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 109,
+                "end": 110
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 108,
+            "end": 109
+          }
+        },
+        "parent": 140,
+        "symbol": 4
+      },
+      {
+        "id": 63,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 111,
+          "line": 12,
+          "column": 0
+        },
+        "fullStart": 110,
+        "endPos": {
+          "offset": 145,
+          "line": 15,
+          "column": 1
+        },
+        "fullEnd": 146,
+        "start": 111,
+        "end": 145,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 111,
+            "line": 12,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 121,
+            "line": 12,
+            "column": 10
+          },
+          "value": "TableGroup",
+          "leadingTrivia": [
             {
-              "id": 56,
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 110,
+                "line": 11,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 111,
+                "line": 12,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 110,
+              "end": 111
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 121,
+                "line": 12,
+                "column": 10
+              },
+              "endPos": {
+                "offset": 122,
+                "line": 12,
+                "column": 11
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 121,
+              "end": 122
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 111,
+          "end": 121
+        },
+        "name": {
+          "id": 49,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 122,
+            "line": 12,
+            "column": 11
+          },
+          "fullStart": 122,
+          "endPos": {
+            "offset": 123,
+            "line": 12,
+            "column": 12
+          },
+          "fullEnd": 124,
+          "start": 122,
+          "end": 123,
+          "expression": {
+            "id": 48,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 122,
+              "line": 12,
+              "column": 11
+            },
+            "fullStart": 122,
+            "endPos": {
+              "offset": 123,
+              "line": 12,
+              "column": 12
+            },
+            "fullEnd": 124,
+            "start": 122,
+            "end": 123,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 122,
+                "line": 12,
+                "column": 11
+              },
+              "endPos": {
+                "offset": 123,
+                "line": 12,
+                "column": 12
+              },
+              "value": "G",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 123,
+                    "line": 12,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 124,
+                    "line": 12,
+                    "column": 13
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 123,
+                  "end": 124
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 122,
+              "end": 123
+            }
+          }
+        },
+        "body": {
+          "id": 62,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 124,
+            "line": 12,
+            "column": 13
+          },
+          "fullStart": 124,
+          "endPos": {
+            "offset": 145,
+            "line": 15,
+            "column": 1
+          },
+          "fullEnd": 146,
+          "start": 124,
+          "end": 145,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 124,
+              "line": 12,
+              "column": 13
+            },
+            "endPos": {
+              "offset": 125,
+              "line": 12,
+              "column": 14
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 125,
+                  "line": 12,
+                  "column": 14
+                },
+                "endPos": {
+                  "offset": 126,
+                  "line": 13,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 125,
+                "end": 126
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 124,
+            "end": 125
+          },
+          "body": [
+            {
+              "id": 54,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 126,
+                "offset": 130,
                 "line": 13,
                 "column": 4
               },
-              "fullStart": 122,
+              "fullStart": 126,
               "endPos": {
-                "offset": 131,
+                "offset": 133,
                 "line": 13,
-                "column": 9
+                "column": 7
               },
-              "fullEnd": 132,
-              "start": 126,
-              "end": 131,
+              "fullEnd": 134,
+              "start": 130,
+              "end": 133,
               "callee": {
                 "id": 51,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 126,
+                  "offset": 130,
                   "line": 13,
                   "column": 4
                 },
-                "fullStart": 122,
+                "fullStart": 126,
                 "endPos": {
-                  "offset": 127,
+                  "offset": 131,
                   "line": 13,
                   "column": 5
                 },
-                "fullEnd": 128,
-                "start": 126,
-                "end": 127,
+                "fullEnd": 132,
+                "start": 130,
+                "end": 131,
                 "expression": {
                   "id": 50,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 126,
+                    "offset": 130,
                     "line": 13,
                     "column": 4
                   },
-                  "fullStart": 122,
+                  "fullStart": 126,
                   "endPos": {
-                    "offset": 127,
+                    "offset": 131,
                     "line": 13,
                     "column": 5
                   },
-                  "fullEnd": 128,
-                  "start": 126,
-                  "end": 127,
+                  "fullEnd": 132,
+                  "start": 130,
+                  "end": 131,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 126,
+                      "offset": 130,
                       "line": 13,
                       "column": 4
                     },
                     "endPos": {
-                      "offset": 127,
+                      "offset": 131,
                       "line": 13,
                       "column": 5
                     },
@@ -2896,12 +2896,12 @@
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 122,
+                          "offset": 126,
                           "line": 13,
                           "column": 0
                         },
                         "endPos": {
-                          "offset": 123,
+                          "offset": 127,
                           "line": 13,
                           "column": 1
                         },
@@ -2911,85 +2911,20 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 122,
-                        "end": 123
+                        "start": 126,
+                        "end": 127
                       },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 123,
-                          "line": 13,
-                          "column": 1
-                        },
-                        "endPos": {
-                          "offset": 124,
-                          "line": 13,
-                          "column": 2
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 123,
-                        "end": 124
-                      },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 124,
-                          "line": 13,
-                          "column": 2
-                        },
-                        "endPos": {
-                          "offset": 125,
-                          "line": 13,
-                          "column": 3
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 124,
-                        "end": 125
-                      },
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 125,
-                          "line": 13,
-                          "column": 3
-                        },
-                        "endPos": {
-                          "offset": 126,
-                          "line": 13,
-                          "column": 4
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 125,
-                        "end": 126
-                      }
-                    ],
-                    "trailingTrivia": [
                       {
                         "kind": "<space>",
                         "startPos": {
                           "offset": 127,
                           "line": 13,
-                          "column": 5
+                          "column": 1
                         },
                         "endPos": {
                           "offset": 128,
                           "line": 13,
-                          "column": 6
+                          "column": 2
                         },
                         "value": " ",
                         "leadingTrivia": [],
@@ -2999,13 +2934,78 @@
                         "isInvalid": false,
                         "start": 127,
                         "end": 128
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 128,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 129,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 128,
+                        "end": 129
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 129,
+                          "line": 13,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 130,
+                          "line": 13,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 129,
+                        "end": 130
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 131,
+                          "line": 13,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 132,
+                          "line": 13,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 131,
+                        "end": 132
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 126,
-                    "end": 127
+                    "start": 130,
+                    "end": 131
                   }
                 }
               },
@@ -3014,45 +3014,45 @@
                   "id": 53,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 128,
+                    "offset": 132,
                     "line": 13,
                     "column": 6
                   },
-                  "fullStart": 128,
+                  "fullStart": 132,
                   "endPos": {
-                    "offset": 129,
+                    "offset": 133,
                     "line": 13,
                     "column": 7
                   },
-                  "fullEnd": 130,
-                  "start": 128,
-                  "end": 129,
+                  "fullEnd": 134,
+                  "start": 132,
+                  "end": 133,
                   "expression": {
                     "id": 52,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 128,
+                      "offset": 132,
                       "line": 13,
                       "column": 6
                     },
-                    "fullStart": 128,
+                    "fullStart": 132,
                     "endPos": {
-                      "offset": 129,
+                      "offset": 133,
                       "line": 13,
                       "column": 7
                     },
-                    "fullEnd": 130,
-                    "start": 128,
-                    "end": 129,
+                    "fullEnd": 134,
+                    "start": 132,
+                    "end": 133,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 128,
+                        "offset": 132,
                         "line": 13,
                         "column": 6
                       },
                       "endPos": {
-                        "offset": 129,
+                        "offset": 133,
                         "line": 13,
                         "column": 7
                       },
@@ -3060,93 +3060,14 @@
                       "leadingTrivia": [],
                       "trailingTrivia": [
                         {
-                          "kind": "<space>",
+                          "kind": "<newline>",
                           "startPos": {
-                            "offset": 129,
+                            "offset": 133,
                             "line": 13,
                             "column": 7
                           },
                           "endPos": {
-                            "offset": 130,
-                            "line": 13,
-                            "column": 8
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 129,
-                          "end": 130
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 128,
-                      "end": 129
-                    }
-                  }
-                },
-                {
-                  "id": 55,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 130,
-                    "line": 13,
-                    "column": 8
-                  },
-                  "fullStart": 130,
-                  "endPos": {
-                    "offset": 131,
-                    "line": 13,
-                    "column": 9
-                  },
-                  "fullEnd": 132,
-                  "start": 130,
-                  "end": 131,
-                  "expression": {
-                    "id": 54,
-                    "kind": "<variable>",
-                    "startPos": {
-                      "offset": 130,
-                      "line": 13,
-                      "column": 8
-                    },
-                    "fullStart": 130,
-                    "endPos": {
-                      "offset": 131,
-                      "line": 13,
-                      "column": 9
-                    },
-                    "fullEnd": 132,
-                    "start": 130,
-                    "end": 131,
-                    "variable": {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 130,
-                        "line": 13,
-                        "column": 8
-                      },
-                      "endPos": {
-                        "offset": 131,
-                        "line": 13,
-                        "column": 9
-                      },
-                      "value": "a",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<newline>",
-                          "startPos": {
-                            "offset": 131,
-                            "line": 13,
-                            "column": 9
-                          },
-                          "endPos": {
-                            "offset": 132,
+                            "offset": 134,
                             "line": 14,
                             "column": 0
                           },
@@ -3156,32 +3077,375 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 131,
-                          "end": 132
+                          "start": 133,
+                          "end": 134
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 130,
-                      "end": 131
+                      "start": 132,
+                      "end": 133
                     }
                   }
                 }
               ],
               "symbol": 10
+            },
+            {
+              "id": 61,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 138,
+                "line": 14,
+                "column": 4
+              },
+              "fullStart": 134,
+              "endPos": {
+                "offset": 143,
+                "line": 14,
+                "column": 9
+              },
+              "fullEnd": 144,
+              "start": 138,
+              "end": 143,
+              "callee": {
+                "id": 56,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 138,
+                  "line": 14,
+                  "column": 4
+                },
+                "fullStart": 134,
+                "endPos": {
+                  "offset": 139,
+                  "line": 14,
+                  "column": 5
+                },
+                "fullEnd": 140,
+                "start": 138,
+                "end": 139,
+                "expression": {
+                  "id": 55,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 138,
+                    "line": 14,
+                    "column": 4
+                  },
+                  "fullStart": 134,
+                  "endPos": {
+                    "offset": 139,
+                    "line": 14,
+                    "column": 5
+                  },
+                  "fullEnd": 140,
+                  "start": 138,
+                  "end": 139,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 138,
+                      "line": 14,
+                      "column": 4
+                    },
+                    "endPos": {
+                      "offset": 139,
+                      "line": 14,
+                      "column": 5
+                    },
+                    "value": "A",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 134,
+                          "line": 14,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 135,
+                          "line": 14,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 134,
+                        "end": 135
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 135,
+                          "line": 14,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 136,
+                          "line": 14,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 135,
+                        "end": 136
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 136,
+                          "line": 14,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 137,
+                          "line": 14,
+                          "column": 3
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 136,
+                        "end": 137
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 137,
+                          "line": 14,
+                          "column": 3
+                        },
+                        "endPos": {
+                          "offset": 138,
+                          "line": 14,
+                          "column": 4
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 137,
+                        "end": 138
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 139,
+                          "line": 14,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 140,
+                          "line": 14,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 139,
+                        "end": 140
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 138,
+                    "end": 139
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 58,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 140,
+                    "line": 14,
+                    "column": 6
+                  },
+                  "fullStart": 140,
+                  "endPos": {
+                    "offset": 141,
+                    "line": 14,
+                    "column": 7
+                  },
+                  "fullEnd": 142,
+                  "start": 140,
+                  "end": 141,
+                  "expression": {
+                    "id": 57,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 140,
+                      "line": 14,
+                      "column": 6
+                    },
+                    "fullStart": 140,
+                    "endPos": {
+                      "offset": 141,
+                      "line": 14,
+                      "column": 7
+                    },
+                    "fullEnd": 142,
+                    "start": 140,
+                    "end": 141,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 140,
+                        "line": 14,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 141,
+                        "line": 14,
+                        "column": 7
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 141,
+                            "line": 14,
+                            "column": 7
+                          },
+                          "endPos": {
+                            "offset": 142,
+                            "line": 14,
+                            "column": 8
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 141,
+                          "end": 142
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 140,
+                      "end": 141
+                    }
+                  }
+                },
+                {
+                  "id": 60,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 142,
+                    "line": 14,
+                    "column": 8
+                  },
+                  "fullStart": 142,
+                  "endPos": {
+                    "offset": 143,
+                    "line": 14,
+                    "column": 9
+                  },
+                  "fullEnd": 144,
+                  "start": 142,
+                  "end": 143,
+                  "expression": {
+                    "id": 59,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 142,
+                      "line": 14,
+                      "column": 8
+                    },
+                    "fullStart": 142,
+                    "endPos": {
+                      "offset": 143,
+                      "line": 14,
+                      "column": 9
+                    },
+                    "fullEnd": 144,
+                    "start": 142,
+                    "end": 143,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 142,
+                        "line": 14,
+                        "column": 8
+                      },
+                      "endPos": {
+                        "offset": 143,
+                        "line": 14,
+                        "column": 9
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 143,
+                            "line": 14,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 144,
+                            "line": 15,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 143,
+                          "end": 144
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 142,
+                      "end": 143
+                    }
+                  }
+                }
+              ],
+              "symbol": 11
             }
           ],
           "blockCloseBrace": {
             "kind": "<rbrace>",
             "startPos": {
-              "offset": 132,
-              "line": 14,
+              "offset": 144,
+              "line": 15,
               "column": 0
             },
             "endPos": {
-              "offset": 133,
-              "line": 14,
+              "offset": 145,
+              "line": 15,
               "column": 1
             },
             "value": "}",
@@ -3190,13 +3454,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 133,
-                  "line": 14,
+                  "offset": 145,
+                  "line": 15,
                   "column": 1
                 },
                 "endPos": {
-                  "offset": 134,
-                  "line": 15,
+                  "offset": 146,
+                  "line": 16,
                   "column": 0
                 },
                 "value": "\n",
@@ -3205,47 +3469,47 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 133,
-                "end": 134
+                "start": 145,
+                "end": 146
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 132,
-            "end": 133
+            "start": 144,
+            "end": 145
           }
         },
-        "parent": 119,
-        "symbol": 8
+        "parent": 140,
+        "symbol": 9
       },
       {
-        "id": 79,
+        "id": 84,
         "kind": "<element-declaration>",
         "startPos": {
-          "offset": 135,
-          "line": 16,
+          "offset": 147,
+          "line": 17,
           "column": 0
         },
-        "fullStart": 134,
+        "fullStart": 146,
         "endPos": {
-          "offset": 178,
-          "line": 18,
+          "offset": 190,
+          "line": 19,
           "column": 1
         },
-        "fullEnd": 179,
-        "start": 135,
-        "end": 178,
+        "fullEnd": 191,
+        "start": 147,
+        "end": 190,
         "type": {
           "kind": "<identifier>",
           "startPos": {
-            "offset": 135,
-            "line": 16,
+            "offset": 147,
+            "line": 17,
             "column": 0
           },
           "endPos": {
-            "offset": 138,
-            "line": 16,
+            "offset": 150,
+            "line": 17,
             "column": 3
           },
           "value": "Ref",
@@ -3253,13 +3517,13 @@
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 134,
-                "line": 15,
+                "offset": 146,
+                "line": 16,
                 "column": 0
               },
               "endPos": {
-                "offset": 135,
-                "line": 16,
+                "offset": 147,
+                "line": 17,
                 "column": 0
               },
               "value": "\n",
@@ -3268,21 +3532,21 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 134,
-              "end": 135
+              "start": 146,
+              "end": 147
             }
           ],
           "trailingTrivia": [
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 138,
-                "line": 16,
+                "offset": 150,
+                "line": 17,
                 "column": 3
               },
               "endPos": {
-                "offset": 139,
-                "line": 16,
+                "offset": 151,
+                "line": 17,
                 "column": 4
               },
               "value": " ",
@@ -3291,43 +3555,43 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 138,
-              "end": 139
+              "start": 150,
+              "end": 151
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": false,
-          "start": 135,
-          "end": 138
+          "start": 147,
+          "end": 150
         },
         "body": {
-          "id": 78,
+          "id": 83,
           "kind": "<block-expression>",
           "startPos": {
-            "offset": 139,
-            "line": 16,
+            "offset": 151,
+            "line": 17,
             "column": 4
           },
-          "fullStart": 139,
+          "fullStart": 151,
           "endPos": {
-            "offset": 178,
-            "line": 18,
+            "offset": 190,
+            "line": 19,
             "column": 1
           },
-          "fullEnd": 179,
-          "start": 139,
-          "end": 178,
+          "fullEnd": 191,
+          "start": 151,
+          "end": 190,
           "blockOpenBrace": {
             "kind": "<lbrace>",
             "startPos": {
-              "offset": 139,
-              "line": 16,
+              "offset": 151,
+              "line": 17,
               "column": 4
             },
             "endPos": {
-              "offset": 140,
-              "line": 16,
+              "offset": 152,
+              "line": 17,
               "column": 5
             },
             "value": "{",
@@ -3336,13 +3600,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 140,
-                  "line": 16,
+                  "offset": 152,
+                  "line": 17,
                   "column": 5
                 },
                 "endPos": {
-                  "offset": 141,
-                  "line": 17,
+                  "offset": 153,
+                  "line": 18,
                   "column": 0
                 },
                 "value": "\n",
@@ -3351,61 +3615,61 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 140,
-                "end": 141
+                "start": 152,
+                "end": 153
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 139,
-            "end": 140
+            "start": 151,
+            "end": 152
           },
           "body": [
             {
-              "id": 77,
+              "id": 82,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 145,
-                "line": 17,
+                "offset": 157,
+                "line": 18,
                 "column": 4
               },
-              "fullStart": 141,
+              "fullStart": 153,
               "endPos": {
-                "offset": 176,
-                "line": 17,
+                "offset": 188,
+                "line": 18,
                 "column": 35
               },
-              "fullEnd": 177,
-              "start": 145,
-              "end": 176,
+              "fullEnd": 189,
+              "start": 157,
+              "end": 188,
               "callee": {
-                "id": 69,
+                "id": 74,
                 "kind": "<infix-expression>",
                 "startPos": {
-                  "offset": 145,
-                  "line": 17,
+                  "offset": 157,
+                  "line": 18,
                   "column": 4
                 },
-                "fullStart": 141,
+                "fullStart": 153,
                 "endPos": {
-                  "offset": 156,
-                  "line": 17,
+                  "offset": 168,
+                  "line": 18,
                   "column": 15
                 },
-                "fullEnd": 157,
-                "start": 145,
-                "end": 156,
+                "fullEnd": 169,
+                "start": 157,
+                "end": 168,
                 "op": {
                   "kind": "<op>",
                   "startPos": {
-                    "offset": 150,
-                    "line": 17,
+                    "offset": 162,
+                    "line": 18,
                     "column": 9
                   },
                   "endPos": {
-                    "offset": 151,
-                    "line": 17,
+                    "offset": 163,
+                    "line": 18,
                     "column": 10
                   },
                   "value": ">",
@@ -3414,13 +3678,13 @@
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 151,
-                        "line": 17,
+                        "offset": 163,
+                        "line": 18,
                         "column": 10
                       },
                       "endPos": {
-                        "offset": 152,
-                        "line": 17,
+                        "offset": 164,
+                        "line": 18,
                         "column": 11
                       },
                       "value": " ",
@@ -3429,43 +3693,43 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 151,
-                      "end": 152
+                      "start": 163,
+                      "end": 164
                     }
                   ],
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 150,
-                  "end": 151
+                  "start": 162,
+                  "end": 163
                 },
                 "leftExpression": {
-                  "id": 63,
+                  "id": 68,
                   "kind": "<infix-expression>",
                   "startPos": {
-                    "offset": 145,
-                    "line": 17,
+                    "offset": 157,
+                    "line": 18,
                     "column": 4
                   },
-                  "fullStart": 141,
+                  "fullStart": 153,
                   "endPos": {
-                    "offset": 149,
-                    "line": 17,
+                    "offset": 161,
+                    "line": 18,
                     "column": 8
                   },
-                  "fullEnd": 150,
-                  "start": 145,
-                  "end": 149,
+                  "fullEnd": 162,
+                  "start": 157,
+                  "end": 161,
                   "op": {
                     "kind": "<op>",
                     "startPos": {
-                      "offset": 146,
-                      "line": 17,
+                      "offset": 158,
+                      "line": 18,
                       "column": 5
                     },
                     "endPos": {
-                      "offset": 147,
-                      "line": 17,
+                      "offset": 159,
+                      "line": 18,
                       "column": 6
                     },
                     "value": ".",
@@ -3474,53 +3738,53 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 146,
-                    "end": 147
+                    "start": 158,
+                    "end": 159
                   },
                   "leftExpression": {
-                    "id": 60,
+                    "id": 65,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 145,
-                      "line": 17,
+                      "offset": 157,
+                      "line": 18,
                       "column": 4
                     },
-                    "fullStart": 141,
+                    "fullStart": 153,
                     "endPos": {
-                      "offset": 146,
-                      "line": 17,
+                      "offset": 158,
+                      "line": 18,
                       "column": 5
                     },
-                    "fullEnd": 146,
-                    "start": 145,
-                    "end": 146,
+                    "fullEnd": 158,
+                    "start": 157,
+                    "end": 158,
                     "expression": {
-                      "id": 59,
+                      "id": 64,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 145,
-                        "line": 17,
+                        "offset": 157,
+                        "line": 18,
                         "column": 4
                       },
-                      "fullStart": 141,
+                      "fullStart": 153,
                       "endPos": {
-                        "offset": 146,
-                        "line": 17,
+                        "offset": 158,
+                        "line": 18,
                         "column": 5
                       },
-                      "fullEnd": 146,
-                      "start": 145,
-                      "end": 146,
+                      "fullEnd": 158,
+                      "start": 157,
+                      "end": 158,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 145,
-                          "line": 17,
+                          "offset": 157,
+                          "line": 18,
                           "column": 4
                         },
                         "endPos": {
-                          "offset": 146,
-                          "line": 17,
+                          "offset": 158,
+                          "line": 18,
                           "column": 5
                         },
                         "value": "A",
@@ -3528,13 +3792,13 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 141,
-                              "line": 17,
+                              "offset": 153,
+                              "line": 18,
                               "column": 0
                             },
                             "endPos": {
-                              "offset": 142,
-                              "line": 17,
+                              "offset": 154,
+                              "line": 18,
                               "column": 1
                             },
                             "value": " ",
@@ -3543,19 +3807,19 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 141,
-                            "end": 142
+                            "start": 153,
+                            "end": 154
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 142,
-                              "line": 17,
+                              "offset": 154,
+                              "line": 18,
                               "column": 1
                             },
                             "endPos": {
-                              "offset": 143,
-                              "line": 17,
+                              "offset": 155,
+                              "line": 18,
                               "column": 2
                             },
                             "value": " ",
@@ -3564,19 +3828,19 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 142,
-                            "end": 143
+                            "start": 154,
+                            "end": 155
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 143,
-                              "line": 17,
+                              "offset": 155,
+                              "line": 18,
                               "column": 2
                             },
                             "endPos": {
-                              "offset": 144,
-                              "line": 17,
+                              "offset": 156,
+                              "line": 18,
                               "column": 3
                             },
                             "value": " ",
@@ -3585,275 +3849,20 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 143,
-                            "end": 144
+                            "start": 155,
+                            "end": 156
                           },
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 144,
-                              "line": 17,
-                              "column": 3
-                            },
-                            "endPos": {
-                              "offset": 145,
-                              "line": 17,
-                              "column": 4
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 144,
-                            "end": 145
-                          }
-                        ],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 145,
-                        "end": 146
-                      }
-                    }
-                  },
-                  "rightExpression": {
-                    "id": 62,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 147,
-                      "line": 17,
-                      "column": 6
-                    },
-                    "fullStart": 147,
-                    "endPos": {
-                      "offset": 149,
-                      "line": 17,
-                      "column": 8
-                    },
-                    "fullEnd": 150,
-                    "start": 147,
-                    "end": 149,
-                    "expression": {
-                      "id": 61,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 147,
-                        "line": 17,
-                        "column": 6
-                      },
-                      "fullStart": 147,
-                      "endPos": {
-                        "offset": 149,
-                        "line": 17,
-                        "column": 8
-                      },
-                      "fullEnd": 150,
-                      "start": 147,
-                      "end": 149,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 147,
-                          "line": 17,
-                          "column": 6
-                        },
-                        "endPos": {
-                          "offset": 149,
-                          "line": 17,
-                          "column": 8
-                        },
-                        "value": "id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 149,
-                              "line": 17,
-                              "column": 8
-                            },
-                            "endPos": {
-                              "offset": 150,
-                              "line": 17,
-                              "column": 9
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 149,
-                            "end": 150
-                          }
-                        ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 147,
-                        "end": 149
-                      }
-                    }
-                  }
-                },
-                "rightExpression": {
-                  "id": 68,
-                  "kind": "<infix-expression>",
-                  "startPos": {
-                    "offset": 152,
-                    "line": 17,
-                    "column": 11
-                  },
-                  "fullStart": 152,
-                  "endPos": {
-                    "offset": 156,
-                    "line": 17,
-                    "column": 15
-                  },
-                  "fullEnd": 157,
-                  "start": 152,
-                  "end": 156,
-                  "op": {
-                    "kind": "<op>",
-                    "startPos": {
-                      "offset": 153,
-                      "line": 17,
-                      "column": 12
-                    },
-                    "endPos": {
-                      "offset": 154,
-                      "line": 17,
-                      "column": 13
-                    },
-                    "value": ".",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 153,
-                    "end": 154
-                  },
-                  "leftExpression": {
-                    "id": 65,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 152,
-                      "line": 17,
-                      "column": 11
-                    },
-                    "fullStart": 152,
-                    "endPos": {
-                      "offset": 153,
-                      "line": 17,
-                      "column": 12
-                    },
-                    "fullEnd": 153,
-                    "start": 152,
-                    "end": 153,
-                    "expression": {
-                      "id": 64,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 152,
-                        "line": 17,
-                        "column": 11
-                      },
-                      "fullStart": 152,
-                      "endPos": {
-                        "offset": 153,
-                        "line": 17,
-                        "column": 12
-                      },
-                      "fullEnd": 153,
-                      "start": 152,
-                      "end": 153,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 152,
-                          "line": 17,
-                          "column": 11
-                        },
-                        "endPos": {
-                          "offset": 153,
-                          "line": 17,
-                          "column": 12
-                        },
-                        "value": "A",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 152,
-                        "end": 153
-                      }
-                    }
-                  },
-                  "rightExpression": {
-                    "id": 67,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 154,
-                      "line": 17,
-                      "column": 13
-                    },
-                    "fullStart": 154,
-                    "endPos": {
-                      "offset": 156,
-                      "line": 17,
-                      "column": 15
-                    },
-                    "fullEnd": 157,
-                    "start": 154,
-                    "end": 156,
-                    "expression": {
-                      "id": 66,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 154,
-                        "line": 17,
-                        "column": 13
-                      },
-                      "fullStart": 154,
-                      "endPos": {
-                        "offset": 156,
-                        "line": 17,
-                        "column": 15
-                      },
-                      "fullEnd": 157,
-                      "start": 154,
-                      "end": 156,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 154,
-                          "line": 17,
-                          "column": 13
-                        },
-                        "endPos": {
-                          "offset": 156,
-                          "line": 17,
-                          "column": 15
-                        },
-                        "value": "id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
                           {
                             "kind": "<space>",
                             "startPos": {
                               "offset": 156,
-                              "line": 17,
-                              "column": 15
+                              "line": 18,
+                              "column": 3
                             },
                             "endPos": {
                               "offset": 157,
-                              "line": 17,
-                              "column": 16
+                              "line": 18,
+                              "column": 4
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -3865,11 +3874,266 @@
                             "end": 157
                           }
                         ],
+                        "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 154,
-                        "end": 156
+                        "start": 157,
+                        "end": 158
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 67,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 159,
+                      "line": 18,
+                      "column": 6
+                    },
+                    "fullStart": 159,
+                    "endPos": {
+                      "offset": 161,
+                      "line": 18,
+                      "column": 8
+                    },
+                    "fullEnd": 162,
+                    "start": 159,
+                    "end": 161,
+                    "expression": {
+                      "id": 66,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 159,
+                        "line": 18,
+                        "column": 6
+                      },
+                      "fullStart": 159,
+                      "endPos": {
+                        "offset": 161,
+                        "line": 18,
+                        "column": 8
+                      },
+                      "fullEnd": 162,
+                      "start": 159,
+                      "end": 161,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 159,
+                          "line": 18,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 161,
+                          "line": 18,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 161,
+                              "line": 18,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 162,
+                              "line": 18,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 161,
+                            "end": 162
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 159,
+                        "end": 161
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 73,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 164,
+                    "line": 18,
+                    "column": 11
+                  },
+                  "fullStart": 164,
+                  "endPos": {
+                    "offset": 168,
+                    "line": 18,
+                    "column": 15
+                  },
+                  "fullEnd": 169,
+                  "start": 164,
+                  "end": 168,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 165,
+                      "line": 18,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 166,
+                      "line": 18,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 165,
+                    "end": 166
+                  },
+                  "leftExpression": {
+                    "id": 70,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 164,
+                      "line": 18,
+                      "column": 11
+                    },
+                    "fullStart": 164,
+                    "endPos": {
+                      "offset": 165,
+                      "line": 18,
+                      "column": 12
+                    },
+                    "fullEnd": 165,
+                    "start": 164,
+                    "end": 165,
+                    "expression": {
+                      "id": 69,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 164,
+                        "line": 18,
+                        "column": 11
+                      },
+                      "fullStart": 164,
+                      "endPos": {
+                        "offset": 165,
+                        "line": 18,
+                        "column": 12
+                      },
+                      "fullEnd": 165,
+                      "start": 164,
+                      "end": 165,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 164,
+                          "line": 18,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 165,
+                          "line": 18,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 164,
+                        "end": 165
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 72,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 166,
+                      "line": 18,
+                      "column": 13
+                    },
+                    "fullStart": 166,
+                    "endPos": {
+                      "offset": 168,
+                      "line": 18,
+                      "column": 15
+                    },
+                    "fullEnd": 169,
+                    "start": 166,
+                    "end": 168,
+                    "expression": {
+                      "id": 71,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 166,
+                        "line": 18,
+                        "column": 13
+                      },
+                      "fullStart": 166,
+                      "endPos": {
+                        "offset": 168,
+                        "line": 18,
+                        "column": 15
+                      },
+                      "fullEnd": 169,
+                      "start": 166,
+                      "end": 168,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 166,
+                          "line": 18,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 168,
+                          "line": 18,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 168,
+                              "line": 18,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 169,
+                              "line": 18,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 168,
+                            "end": 169
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 166,
+                        "end": 168
                       }
                     }
                   }
@@ -3877,32 +4141,32 @@
               },
               "args": [
                 {
-                  "id": 74,
+                  "id": 79,
                   "kind": "<list-expression>",
                   "startPos": {
-                    "offset": 157,
-                    "line": 17,
+                    "offset": 169,
+                    "line": 18,
                     "column": 16
                   },
-                  "fullStart": 157,
+                  "fullStart": 169,
                   "endPos": {
-                    "offset": 174,
-                    "line": 17,
+                    "offset": 186,
+                    "line": 18,
                     "column": 33
                   },
-                  "fullEnd": 175,
-                  "start": 157,
-                  "end": 174,
+                  "fullEnd": 187,
+                  "start": 169,
+                  "end": 186,
                   "listOpenBracket": {
                     "kind": "<lbracket>",
                     "startPos": {
-                      "offset": 157,
-                      "line": 17,
+                      "offset": 169,
+                      "line": 18,
                       "column": 16
                     },
                     "endPos": {
-                      "offset": 158,
-                      "line": 17,
+                      "offset": 170,
+                      "line": 18,
                       "column": 17
                     },
                     "value": "[",
@@ -3911,55 +4175,55 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 157,
-                    "end": 158
+                    "start": 169,
+                    "end": 170
                   },
                   "elementList": [
                     {
-                      "id": 73,
+                      "id": 78,
                       "kind": "<attribute>",
                       "startPos": {
-                        "offset": 158,
-                        "line": 17,
+                        "offset": 170,
+                        "line": 18,
                         "column": 17
                       },
-                      "fullStart": 158,
+                      "fullStart": 170,
                       "endPos": {
-                        "offset": 173,
-                        "line": 17,
+                        "offset": 185,
+                        "line": 18,
                         "column": 32
                       },
-                      "fullEnd": 173,
-                      "start": 158,
-                      "end": 173,
+                      "fullEnd": 185,
+                      "start": 170,
+                      "end": 185,
                       "name": {
-                        "id": 70,
+                        "id": 75,
                         "kind": "<identifer-stream>",
                         "startPos": {
-                          "offset": 158,
-                          "line": 17,
+                          "offset": 170,
+                          "line": 18,
                           "column": 17
                         },
-                        "fullStart": 158,
+                        "fullStart": 170,
                         "endPos": {
-                          "offset": 164,
-                          "line": 17,
+                          "offset": 176,
+                          "line": 18,
                           "column": 23
                         },
-                        "fullEnd": 164,
-                        "start": 158,
-                        "end": 164,
+                        "fullEnd": 176,
+                        "start": 170,
+                        "end": 176,
                         "identifiers": [
                           {
                             "kind": "<identifier>",
                             "startPos": {
-                              "offset": 158,
-                              "line": 17,
+                              "offset": 170,
+                              "line": 18,
                               "column": 17
                             },
                             "endPos": {
-                              "offset": 164,
-                              "line": 17,
+                              "offset": 176,
+                              "line": 18,
                               "column": 23
                             },
                             "value": "delete",
@@ -3968,55 +4232,55 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 158,
-                            "end": 164
+                            "start": 170,
+                            "end": 176
                           }
                         ]
                       },
                       "value": {
-                        "id": 72,
+                        "id": 77,
                         "kind": "<primary-expression>",
                         "startPos": {
-                          "offset": 166,
-                          "line": 17,
+                          "offset": 178,
+                          "line": 18,
                           "column": 25
                         },
-                        "fullStart": 166,
+                        "fullStart": 178,
                         "endPos": {
-                          "offset": 173,
-                          "line": 17,
+                          "offset": 185,
+                          "line": 18,
                           "column": 32
                         },
-                        "fullEnd": 173,
-                        "start": 166,
-                        "end": 173,
+                        "fullEnd": 185,
+                        "start": 178,
+                        "end": 185,
                         "expression": {
-                          "id": 71,
+                          "id": 76,
                           "kind": "<variable>",
                           "startPos": {
-                            "offset": 166,
-                            "line": 17,
+                            "offset": 178,
+                            "line": 18,
                             "column": 25
                           },
-                          "fullStart": 166,
+                          "fullStart": 178,
                           "endPos": {
-                            "offset": 173,
-                            "line": 17,
+                            "offset": 185,
+                            "line": 18,
                             "column": 32
                           },
-                          "fullEnd": 173,
-                          "start": 166,
-                          "end": 173,
+                          "fullEnd": 185,
+                          "start": 178,
+                          "end": 185,
                           "variable": {
                             "kind": "<identifier>",
                             "startPos": {
-                              "offset": 166,
-                              "line": 17,
+                              "offset": 178,
+                              "line": 18,
                               "column": 25
                             },
                             "endPos": {
-                              "offset": 173,
-                              "line": 17,
+                              "offset": 185,
+                              "line": 18,
                               "column": 32
                             },
                             "value": "cascade",
@@ -4025,21 +4289,21 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 166,
-                            "end": 173
+                            "start": 178,
+                            "end": 185
                           }
                         }
                       },
                       "colon": {
                         "kind": "<colon>",
                         "startPos": {
-                          "offset": 164,
-                          "line": 17,
+                          "offset": 176,
+                          "line": 18,
                           "column": 23
                         },
                         "endPos": {
-                          "offset": 165,
-                          "line": 17,
+                          "offset": 177,
+                          "line": 18,
                           "column": 24
                         },
                         "value": ":",
@@ -4048,13 +4312,13 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 165,
-                              "line": 17,
+                              "offset": 177,
+                              "line": 18,
                               "column": 24
                             },
                             "endPos": {
-                              "offset": 166,
-                              "line": 17,
+                              "offset": 178,
+                              "line": 18,
                               "column": 25
                             },
                             "value": " ",
@@ -4063,15 +4327,15 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 165,
-                            "end": 166
+                            "start": 177,
+                            "end": 178
                           }
                         ],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 164,
-                        "end": 165
+                        "start": 176,
+                        "end": 177
                       }
                     }
                   ],
@@ -4079,13 +4343,13 @@
                   "listCloseBracket": {
                     "kind": "<rbracket>",
                     "startPos": {
-                      "offset": 173,
-                      "line": 17,
+                      "offset": 185,
+                      "line": 18,
                       "column": 32
                     },
                     "endPos": {
-                      "offset": 174,
-                      "line": 17,
+                      "offset": 186,
+                      "line": 18,
                       "column": 33
                     },
                     "value": "]",
@@ -4094,13 +4358,13 @@
                       {
                         "kind": "<space>",
                         "startPos": {
-                          "offset": 174,
-                          "line": 17,
+                          "offset": 186,
+                          "line": 18,
                           "column": 33
                         },
                         "endPos": {
-                          "offset": 175,
-                          "line": 17,
+                          "offset": 187,
+                          "line": 18,
                           "column": 34
                         },
                         "value": " ",
@@ -4109,61 +4373,61 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 174,
-                        "end": 175
+                        "start": 186,
+                        "end": 187
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 173,
-                    "end": 174
+                    "start": 185,
+                    "end": 186
                   }
                 },
                 {
-                  "id": 76,
+                  "id": 81,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 175,
-                    "line": 17,
+                    "offset": 187,
+                    "line": 18,
                     "column": 34
                   },
-                  "fullStart": 175,
+                  "fullStart": 187,
                   "endPos": {
-                    "offset": 176,
-                    "line": 17,
+                    "offset": 188,
+                    "line": 18,
                     "column": 35
                   },
-                  "fullEnd": 177,
-                  "start": 175,
-                  "end": 176,
+                  "fullEnd": 189,
+                  "start": 187,
+                  "end": 188,
                   "expression": {
-                    "id": 75,
+                    "id": 80,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 175,
-                      "line": 17,
+                      "offset": 187,
+                      "line": 18,
                       "column": 34
                     },
-                    "fullStart": 175,
+                    "fullStart": 187,
                     "endPos": {
-                      "offset": 176,
-                      "line": 17,
+                      "offset": 188,
+                      "line": 18,
                       "column": 35
                     },
-                    "fullEnd": 177,
-                    "start": 175,
-                    "end": 176,
+                    "fullEnd": 189,
+                    "start": 187,
+                    "end": 188,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 175,
-                        "line": 17,
+                        "offset": 187,
+                        "line": 18,
                         "column": 34
                       },
                       "endPos": {
-                        "offset": 176,
-                        "line": 17,
+                        "offset": 188,
+                        "line": 18,
                         "column": 35
                       },
                       "value": "a",
@@ -4172,13 +4436,13 @@
                         {
                           "kind": "<newline>",
                           "startPos": {
-                            "offset": 176,
-                            "line": 17,
+                            "offset": 188,
+                            "line": 18,
                             "column": 35
                           },
                           "endPos": {
-                            "offset": 177,
-                            "line": 18,
+                            "offset": 189,
+                            "line": 19,
                             "column": 0
                           },
                           "value": "\n",
@@ -4187,15 +4451,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 176,
-                          "end": 177
+                          "start": 188,
+                          "end": 189
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 175,
-                      "end": 176
+                      "start": 187,
+                      "end": 188
                     }
                   }
                 }
@@ -4205,13 +4469,13 @@
           "blockCloseBrace": {
             "kind": "<rbrace>",
             "startPos": {
-              "offset": 177,
-              "line": 18,
+              "offset": 189,
+              "line": 19,
               "column": 0
             },
             "endPos": {
-              "offset": 178,
-              "line": 18,
+              "offset": 190,
+              "line": 19,
               "column": 1
             },
             "value": "}",
@@ -4220,13 +4484,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 178,
-                  "line": 18,
+                  "offset": 190,
+                  "line": 19,
                   "column": 1
                 },
                 "endPos": {
-                  "offset": 179,
-                  "line": 19,
+                  "offset": 191,
+                  "line": 20,
                   "column": 0
                 },
                 "value": "\n",
@@ -4235,46 +4499,46 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 178,
-                "end": 179
+                "start": 190,
+                "end": 191
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 177,
-            "end": 178
+            "start": 189,
+            "end": 190
           }
         },
-        "parent": 119
+        "parent": 140
       },
       {
-        "id": 100,
+        "id": 105,
         "kind": "<element-declaration>",
         "startPos": {
-          "offset": 180,
-          "line": 20,
+          "offset": 192,
+          "line": 21,
           "column": 0
         },
-        "fullStart": 179,
+        "fullStart": 191,
         "endPos": {
-          "offset": 223,
-          "line": 22,
+          "offset": 235,
+          "line": 23,
           "column": 1
         },
-        "fullEnd": 224,
-        "start": 180,
-        "end": 223,
+        "fullEnd": 236,
+        "start": 192,
+        "end": 235,
         "type": {
           "kind": "<identifier>",
           "startPos": {
-            "offset": 180,
-            "line": 20,
+            "offset": 192,
+            "line": 21,
             "column": 0
           },
           "endPos": {
-            "offset": 183,
-            "line": 20,
+            "offset": 195,
+            "line": 21,
             "column": 3
           },
           "value": "Ref",
@@ -4282,13 +4546,13 @@
             {
               "kind": "<newline>",
               "startPos": {
-                "offset": 179,
-                "line": 19,
+                "offset": 191,
+                "line": 20,
                 "column": 0
               },
               "endPos": {
-                "offset": 180,
-                "line": 20,
+                "offset": 192,
+                "line": 21,
                 "column": 0
               },
               "value": "\n",
@@ -4297,21 +4561,21 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 179,
-              "end": 180
+              "start": 191,
+              "end": 192
             }
           ],
           "trailingTrivia": [
             {
               "kind": "<space>",
               "startPos": {
-                "offset": 183,
-                "line": 20,
+                "offset": 195,
+                "line": 21,
                 "column": 3
               },
               "endPos": {
-                "offset": 184,
-                "line": 20,
+                "offset": 196,
+                "line": 21,
                 "column": 4
               },
               "value": " ",
@@ -4320,43 +4584,43 @@
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
-              "start": 183,
-              "end": 184
+              "start": 195,
+              "end": 196
             }
           ],
           "leadingInvalid": [],
           "trailingInvalid": [],
           "isInvalid": false,
-          "start": 180,
-          "end": 183
+          "start": 192,
+          "end": 195
         },
         "body": {
-          "id": 99,
+          "id": 104,
           "kind": "<block-expression>",
           "startPos": {
-            "offset": 184,
-            "line": 20,
+            "offset": 196,
+            "line": 21,
             "column": 4
           },
-          "fullStart": 184,
+          "fullStart": 196,
           "endPos": {
-            "offset": 223,
-            "line": 22,
+            "offset": 235,
+            "line": 23,
             "column": 1
           },
-          "fullEnd": 224,
-          "start": 184,
-          "end": 223,
+          "fullEnd": 236,
+          "start": 196,
+          "end": 235,
           "blockOpenBrace": {
             "kind": "<lbrace>",
             "startPos": {
-              "offset": 184,
-              "line": 20,
+              "offset": 196,
+              "line": 21,
               "column": 4
             },
             "endPos": {
-              "offset": 185,
-              "line": 20,
+              "offset": 197,
+              "line": 21,
               "column": 5
             },
             "value": "{",
@@ -4365,13 +4629,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 185,
-                  "line": 20,
+                  "offset": 197,
+                  "line": 21,
                   "column": 5
                 },
                 "endPos": {
-                  "offset": 186,
-                  "line": 21,
+                  "offset": 198,
+                  "line": 22,
                   "column": 0
                 },
                 "value": "\n",
@@ -4380,61 +4644,61 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 185,
-                "end": 186
+                "start": 197,
+                "end": 198
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 184,
-            "end": 185
+            "start": 196,
+            "end": 197
           },
           "body": [
             {
-              "id": 98,
+              "id": 103,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 190,
-                "line": 21,
+                "offset": 202,
+                "line": 22,
                 "column": 4
               },
-              "fullStart": 186,
+              "fullStart": 198,
               "endPos": {
-                "offset": 221,
-                "line": 21,
+                "offset": 233,
+                "line": 22,
                 "column": 35
               },
-              "fullEnd": 222,
-              "start": 190,
-              "end": 221,
+              "fullEnd": 234,
+              "start": 202,
+              "end": 233,
               "callee": {
-                "id": 90,
+                "id": 95,
                 "kind": "<infix-expression>",
                 "startPos": {
-                  "offset": 190,
-                  "line": 21,
+                  "offset": 202,
+                  "line": 22,
                   "column": 4
                 },
-                "fullStart": 186,
+                "fullStart": 198,
                 "endPos": {
-                  "offset": 201,
-                  "line": 21,
+                  "offset": 213,
+                  "line": 22,
                   "column": 15
                 },
-                "fullEnd": 202,
-                "start": 190,
-                "end": 201,
+                "fullEnd": 214,
+                "start": 202,
+                "end": 213,
                 "op": {
                   "kind": "<op>",
                   "startPos": {
-                    "offset": 195,
-                    "line": 21,
+                    "offset": 207,
+                    "line": 22,
                     "column": 9
                   },
                   "endPos": {
-                    "offset": 196,
-                    "line": 21,
+                    "offset": 208,
+                    "line": 22,
                     "column": 10
                   },
                   "value": ">",
@@ -4443,13 +4707,13 @@
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 196,
-                        "line": 21,
+                        "offset": 208,
+                        "line": 22,
                         "column": 10
                       },
                       "endPos": {
-                        "offset": 197,
-                        "line": 21,
+                        "offset": 209,
+                        "line": 22,
                         "column": 11
                       },
                       "value": " ",
@@ -4458,43 +4722,43 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 196,
-                      "end": 197
+                      "start": 208,
+                      "end": 209
                     }
                   ],
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 195,
-                  "end": 196
+                  "start": 207,
+                  "end": 208
                 },
                 "leftExpression": {
-                  "id": 84,
+                  "id": 89,
                   "kind": "<infix-expression>",
                   "startPos": {
-                    "offset": 190,
-                    "line": 21,
+                    "offset": 202,
+                    "line": 22,
                     "column": 4
                   },
-                  "fullStart": 186,
+                  "fullStart": 198,
                   "endPos": {
-                    "offset": 194,
-                    "line": 21,
+                    "offset": 206,
+                    "line": 22,
                     "column": 8
                   },
-                  "fullEnd": 195,
-                  "start": 190,
-                  "end": 194,
+                  "fullEnd": 207,
+                  "start": 202,
+                  "end": 206,
                   "op": {
                     "kind": "<op>",
                     "startPos": {
-                      "offset": 191,
-                      "line": 21,
+                      "offset": 203,
+                      "line": 22,
                       "column": 5
                     },
                     "endPos": {
-                      "offset": 192,
-                      "line": 21,
+                      "offset": 204,
+                      "line": 22,
                       "column": 6
                     },
                     "value": ".",
@@ -4503,53 +4767,53 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 191,
-                    "end": 192
+                    "start": 203,
+                    "end": 204
                   },
                   "leftExpression": {
-                    "id": 81,
+                    "id": 86,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 190,
-                      "line": 21,
+                      "offset": 202,
+                      "line": 22,
                       "column": 4
                     },
-                    "fullStart": 186,
+                    "fullStart": 198,
                     "endPos": {
-                      "offset": 191,
-                      "line": 21,
+                      "offset": 203,
+                      "line": 22,
                       "column": 5
                     },
-                    "fullEnd": 191,
-                    "start": 190,
-                    "end": 191,
+                    "fullEnd": 203,
+                    "start": 202,
+                    "end": 203,
                     "expression": {
-                      "id": 80,
+                      "id": 85,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 190,
-                        "line": 21,
+                        "offset": 202,
+                        "line": 22,
                         "column": 4
                       },
-                      "fullStart": 186,
+                      "fullStart": 198,
                       "endPos": {
-                        "offset": 191,
-                        "line": 21,
+                        "offset": 203,
+                        "line": 22,
                         "column": 5
                       },
-                      "fullEnd": 191,
-                      "start": 190,
-                      "end": 191,
+                      "fullEnd": 203,
+                      "start": 202,
+                      "end": 203,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 190,
-                          "line": 21,
+                          "offset": 202,
+                          "line": 22,
                           "column": 4
                         },
                         "endPos": {
-                          "offset": 191,
-                          "line": 21,
+                          "offset": 203,
+                          "line": 22,
                           "column": 5
                         },
                         "value": "A",
@@ -4557,13 +4821,13 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 186,
-                              "line": 21,
+                              "offset": 198,
+                              "line": 22,
                               "column": 0
                             },
                             "endPos": {
-                              "offset": 187,
-                              "line": 21,
+                              "offset": 199,
+                              "line": 22,
                               "column": 1
                             },
                             "value": " ",
@@ -4572,19 +4836,19 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 186,
-                            "end": 187
+                            "start": 198,
+                            "end": 199
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 187,
-                              "line": 21,
+                              "offset": 199,
+                              "line": 22,
                               "column": 1
                             },
                             "endPos": {
-                              "offset": 188,
-                              "line": 21,
+                              "offset": 200,
+                              "line": 22,
                               "column": 2
                             },
                             "value": " ",
@@ -4593,19 +4857,19 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 187,
-                            "end": 188
+                            "start": 199,
+                            "end": 200
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 188,
-                              "line": 21,
+                              "offset": 200,
+                              "line": 22,
                               "column": 2
                             },
                             "endPos": {
-                              "offset": 189,
-                              "line": 21,
+                              "offset": 201,
+                              "line": 22,
                               "column": 3
                             },
                             "value": " ",
@@ -4614,275 +4878,20 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 188,
-                            "end": 189
+                            "start": 200,
+                            "end": 201
                           },
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 189,
-                              "line": 21,
-                              "column": 3
-                            },
-                            "endPos": {
-                              "offset": 190,
-                              "line": 21,
-                              "column": 4
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 189,
-                            "end": 190
-                          }
-                        ],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 190,
-                        "end": 191
-                      }
-                    }
-                  },
-                  "rightExpression": {
-                    "id": 83,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 192,
-                      "line": 21,
-                      "column": 6
-                    },
-                    "fullStart": 192,
-                    "endPos": {
-                      "offset": 194,
-                      "line": 21,
-                      "column": 8
-                    },
-                    "fullEnd": 195,
-                    "start": 192,
-                    "end": 194,
-                    "expression": {
-                      "id": 82,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 192,
-                        "line": 21,
-                        "column": 6
-                      },
-                      "fullStart": 192,
-                      "endPos": {
-                        "offset": 194,
-                        "line": 21,
-                        "column": 8
-                      },
-                      "fullEnd": 195,
-                      "start": 192,
-                      "end": 194,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 192,
-                          "line": 21,
-                          "column": 6
-                        },
-                        "endPos": {
-                          "offset": 194,
-                          "line": 21,
-                          "column": 8
-                        },
-                        "value": "id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 194,
-                              "line": 21,
-                              "column": 8
-                            },
-                            "endPos": {
-                              "offset": 195,
-                              "line": 21,
-                              "column": 9
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 194,
-                            "end": 195
-                          }
-                        ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 192,
-                        "end": 194
-                      }
-                    }
-                  }
-                },
-                "rightExpression": {
-                  "id": 89,
-                  "kind": "<infix-expression>",
-                  "startPos": {
-                    "offset": 197,
-                    "line": 21,
-                    "column": 11
-                  },
-                  "fullStart": 197,
-                  "endPos": {
-                    "offset": 201,
-                    "line": 21,
-                    "column": 15
-                  },
-                  "fullEnd": 202,
-                  "start": 197,
-                  "end": 201,
-                  "op": {
-                    "kind": "<op>",
-                    "startPos": {
-                      "offset": 198,
-                      "line": 21,
-                      "column": 12
-                    },
-                    "endPos": {
-                      "offset": 199,
-                      "line": 21,
-                      "column": 13
-                    },
-                    "value": ".",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 198,
-                    "end": 199
-                  },
-                  "leftExpression": {
-                    "id": 86,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 197,
-                      "line": 21,
-                      "column": 11
-                    },
-                    "fullStart": 197,
-                    "endPos": {
-                      "offset": 198,
-                      "line": 21,
-                      "column": 12
-                    },
-                    "fullEnd": 198,
-                    "start": 197,
-                    "end": 198,
-                    "expression": {
-                      "id": 85,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 197,
-                        "line": 21,
-                        "column": 11
-                      },
-                      "fullStart": 197,
-                      "endPos": {
-                        "offset": 198,
-                        "line": 21,
-                        "column": 12
-                      },
-                      "fullEnd": 198,
-                      "start": 197,
-                      "end": 198,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 197,
-                          "line": 21,
-                          "column": 11
-                        },
-                        "endPos": {
-                          "offset": 198,
-                          "line": 21,
-                          "column": 12
-                        },
-                        "value": "A",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 197,
-                        "end": 198
-                      }
-                    }
-                  },
-                  "rightExpression": {
-                    "id": 88,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 199,
-                      "line": 21,
-                      "column": 13
-                    },
-                    "fullStart": 199,
-                    "endPos": {
-                      "offset": 201,
-                      "line": 21,
-                      "column": 15
-                    },
-                    "fullEnd": 202,
-                    "start": 199,
-                    "end": 201,
-                    "expression": {
-                      "id": 87,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 199,
-                        "line": 21,
-                        "column": 13
-                      },
-                      "fullStart": 199,
-                      "endPos": {
-                        "offset": 201,
-                        "line": 21,
-                        "column": 15
-                      },
-                      "fullEnd": 202,
-                      "start": 199,
-                      "end": 201,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 199,
-                          "line": 21,
-                          "column": 13
-                        },
-                        "endPos": {
-                          "offset": 201,
-                          "line": 21,
-                          "column": 15
-                        },
-                        "value": "id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
                           {
                             "kind": "<space>",
                             "startPos": {
                               "offset": 201,
-                              "line": 21,
-                              "column": 15
+                              "line": 22,
+                              "column": 3
                             },
                             "endPos": {
                               "offset": 202,
-                              "line": 21,
-                              "column": 16
+                              "line": 22,
+                              "column": 4
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -4894,833 +4903,59 @@
                             "end": 202
                           }
                         ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 199,
-                        "end": 201
-                      }
-                    }
-                  }
-                }
-              },
-              "args": [
-                {
-                  "id": 92,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 202,
-                    "line": 21,
-                    "column": 16
-                  },
-                  "fullStart": 202,
-                  "endPos": {
-                    "offset": 203,
-                    "line": 21,
-                    "column": 17
-                  },
-                  "fullEnd": 204,
-                  "start": 202,
-                  "end": 203,
-                  "expression": {
-                    "id": 91,
-                    "kind": "<variable>",
-                    "startPos": {
-                      "offset": 202,
-                      "line": 21,
-                      "column": 16
-                    },
-                    "fullStart": 202,
-                    "endPos": {
-                      "offset": 203,
-                      "line": 21,
-                      "column": 17
-                    },
-                    "fullEnd": 204,
-                    "start": 202,
-                    "end": 203,
-                    "variable": {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 202,
-                        "line": 21,
-                        "column": 16
-                      },
-                      "endPos": {
-                        "offset": 203,
-                        "line": 21,
-                        "column": 17
-                      },
-                      "value": "a",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<space>",
-                          "startPos": {
-                            "offset": 203,
-                            "line": 21,
-                            "column": 17
-                          },
-                          "endPos": {
-                            "offset": 204,
-                            "line": 21,
-                            "column": 18
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 203,
-                          "end": 204
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 202,
-                      "end": 203
-                    }
-                  }
-                },
-                {
-                  "id": 97,
-                  "kind": "<list-expression>",
-                  "startPos": {
-                    "offset": 204,
-                    "line": 21,
-                    "column": 18
-                  },
-                  "fullStart": 204,
-                  "endPos": {
-                    "offset": 221,
-                    "line": 21,
-                    "column": 35
-                  },
-                  "fullEnd": 222,
-                  "start": 204,
-                  "end": 221,
-                  "listOpenBracket": {
-                    "kind": "<lbracket>",
-                    "startPos": {
-                      "offset": 204,
-                      "line": 21,
-                      "column": 18
-                    },
-                    "endPos": {
-                      "offset": 205,
-                      "line": 21,
-                      "column": 19
-                    },
-                    "value": "[",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 204,
-                    "end": 205
-                  },
-                  "elementList": [
-                    {
-                      "id": 96,
-                      "kind": "<attribute>",
-                      "startPos": {
-                        "offset": 205,
-                        "line": 21,
-                        "column": 19
-                      },
-                      "fullStart": 205,
-                      "endPos": {
-                        "offset": 220,
-                        "line": 21,
-                        "column": 34
-                      },
-                      "fullEnd": 220,
-                      "start": 205,
-                      "end": 220,
-                      "name": {
-                        "id": 93,
-                        "kind": "<identifer-stream>",
-                        "startPos": {
-                          "offset": 205,
-                          "line": 21,
-                          "column": 19
-                        },
-                        "fullStart": 205,
-                        "endPos": {
-                          "offset": 211,
-                          "line": 21,
-                          "column": 25
-                        },
-                        "fullEnd": 211,
-                        "start": 205,
-                        "end": 211,
-                        "identifiers": [
-                          {
-                            "kind": "<identifier>",
-                            "startPos": {
-                              "offset": 205,
-                              "line": 21,
-                              "column": 19
-                            },
-                            "endPos": {
-                              "offset": 211,
-                              "line": 21,
-                              "column": 25
-                            },
-                            "value": "delete",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 205,
-                            "end": 211
-                          }
-                        ]
-                      },
-                      "value": {
-                        "id": 95,
-                        "kind": "<primary-expression>",
-                        "startPos": {
-                          "offset": 213,
-                          "line": 21,
-                          "column": 27
-                        },
-                        "fullStart": 213,
-                        "endPos": {
-                          "offset": 220,
-                          "line": 21,
-                          "column": 34
-                        },
-                        "fullEnd": 220,
-                        "start": 213,
-                        "end": 220,
-                        "expression": {
-                          "id": 94,
-                          "kind": "<variable>",
-                          "startPos": {
-                            "offset": 213,
-                            "line": 21,
-                            "column": 27
-                          },
-                          "fullStart": 213,
-                          "endPos": {
-                            "offset": 220,
-                            "line": 21,
-                            "column": 34
-                          },
-                          "fullEnd": 220,
-                          "start": 213,
-                          "end": 220,
-                          "variable": {
-                            "kind": "<identifier>",
-                            "startPos": {
-                              "offset": 213,
-                              "line": 21,
-                              "column": 27
-                            },
-                            "endPos": {
-                              "offset": 220,
-                              "line": 21,
-                              "column": 34
-                            },
-                            "value": "cascade",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 213,
-                            "end": 220
-                          }
-                        }
-                      },
-                      "colon": {
-                        "kind": "<colon>",
-                        "startPos": {
-                          "offset": 211,
-                          "line": 21,
-                          "column": 25
-                        },
-                        "endPos": {
-                          "offset": 212,
-                          "line": 21,
-                          "column": 26
-                        },
-                        "value": ":",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 212,
-                              "line": 21,
-                              "column": 26
-                            },
-                            "endPos": {
-                              "offset": 213,
-                              "line": 21,
-                              "column": 27
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 212,
-                            "end": 213
-                          }
-                        ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 211,
-                        "end": 212
-                      }
-                    }
-                  ],
-                  "commaList": [],
-                  "listCloseBracket": {
-                    "kind": "<rbracket>",
-                    "startPos": {
-                      "offset": 220,
-                      "line": 21,
-                      "column": 34
-                    },
-                    "endPos": {
-                      "offset": 221,
-                      "line": 21,
-                      "column": 35
-                    },
-                    "value": "]",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [
-                      {
-                        "kind": "<newline>",
-                        "startPos": {
-                          "offset": 221,
-                          "line": 21,
-                          "column": 35
-                        },
-                        "endPos": {
-                          "offset": 222,
-                          "line": 22,
-                          "column": 0
-                        },
-                        "value": "\n",
-                        "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 221,
-                        "end": 222
-                      }
-                    ],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 220,
-                    "end": 221
-                  }
-                }
-              ]
-            }
-          ],
-          "blockCloseBrace": {
-            "kind": "<rbrace>",
-            "startPos": {
-              "offset": 222,
-              "line": 22,
-              "column": 0
-            },
-            "endPos": {
-              "offset": 223,
-              "line": 22,
-              "column": 1
-            },
-            "value": "}",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<newline>",
-                "startPos": {
-                  "offset": 223,
-                  "line": 22,
-                  "column": 1
-                },
-                "endPos": {
-                  "offset": 224,
-                  "line": 23,
-                  "column": 0
-                },
-                "value": "\n",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 223,
-                "end": 224
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 222,
-            "end": 223
-          }
-        },
-        "parent": 119
-      },
-      {
-        "id": 118,
-        "kind": "<element-declaration>",
-        "startPos": {
-          "offset": 225,
-          "line": 24,
-          "column": 0
-        },
-        "fullStart": 224,
-        "endPos": {
-          "offset": 252,
-          "line": 26,
-          "column": 1
-        },
-        "fullEnd": 252,
-        "start": 225,
-        "end": 252,
-        "type": {
-          "kind": "<identifier>",
-          "startPos": {
-            "offset": 225,
-            "line": 24,
-            "column": 0
-          },
-          "endPos": {
-            "offset": 228,
-            "line": 24,
-            "column": 3
-          },
-          "value": "Ref",
-          "leadingTrivia": [
-            {
-              "kind": "<newline>",
-              "startPos": {
-                "offset": 224,
-                "line": 23,
-                "column": 0
-              },
-              "endPos": {
-                "offset": 225,
-                "line": 24,
-                "column": 0
-              },
-              "value": "\n",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 224,
-              "end": 225
-            }
-          ],
-          "trailingTrivia": [
-            {
-              "kind": "<space>",
-              "startPos": {
-                "offset": 228,
-                "line": 24,
-                "column": 3
-              },
-              "endPos": {
-                "offset": 229,
-                "line": 24,
-                "column": 4
-              },
-              "value": " ",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 228,
-              "end": 229
-            }
-          ],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 225,
-          "end": 228
-        },
-        "body": {
-          "id": 117,
-          "kind": "<block-expression>",
-          "startPos": {
-            "offset": 229,
-            "line": 24,
-            "column": 4
-          },
-          "fullStart": 229,
-          "endPos": {
-            "offset": 252,
-            "line": 26,
-            "column": 1
-          },
-          "fullEnd": 252,
-          "start": 229,
-          "end": 252,
-          "blockOpenBrace": {
-            "kind": "<lbrace>",
-            "startPos": {
-              "offset": 229,
-              "line": 24,
-              "column": 4
-            },
-            "endPos": {
-              "offset": 230,
-              "line": 24,
-              "column": 5
-            },
-            "value": "{",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<newline>",
-                "startPos": {
-                  "offset": 230,
-                  "line": 24,
-                  "column": 5
-                },
-                "endPos": {
-                  "offset": 231,
-                  "line": 25,
-                  "column": 0
-                },
-                "value": "\n",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 230,
-                "end": 231
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 229,
-            "end": 230
-          },
-          "body": [
-            {
-              "id": 116,
-              "kind": "<function-application>",
-              "startPos": {
-                "offset": 235,
-                "line": 25,
-                "column": 4
-              },
-              "fullStart": 231,
-              "endPos": {
-                "offset": 250,
-                "line": 25,
-                "column": 19
-              },
-              "fullEnd": 251,
-              "start": 235,
-              "end": 250,
-              "callee": {
-                "id": 111,
-                "kind": "<infix-expression>",
-                "startPos": {
-                  "offset": 235,
-                  "line": 25,
-                  "column": 4
-                },
-                "fullStart": 231,
-                "endPos": {
-                  "offset": 246,
-                  "line": 25,
-                  "column": 15
-                },
-                "fullEnd": 247,
-                "start": 235,
-                "end": 246,
-                "op": {
-                  "kind": "<op>",
-                  "startPos": {
-                    "offset": 240,
-                    "line": 25,
-                    "column": 9
-                  },
-                  "endPos": {
-                    "offset": 241,
-                    "line": 25,
-                    "column": 10
-                  },
-                  "value": ">",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 241,
-                        "line": 25,
-                        "column": 10
-                      },
-                      "endPos": {
-                        "offset": 242,
-                        "line": 25,
-                        "column": 11
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 241,
-                      "end": 242
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 240,
-                  "end": 241
-                },
-                "leftExpression": {
-                  "id": 105,
-                  "kind": "<infix-expression>",
-                  "startPos": {
-                    "offset": 235,
-                    "line": 25,
-                    "column": 4
-                  },
-                  "fullStart": 231,
-                  "endPos": {
-                    "offset": 239,
-                    "line": 25,
-                    "column": 8
-                  },
-                  "fullEnd": 240,
-                  "start": 235,
-                  "end": 239,
-                  "op": {
-                    "kind": "<op>",
-                    "startPos": {
-                      "offset": 236,
-                      "line": 25,
-                      "column": 5
-                    },
-                    "endPos": {
-                      "offset": 237,
-                      "line": 25,
-                      "column": 6
-                    },
-                    "value": ".",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 236,
-                    "end": 237
-                  },
-                  "leftExpression": {
-                    "id": 102,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 235,
-                      "line": 25,
-                      "column": 4
-                    },
-                    "fullStart": 231,
-                    "endPos": {
-                      "offset": 236,
-                      "line": 25,
-                      "column": 5
-                    },
-                    "fullEnd": 236,
-                    "start": 235,
-                    "end": 236,
-                    "expression": {
-                      "id": 101,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 235,
-                        "line": 25,
-                        "column": 4
-                      },
-                      "fullStart": 231,
-                      "endPos": {
-                        "offset": 236,
-                        "line": 25,
-                        "column": 5
-                      },
-                      "fullEnd": 236,
-                      "start": 235,
-                      "end": 236,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 235,
-                          "line": 25,
-                          "column": 4
-                        },
-                        "endPos": {
-                          "offset": 236,
-                          "line": 25,
-                          "column": 5
-                        },
-                        "value": "A",
-                        "leadingTrivia": [
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 231,
-                              "line": 25,
-                              "column": 0
-                            },
-                            "endPos": {
-                              "offset": 232,
-                              "line": 25,
-                              "column": 1
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 231,
-                            "end": 232
-                          },
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 232,
-                              "line": 25,
-                              "column": 1
-                            },
-                            "endPos": {
-                              "offset": 233,
-                              "line": 25,
-                              "column": 2
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 232,
-                            "end": 233
-                          },
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 233,
-                              "line": 25,
-                              "column": 2
-                            },
-                            "endPos": {
-                              "offset": 234,
-                              "line": 25,
-                              "column": 3
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 233,
-                            "end": 234
-                          },
-                          {
-                            "kind": "<space>",
-                            "startPos": {
-                              "offset": 234,
-                              "line": 25,
-                              "column": 3
-                            },
-                            "endPos": {
-                              "offset": 235,
-                              "line": 25,
-                              "column": 4
-                            },
-                            "value": " ",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 234,
-                            "end": 235
-                          }
-                        ],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 235,
-                        "end": 236
+                        "start": 202,
+                        "end": 203
                       }
                     }
                   },
                   "rightExpression": {
-                    "id": 104,
+                    "id": 88,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 237,
-                      "line": 25,
+                      "offset": 204,
+                      "line": 22,
                       "column": 6
                     },
-                    "fullStart": 237,
+                    "fullStart": 204,
                     "endPos": {
-                      "offset": 239,
-                      "line": 25,
+                      "offset": 206,
+                      "line": 22,
                       "column": 8
                     },
-                    "fullEnd": 240,
-                    "start": 237,
-                    "end": 239,
+                    "fullEnd": 207,
+                    "start": 204,
+                    "end": 206,
                     "expression": {
-                      "id": 103,
+                      "id": 87,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 237,
-                        "line": 25,
+                        "offset": 204,
+                        "line": 22,
                         "column": 6
                       },
-                      "fullStart": 237,
+                      "fullStart": 204,
                       "endPos": {
-                        "offset": 239,
-                        "line": 25,
+                        "offset": 206,
+                        "line": 22,
                         "column": 8
                       },
-                      "fullEnd": 240,
-                      "start": 237,
-                      "end": 239,
+                      "fullEnd": 207,
+                      "start": 204,
+                      "end": 206,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 237,
-                          "line": 25,
+                          "offset": 204,
+                          "line": 22,
                           "column": 6
                         },
                         "endPos": {
-                          "offset": 239,
-                          "line": 25,
+                          "offset": 206,
+                          "line": 22,
                           "column": 8
                         },
                         "value": "id",
@@ -5729,13 +4964,13 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 239,
-                              "line": 25,
+                              "offset": 206,
+                              "line": 22,
                               "column": 8
                             },
                             "endPos": {
-                              "offset": 240,
-                              "line": 25,
+                              "offset": 207,
+                              "line": 22,
                               "column": 9
                             },
                             "value": " ",
@@ -5744,46 +4979,46 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 239,
-                            "end": 240
+                            "start": 206,
+                            "end": 207
                           }
                         ],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 237,
-                        "end": 239
+                        "start": 204,
+                        "end": 206
                       }
                     }
                   }
                 },
                 "rightExpression": {
-                  "id": 110,
+                  "id": 94,
                   "kind": "<infix-expression>",
                   "startPos": {
-                    "offset": 242,
-                    "line": 25,
+                    "offset": 209,
+                    "line": 22,
                     "column": 11
                   },
-                  "fullStart": 242,
+                  "fullStart": 209,
                   "endPos": {
-                    "offset": 246,
-                    "line": 25,
+                    "offset": 213,
+                    "line": 22,
                     "column": 15
                   },
-                  "fullEnd": 247,
-                  "start": 242,
-                  "end": 246,
+                  "fullEnd": 214,
+                  "start": 209,
+                  "end": 213,
                   "op": {
                     "kind": "<op>",
                     "startPos": {
-                      "offset": 243,
-                      "line": 25,
+                      "offset": 210,
+                      "line": 22,
                       "column": 12
                     },
                     "endPos": {
-                      "offset": 244,
-                      "line": 25,
+                      "offset": 211,
+                      "line": 22,
                       "column": 13
                     },
                     "value": ".",
@@ -5792,53 +5027,53 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 243,
-                    "end": 244
+                    "start": 210,
+                    "end": 211
                   },
                   "leftExpression": {
-                    "id": 107,
+                    "id": 91,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 242,
-                      "line": 25,
+                      "offset": 209,
+                      "line": 22,
                       "column": 11
                     },
-                    "fullStart": 242,
+                    "fullStart": 209,
                     "endPos": {
-                      "offset": 243,
-                      "line": 25,
+                      "offset": 210,
+                      "line": 22,
                       "column": 12
                     },
-                    "fullEnd": 243,
-                    "start": 242,
-                    "end": 243,
+                    "fullEnd": 210,
+                    "start": 209,
+                    "end": 210,
                     "expression": {
-                      "id": 106,
+                      "id": 90,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 242,
-                        "line": 25,
+                        "offset": 209,
+                        "line": 22,
                         "column": 11
                       },
-                      "fullStart": 242,
+                      "fullStart": 209,
                       "endPos": {
-                        "offset": 243,
-                        "line": 25,
+                        "offset": 210,
+                        "line": 22,
                         "column": 12
                       },
-                      "fullEnd": 243,
-                      "start": 242,
-                      "end": 243,
+                      "fullEnd": 210,
+                      "start": 209,
+                      "end": 210,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 242,
-                          "line": 25,
+                          "offset": 209,
+                          "line": 22,
                           "column": 11
                         },
                         "endPos": {
-                          "offset": 243,
-                          "line": 25,
+                          "offset": 210,
+                          "line": 22,
                           "column": 12
                         },
                         "value": "A",
@@ -5847,55 +5082,55 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 242,
-                        "end": 243
+                        "start": 209,
+                        "end": 210
                       }
                     }
                   },
                   "rightExpression": {
-                    "id": 109,
+                    "id": 93,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 244,
-                      "line": 25,
+                      "offset": 211,
+                      "line": 22,
                       "column": 13
                     },
-                    "fullStart": 244,
+                    "fullStart": 211,
                     "endPos": {
-                      "offset": 246,
-                      "line": 25,
+                      "offset": 213,
+                      "line": 22,
                       "column": 15
                     },
-                    "fullEnd": 247,
-                    "start": 244,
-                    "end": 246,
+                    "fullEnd": 214,
+                    "start": 211,
+                    "end": 213,
                     "expression": {
-                      "id": 108,
+                      "id": 92,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 244,
-                        "line": 25,
+                        "offset": 211,
+                        "line": 22,
                         "column": 13
                       },
-                      "fullStart": 244,
+                      "fullStart": 211,
                       "endPos": {
-                        "offset": 246,
-                        "line": 25,
+                        "offset": 213,
+                        "line": 22,
                         "column": 15
                       },
-                      "fullEnd": 247,
-                      "start": 244,
-                      "end": 246,
+                      "fullEnd": 214,
+                      "start": 211,
+                      "end": 213,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 244,
-                          "line": 25,
+                          "offset": 211,
+                          "line": 22,
                           "column": 13
                         },
                         "endPos": {
-                          "offset": 246,
-                          "line": 25,
+                          "offset": 213,
+                          "line": 22,
                           "column": 15
                         },
                         "value": "id",
@@ -5904,14 +5139,788 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 246,
-                              "line": 25,
+                              "offset": 213,
+                              "line": 22,
                               "column": 15
                             },
                             "endPos": {
-                              "offset": 247,
-                              "line": 25,
+                              "offset": 214,
+                              "line": 22,
                               "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 213,
+                            "end": 214
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 211,
+                        "end": 213
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 97,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 214,
+                    "line": 22,
+                    "column": 16
+                  },
+                  "fullStart": 214,
+                  "endPos": {
+                    "offset": 215,
+                    "line": 22,
+                    "column": 17
+                  },
+                  "fullEnd": 216,
+                  "start": 214,
+                  "end": 215,
+                  "expression": {
+                    "id": 96,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 214,
+                      "line": 22,
+                      "column": 16
+                    },
+                    "fullStart": 214,
+                    "endPos": {
+                      "offset": 215,
+                      "line": 22,
+                      "column": 17
+                    },
+                    "fullEnd": 216,
+                    "start": 214,
+                    "end": 215,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 214,
+                        "line": 22,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 215,
+                        "line": 22,
+                        "column": 17
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 215,
+                            "line": 22,
+                            "column": 17
+                          },
+                          "endPos": {
+                            "offset": 216,
+                            "line": 22,
+                            "column": 18
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 215,
+                          "end": 216
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 214,
+                      "end": 215
+                    }
+                  }
+                },
+                {
+                  "id": 102,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 216,
+                    "line": 22,
+                    "column": 18
+                  },
+                  "fullStart": 216,
+                  "endPos": {
+                    "offset": 233,
+                    "line": 22,
+                    "column": 35
+                  },
+                  "fullEnd": 234,
+                  "start": 216,
+                  "end": 233,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 216,
+                      "line": 22,
+                      "column": 18
+                    },
+                    "endPos": {
+                      "offset": 217,
+                      "line": 22,
+                      "column": 19
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 216,
+                    "end": 217
+                  },
+                  "elementList": [
+                    {
+                      "id": 101,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 217,
+                        "line": 22,
+                        "column": 19
+                      },
+                      "fullStart": 217,
+                      "endPos": {
+                        "offset": 232,
+                        "line": 22,
+                        "column": 34
+                      },
+                      "fullEnd": 232,
+                      "start": 217,
+                      "end": 232,
+                      "name": {
+                        "id": 98,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 217,
+                          "line": 22,
+                          "column": 19
+                        },
+                        "fullStart": 217,
+                        "endPos": {
+                          "offset": 223,
+                          "line": 22,
+                          "column": 25
+                        },
+                        "fullEnd": 223,
+                        "start": 217,
+                        "end": 223,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 217,
+                              "line": 22,
+                              "column": 19
+                            },
+                            "endPos": {
+                              "offset": 223,
+                              "line": 22,
+                              "column": 25
+                            },
+                            "value": "delete",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 217,
+                            "end": 223
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 100,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 225,
+                          "line": 22,
+                          "column": 27
+                        },
+                        "fullStart": 225,
+                        "endPos": {
+                          "offset": 232,
+                          "line": 22,
+                          "column": 34
+                        },
+                        "fullEnd": 232,
+                        "start": 225,
+                        "end": 232,
+                        "expression": {
+                          "id": 99,
+                          "kind": "<variable>",
+                          "startPos": {
+                            "offset": 225,
+                            "line": 22,
+                            "column": 27
+                          },
+                          "fullStart": 225,
+                          "endPos": {
+                            "offset": 232,
+                            "line": 22,
+                            "column": 34
+                          },
+                          "fullEnd": 232,
+                          "start": 225,
+                          "end": 232,
+                          "variable": {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 225,
+                              "line": 22,
+                              "column": 27
+                            },
+                            "endPos": {
+                              "offset": 232,
+                              "line": 22,
+                              "column": 34
+                            },
+                            "value": "cascade",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 225,
+                            "end": 232
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 223,
+                          "line": 22,
+                          "column": 25
+                        },
+                        "endPos": {
+                          "offset": 224,
+                          "line": 22,
+                          "column": 26
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 224,
+                              "line": 22,
+                              "column": 26
+                            },
+                            "endPos": {
+                              "offset": 225,
+                              "line": 22,
+                              "column": 27
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 224,
+                            "end": 225
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 223,
+                        "end": 224
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 232,
+                      "line": 22,
+                      "column": 34
+                    },
+                    "endPos": {
+                      "offset": 233,
+                      "line": 22,
+                      "column": 35
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 233,
+                          "line": 22,
+                          "column": 35
+                        },
+                        "endPos": {
+                          "offset": 234,
+                          "line": 23,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 233,
+                        "end": 234
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 232,
+                    "end": 233
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 234,
+              "line": 23,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 235,
+              "line": 23,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 235,
+                  "line": 23,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 236,
+                  "line": 24,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 235,
+                "end": 236
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 234,
+            "end": 235
+          }
+        },
+        "parent": 140
+      },
+      {
+        "id": 121,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 237,
+          "line": 25,
+          "column": 0
+        },
+        "fullStart": 236,
+        "endPos": {
+          "offset": 262,
+          "line": 27,
+          "column": 1
+        },
+        "fullEnd": 263,
+        "start": 237,
+        "end": 262,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 237,
+            "line": 25,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 240,
+            "line": 25,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 236,
+                "line": 24,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 237,
+                "line": 25,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 236,
+              "end": 237
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 240,
+                "line": 25,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 241,
+                "line": 25,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 240,
+              "end": 241
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 237,
+          "end": 240
+        },
+        "body": {
+          "id": 120,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 241,
+            "line": 25,
+            "column": 4
+          },
+          "fullStart": 241,
+          "endPos": {
+            "offset": 262,
+            "line": 27,
+            "column": 1
+          },
+          "fullEnd": 263,
+          "start": 241,
+          "end": 262,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 241,
+              "line": 25,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 242,
+              "line": 25,
+              "column": 5
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 242,
+                  "line": 25,
+                  "column": 5
+                },
+                "endPos": {
+                  "offset": 243,
+                  "line": 26,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 242,
+                "end": 243
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 241,
+            "end": 242
+          },
+          "body": [
+            {
+              "id": 119,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 247,
+                "line": 26,
+                "column": 4
+              },
+              "fullStart": 243,
+              "endPos": {
+                "offset": 260,
+                "line": 26,
+                "column": 17
+              },
+              "fullEnd": 261,
+              "start": 247,
+              "end": 260,
+              "callee": {
+                "id": 116,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 247,
+                  "line": 26,
+                  "column": 4
+                },
+                "fullStart": 243,
+                "endPos": {
+                  "offset": 258,
+                  "line": 26,
+                  "column": 15
+                },
+                "fullEnd": 259,
+                "start": 247,
+                "end": 258,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 252,
+                    "line": 26,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 253,
+                    "line": 26,
+                    "column": 10
+                  },
+                  "value": ">",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 253,
+                        "line": 26,
+                        "column": 10
+                      },
+                      "endPos": {
+                        "offset": 254,
+                        "line": 26,
+                        "column": 11
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 253,
+                      "end": 254
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 252,
+                  "end": 253
+                },
+                "leftExpression": {
+                  "id": 110,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 247,
+                    "line": 26,
+                    "column": 4
+                  },
+                  "fullStart": 243,
+                  "endPos": {
+                    "offset": 251,
+                    "line": 26,
+                    "column": 8
+                  },
+                  "fullEnd": 252,
+                  "start": 247,
+                  "end": 251,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 248,
+                      "line": 26,
+                      "column": 5
+                    },
+                    "endPos": {
+                      "offset": 249,
+                      "line": 26,
+                      "column": 6
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 248,
+                    "end": 249
+                  },
+                  "leftExpression": {
+                    "id": 107,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 247,
+                      "line": 26,
+                      "column": 4
+                    },
+                    "fullStart": 243,
+                    "endPos": {
+                      "offset": 248,
+                      "line": 26,
+                      "column": 5
+                    },
+                    "fullEnd": 248,
+                    "start": 247,
+                    "end": 248,
+                    "expression": {
+                      "id": 106,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 247,
+                        "line": 26,
+                        "column": 4
+                      },
+                      "fullStart": 243,
+                      "endPos": {
+                        "offset": 248,
+                        "line": 26,
+                        "column": 5
+                      },
+                      "fullEnd": 248,
+                      "start": 247,
+                      "end": 248,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 247,
+                          "line": 26,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 248,
+                          "line": 26,
+                          "column": 5
+                        },
+                        "value": "A",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 243,
+                              "line": 26,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 244,
+                              "line": 26,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 243,
+                            "end": 244
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 244,
+                              "line": 26,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 245,
+                              "line": 26,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 244,
+                            "end": 245
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 245,
+                              "line": 26,
+                              "column": 2
+                            },
+                            "endPos": {
+                              "offset": 246,
+                              "line": 26,
+                              "column": 3
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 245,
+                            "end": 246
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 246,
+                              "line": 26,
+                              "column": 3
+                            },
+                            "endPos": {
+                              "offset": 247,
+                              "line": 26,
+                              "column": 4
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -5923,11 +5932,266 @@
                             "end": 247
                           }
                         ],
+                        "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 244,
-                        "end": 246
+                        "start": 247,
+                        "end": 248
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 109,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 249,
+                      "line": 26,
+                      "column": 6
+                    },
+                    "fullStart": 249,
+                    "endPos": {
+                      "offset": 251,
+                      "line": 26,
+                      "column": 8
+                    },
+                    "fullEnd": 252,
+                    "start": 249,
+                    "end": 251,
+                    "expression": {
+                      "id": 108,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 249,
+                        "line": 26,
+                        "column": 6
+                      },
+                      "fullStart": 249,
+                      "endPos": {
+                        "offset": 251,
+                        "line": 26,
+                        "column": 8
+                      },
+                      "fullEnd": 252,
+                      "start": 249,
+                      "end": 251,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 249,
+                          "line": 26,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 251,
+                          "line": 26,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 251,
+                              "line": 26,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 252,
+                              "line": 26,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 251,
+                            "end": 252
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 249,
+                        "end": 251
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 115,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 254,
+                    "line": 26,
+                    "column": 11
+                  },
+                  "fullStart": 254,
+                  "endPos": {
+                    "offset": 258,
+                    "line": 26,
+                    "column": 15
+                  },
+                  "fullEnd": 259,
+                  "start": 254,
+                  "end": 258,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 255,
+                      "line": 26,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 256,
+                      "line": 26,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 255,
+                    "end": 256
+                  },
+                  "leftExpression": {
+                    "id": 112,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 254,
+                      "line": 26,
+                      "column": 11
+                    },
+                    "fullStart": 254,
+                    "endPos": {
+                      "offset": 255,
+                      "line": 26,
+                      "column": 12
+                    },
+                    "fullEnd": 255,
+                    "start": 254,
+                    "end": 255,
+                    "expression": {
+                      "id": 111,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 254,
+                        "line": 26,
+                        "column": 11
+                      },
+                      "fullStart": 254,
+                      "endPos": {
+                        "offset": 255,
+                        "line": 26,
+                        "column": 12
+                      },
+                      "fullEnd": 255,
+                      "start": 254,
+                      "end": 255,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 254,
+                          "line": 26,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 255,
+                          "line": 26,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 254,
+                        "end": 255
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 114,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 256,
+                      "line": 26,
+                      "column": 13
+                    },
+                    "fullStart": 256,
+                    "endPos": {
+                      "offset": 258,
+                      "line": 26,
+                      "column": 15
+                    },
+                    "fullEnd": 259,
+                    "start": 256,
+                    "end": 258,
+                    "expression": {
+                      "id": 113,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 256,
+                        "line": 26,
+                        "column": 13
+                      },
+                      "fullStart": 256,
+                      "endPos": {
+                        "offset": 258,
+                        "line": 26,
+                        "column": 15
+                      },
+                      "fullEnd": 259,
+                      "start": 256,
+                      "end": 258,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 256,
+                          "line": 26,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 258,
+                          "line": 26,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 258,
+                              "line": 26,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 259,
+                              "line": 26,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 258,
+                            "end": 259
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 256,
+                        "end": 258
                       }
                     }
                   }
@@ -5935,129 +6199,50 @@
               },
               "args": [
                 {
-                  "id": 113,
+                  "id": 118,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 247,
-                    "line": 25,
+                    "offset": 259,
+                    "line": 26,
                     "column": 16
                   },
-                  "fullStart": 247,
+                  "fullStart": 259,
                   "endPos": {
-                    "offset": 248,
-                    "line": 25,
+                    "offset": 260,
+                    "line": 26,
                     "column": 17
                   },
-                  "fullEnd": 249,
-                  "start": 247,
-                  "end": 248,
+                  "fullEnd": 261,
+                  "start": 259,
+                  "end": 260,
                   "expression": {
-                    "id": 112,
+                    "id": 117,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 247,
-                      "line": 25,
+                      "offset": 259,
+                      "line": 26,
                       "column": 16
                     },
-                    "fullStart": 247,
+                    "fullStart": 259,
                     "endPos": {
-                      "offset": 248,
-                      "line": 25,
+                      "offset": 260,
+                      "line": 26,
                       "column": 17
                     },
-                    "fullEnd": 249,
-                    "start": 247,
-                    "end": 248,
+                    "fullEnd": 261,
+                    "start": 259,
+                    "end": 260,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 247,
-                        "line": 25,
+                        "offset": 259,
+                        "line": 26,
                         "column": 16
                       },
                       "endPos": {
-                        "offset": 248,
-                        "line": 25,
+                        "offset": 260,
+                        "line": 26,
                         "column": 17
-                      },
-                      "value": "a",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "<space>",
-                          "startPos": {
-                            "offset": 248,
-                            "line": 25,
-                            "column": 17
-                          },
-                          "endPos": {
-                            "offset": 249,
-                            "line": 25,
-                            "column": 18
-                          },
-                          "value": " ",
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
-                          "leadingInvalid": [],
-                          "trailingInvalid": [],
-                          "isInvalid": false,
-                          "start": 248,
-                          "end": 249
-                        }
-                      ],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 247,
-                      "end": 248
-                    }
-                  }
-                },
-                {
-                  "id": 115,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 249,
-                    "line": 25,
-                    "column": 18
-                  },
-                  "fullStart": 249,
-                  "endPos": {
-                    "offset": 250,
-                    "line": 25,
-                    "column": 19
-                  },
-                  "fullEnd": 251,
-                  "start": 249,
-                  "end": 250,
-                  "expression": {
-                    "id": 114,
-                    "kind": "<variable>",
-                    "startPos": {
-                      "offset": 249,
-                      "line": 25,
-                      "column": 18
-                    },
-                    "fullStart": 249,
-                    "endPos": {
-                      "offset": 250,
-                      "line": 25,
-                      "column": 19
-                    },
-                    "fullEnd": 251,
-                    "start": 249,
-                    "end": 250,
-                    "variable": {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 249,
-                        "line": 25,
-                        "column": 18
-                      },
-                      "endPos": {
-                        "offset": 250,
-                        "line": 25,
-                        "column": 19
                       },
                       "value": "a",
                       "leadingTrivia": [],
@@ -6065,13 +6250,13 @@
                         {
                           "kind": "<newline>",
                           "startPos": {
-                            "offset": 250,
-                            "line": 25,
-                            "column": 19
+                            "offset": 260,
+                            "line": 26,
+                            "column": 17
                           },
                           "endPos": {
-                            "offset": 251,
-                            "line": 26,
+                            "offset": 261,
+                            "line": 27,
                             "column": 0
                           },
                           "value": "\n",
@@ -6080,15 +6265,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 250,
-                          "end": 251
+                          "start": 260,
+                          "end": 261
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 249,
-                      "end": 250
+                      "start": 259,
+                      "end": 260
                     }
                   }
                 }
@@ -6098,13 +6283,877 @@
           "blockCloseBrace": {
             "kind": "<rbrace>",
             "startPos": {
-              "offset": 251,
-              "line": 26,
+              "offset": 261,
+              "line": 27,
               "column": 0
             },
             "endPos": {
-              "offset": 252,
-              "line": 26,
+              "offset": 262,
+              "line": 27,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 262,
+                  "line": 27,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 263,
+                  "line": 28,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 262,
+                "end": 263
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 261,
+            "end": 262
+          }
+        },
+        "parent": 140
+      },
+      {
+        "id": 139,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 264,
+          "line": 29,
+          "column": 0
+        },
+        "fullStart": 263,
+        "endPos": {
+          "offset": 291,
+          "line": 31,
+          "column": 1
+        },
+        "fullEnd": 291,
+        "start": 264,
+        "end": 291,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 264,
+            "line": 29,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 267,
+            "line": 29,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 263,
+                "line": 28,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 264,
+                "line": 29,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 263,
+              "end": 264
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 267,
+                "line": 29,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 268,
+                "line": 29,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 267,
+              "end": 268
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 264,
+          "end": 267
+        },
+        "body": {
+          "id": 138,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 268,
+            "line": 29,
+            "column": 4
+          },
+          "fullStart": 268,
+          "endPos": {
+            "offset": 291,
+            "line": 31,
+            "column": 1
+          },
+          "fullEnd": 291,
+          "start": 268,
+          "end": 291,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 268,
+              "line": 29,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 269,
+              "line": 29,
+              "column": 5
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 269,
+                  "line": 29,
+                  "column": 5
+                },
+                "endPos": {
+                  "offset": 270,
+                  "line": 30,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 269,
+                "end": 270
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 268,
+            "end": 269
+          },
+          "body": [
+            {
+              "id": 137,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 274,
+                "line": 30,
+                "column": 4
+              },
+              "fullStart": 270,
+              "endPos": {
+                "offset": 289,
+                "line": 30,
+                "column": 19
+              },
+              "fullEnd": 290,
+              "start": 274,
+              "end": 289,
+              "callee": {
+                "id": 132,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 274,
+                  "line": 30,
+                  "column": 4
+                },
+                "fullStart": 270,
+                "endPos": {
+                  "offset": 285,
+                  "line": 30,
+                  "column": 15
+                },
+                "fullEnd": 286,
+                "start": 274,
+                "end": 285,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 279,
+                    "line": 30,
+                    "column": 9
+                  },
+                  "endPos": {
+                    "offset": 280,
+                    "line": 30,
+                    "column": 10
+                  },
+                  "value": ">",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 280,
+                        "line": 30,
+                        "column": 10
+                      },
+                      "endPos": {
+                        "offset": 281,
+                        "line": 30,
+                        "column": 11
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 280,
+                      "end": 281
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 279,
+                  "end": 280
+                },
+                "leftExpression": {
+                  "id": 126,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 274,
+                    "line": 30,
+                    "column": 4
+                  },
+                  "fullStart": 270,
+                  "endPos": {
+                    "offset": 278,
+                    "line": 30,
+                    "column": 8
+                  },
+                  "fullEnd": 279,
+                  "start": 274,
+                  "end": 278,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 275,
+                      "line": 30,
+                      "column": 5
+                    },
+                    "endPos": {
+                      "offset": 276,
+                      "line": 30,
+                      "column": 6
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 275,
+                    "end": 276
+                  },
+                  "leftExpression": {
+                    "id": 123,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 274,
+                      "line": 30,
+                      "column": 4
+                    },
+                    "fullStart": 270,
+                    "endPos": {
+                      "offset": 275,
+                      "line": 30,
+                      "column": 5
+                    },
+                    "fullEnd": 275,
+                    "start": 274,
+                    "end": 275,
+                    "expression": {
+                      "id": 122,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 274,
+                        "line": 30,
+                        "column": 4
+                      },
+                      "fullStart": 270,
+                      "endPos": {
+                        "offset": 275,
+                        "line": 30,
+                        "column": 5
+                      },
+                      "fullEnd": 275,
+                      "start": 274,
+                      "end": 275,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 274,
+                          "line": 30,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 275,
+                          "line": 30,
+                          "column": 5
+                        },
+                        "value": "A",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 270,
+                              "line": 30,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 271,
+                              "line": 30,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 270,
+                            "end": 271
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 271,
+                              "line": 30,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 272,
+                              "line": 30,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 271,
+                            "end": 272
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 272,
+                              "line": 30,
+                              "column": 2
+                            },
+                            "endPos": {
+                              "offset": 273,
+                              "line": 30,
+                              "column": 3
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 272,
+                            "end": 273
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 273,
+                              "line": 30,
+                              "column": 3
+                            },
+                            "endPos": {
+                              "offset": 274,
+                              "line": 30,
+                              "column": 4
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 273,
+                            "end": 274
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 274,
+                        "end": 275
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 125,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 276,
+                      "line": 30,
+                      "column": 6
+                    },
+                    "fullStart": 276,
+                    "endPos": {
+                      "offset": 278,
+                      "line": 30,
+                      "column": 8
+                    },
+                    "fullEnd": 279,
+                    "start": 276,
+                    "end": 278,
+                    "expression": {
+                      "id": 124,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 276,
+                        "line": 30,
+                        "column": 6
+                      },
+                      "fullStart": 276,
+                      "endPos": {
+                        "offset": 278,
+                        "line": 30,
+                        "column": 8
+                      },
+                      "fullEnd": 279,
+                      "start": 276,
+                      "end": 278,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 276,
+                          "line": 30,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 278,
+                          "line": 30,
+                          "column": 8
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 278,
+                              "line": 30,
+                              "column": 8
+                            },
+                            "endPos": {
+                              "offset": 279,
+                              "line": 30,
+                              "column": 9
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 278,
+                            "end": 279
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 276,
+                        "end": 278
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 131,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 281,
+                    "line": 30,
+                    "column": 11
+                  },
+                  "fullStart": 281,
+                  "endPos": {
+                    "offset": 285,
+                    "line": 30,
+                    "column": 15
+                  },
+                  "fullEnd": 286,
+                  "start": 281,
+                  "end": 285,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 282,
+                      "line": 30,
+                      "column": 12
+                    },
+                    "endPos": {
+                      "offset": 283,
+                      "line": 30,
+                      "column": 13
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 282,
+                    "end": 283
+                  },
+                  "leftExpression": {
+                    "id": 128,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 281,
+                      "line": 30,
+                      "column": 11
+                    },
+                    "fullStart": 281,
+                    "endPos": {
+                      "offset": 282,
+                      "line": 30,
+                      "column": 12
+                    },
+                    "fullEnd": 282,
+                    "start": 281,
+                    "end": 282,
+                    "expression": {
+                      "id": 127,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 281,
+                        "line": 30,
+                        "column": 11
+                      },
+                      "fullStart": 281,
+                      "endPos": {
+                        "offset": 282,
+                        "line": 30,
+                        "column": 12
+                      },
+                      "fullEnd": 282,
+                      "start": 281,
+                      "end": 282,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 281,
+                          "line": 30,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 282,
+                          "line": 30,
+                          "column": 12
+                        },
+                        "value": "A",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 281,
+                        "end": 282
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 130,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 283,
+                      "line": 30,
+                      "column": 13
+                    },
+                    "fullStart": 283,
+                    "endPos": {
+                      "offset": 285,
+                      "line": 30,
+                      "column": 15
+                    },
+                    "fullEnd": 286,
+                    "start": 283,
+                    "end": 285,
+                    "expression": {
+                      "id": 129,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 283,
+                        "line": 30,
+                        "column": 13
+                      },
+                      "fullStart": 283,
+                      "endPos": {
+                        "offset": 285,
+                        "line": 30,
+                        "column": 15
+                      },
+                      "fullEnd": 286,
+                      "start": 283,
+                      "end": 285,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 283,
+                          "line": 30,
+                          "column": 13
+                        },
+                        "endPos": {
+                          "offset": 285,
+                          "line": 30,
+                          "column": 15
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 285,
+                              "line": 30,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 286,
+                              "line": 30,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 285,
+                            "end": 286
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 283,
+                        "end": 285
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 134,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 286,
+                    "line": 30,
+                    "column": 16
+                  },
+                  "fullStart": 286,
+                  "endPos": {
+                    "offset": 287,
+                    "line": 30,
+                    "column": 17
+                  },
+                  "fullEnd": 288,
+                  "start": 286,
+                  "end": 287,
+                  "expression": {
+                    "id": 133,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 286,
+                      "line": 30,
+                      "column": 16
+                    },
+                    "fullStart": 286,
+                    "endPos": {
+                      "offset": 287,
+                      "line": 30,
+                      "column": 17
+                    },
+                    "fullEnd": 288,
+                    "start": 286,
+                    "end": 287,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 286,
+                        "line": 30,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 287,
+                        "line": 30,
+                        "column": 17
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 287,
+                            "line": 30,
+                            "column": 17
+                          },
+                          "endPos": {
+                            "offset": 288,
+                            "line": 30,
+                            "column": 18
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 287,
+                          "end": 288
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 286,
+                      "end": 287
+                    }
+                  }
+                },
+                {
+                  "id": 136,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 288,
+                    "line": 30,
+                    "column": 18
+                  },
+                  "fullStart": 288,
+                  "endPos": {
+                    "offset": 289,
+                    "line": 30,
+                    "column": 19
+                  },
+                  "fullEnd": 290,
+                  "start": 288,
+                  "end": 289,
+                  "expression": {
+                    "id": 135,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 288,
+                      "line": 30,
+                      "column": 18
+                    },
+                    "fullStart": 288,
+                    "endPos": {
+                      "offset": 289,
+                      "line": 30,
+                      "column": 19
+                    },
+                    "fullEnd": 290,
+                    "start": 288,
+                    "end": 289,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 288,
+                        "line": 30,
+                        "column": 18
+                      },
+                      "endPos": {
+                        "offset": 289,
+                        "line": 30,
+                        "column": 19
+                      },
+                      "value": "a",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 289,
+                            "line": 30,
+                            "column": 19
+                          },
+                          "endPos": {
+                            "offset": 290,
+                            "line": 31,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 289,
+                          "end": 290
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 288,
+                      "end": 289
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 290,
+              "line": 31,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 291,
+              "line": 31,
               "column": 1
             },
             "value": "}",
@@ -6113,23 +7162,23 @@
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 251,
-            "end": 252
+            "start": 290,
+            "end": 291
           }
         },
-        "parent": 119
+        "parent": 140
       }
     ],
     "eof": {
       "kind": "<eof>",
       "startPos": {
-        "offset": 252,
-        "line": 26,
+        "offset": 291,
+        "line": 31,
         "column": 1
       },
       "endPos": {
-        "offset": 252,
-        "line": 26,
+        "offset": 291,
+        "line": 31,
         "column": 1
       },
       "value": "",
@@ -6138,8 +7187,8 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 252,
-      "end": 252
+      "start": 291,
+      "end": 291
     },
     "symbol": {
       "symbolTable": {
@@ -6164,25 +7213,40 @@
           "references": [],
           "id": 4,
           "symbolTable": {
-            "Enum field:a": {
+            "Enum field:a1": {
               "references": [],
               "id": 5,
               "declaration": 23
+            },
+            "Enum field:a2": {
+              "references": [],
+              "id": 6,
+              "declaration": 33
+            },
+            "Enum field:a3": {
+              "references": [],
+              "id": 7,
+              "declaration": 40
+            },
+            "Enum field:a4": {
+              "references": [],
+              "id": 8,
+              "declaration": 45
             }
           },
-          "declaration": 42
+          "declaration": 47
         },
         "TableGroup:G": {
           "references": [],
-          "id": 8,
+          "id": 9,
           "symbolTable": {
             "TableGroup field:A": {
               "references": [],
-              "id": 9,
-              "declaration": 49
+              "id": 10,
+              "declaration": 54
             }
           },
-          "declaration": 58
+          "declaration": 63
         }
       },
       "id": 0,
@@ -6368,47 +7432,47 @@
         "id": 17,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 48,
-          "line": 6,
-          "column": 6
-        },
-        "fullStart": 48,
-        "endPos": {
           "offset": 49,
           "line": 6,
           "column": 7
         },
-        "fullEnd": 50,
-        "start": 48,
-        "end": 49,
+        "fullStart": 49,
+        "endPos": {
+          "offset": 50,
+          "line": 6,
+          "column": 8
+        },
+        "fullEnd": 51,
+        "start": 49,
+        "end": 50,
         "expression": {
           "id": 16,
           "kind": "<variable>",
           "startPos": {
-            "offset": 48,
-            "line": 6,
-            "column": 6
-          },
-          "fullStart": 48,
-          "endPos": {
             "offset": 49,
             "line": 6,
             "column": 7
           },
-          "fullEnd": 50,
-          "start": 48,
-          "end": 49,
+          "fullStart": 49,
+          "endPos": {
+            "offset": 50,
+            "line": 6,
+            "column": 8
+          },
+          "fullEnd": 51,
+          "start": 49,
+          "end": 50,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 48,
-              "line": 6,
-              "column": 6
-            },
-            "endPos": {
               "offset": 49,
               "line": 6,
               "column": 7
+            },
+            "endPos": {
+              "offset": 50,
+              "line": 6,
+              "column": 8
             },
             "value": "e",
             "leadingTrivia": [],
@@ -6416,14 +7480,14 @@
               {
                 "kind": "<space>",
                 "startPos": {
-                  "offset": 49,
-                  "line": 6,
-                  "column": 7
-                },
-                "endPos": {
                   "offset": 50,
                   "line": 6,
                   "column": 8
+                },
+                "endPos": {
+                  "offset": 51,
+                  "line": 6,
+                  "column": 9
                 },
                 "value": " ",
                 "leadingTrivia": [],
@@ -6431,20 +7495,20 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 49,
-                "end": 50
+                "start": 50,
+                "end": 51
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 48,
-            "end": 49
+            "start": 49,
+            "end": 50
           }
         }
       },
-      "start": 48,
-      "end": 49,
+      "start": 49,
+      "end": 50,
       "name": "CompileError"
     },
     {
@@ -6454,47 +7518,47 @@
         "id": 32,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 84,
-          "line": 7,
-          "column": 20
-        },
-        "fullStart": 84,
-        "endPos": {
-          "offset": 85,
+          "offset": 86,
           "line": 7,
           "column": 21
         },
-        "fullEnd": 86,
-        "start": 84,
-        "end": 85,
+        "fullStart": 86,
+        "endPos": {
+          "offset": 87,
+          "line": 7,
+          "column": 22
+        },
+        "fullEnd": 88,
+        "start": 86,
+        "end": 87,
         "expression": {
           "id": 31,
           "kind": "<variable>",
           "startPos": {
-            "offset": 84,
-            "line": 7,
-            "column": 20
-          },
-          "fullStart": 84,
-          "endPos": {
-            "offset": 85,
+            "offset": 86,
             "line": 7,
             "column": 21
           },
-          "fullEnd": 86,
-          "start": 84,
-          "end": 85,
+          "fullStart": 86,
+          "endPos": {
+            "offset": 87,
+            "line": 7,
+            "column": 22
+          },
+          "fullEnd": 88,
+          "start": 86,
+          "end": 87,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 84,
-              "line": 7,
-              "column": 20
-            },
-            "endPos": {
-              "offset": 85,
+              "offset": 86,
               "line": 7,
               "column": 21
+            },
+            "endPos": {
+              "offset": 87,
+              "line": 7,
+              "column": 22
             },
             "value": "e",
             "leadingTrivia": [],
@@ -6502,12 +7566,12 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 85,
+                  "offset": 87,
                   "line": 7,
-                  "column": 21
+                  "column": 22
                 },
                 "endPos": {
-                  "offset": 86,
+                  "offset": 88,
                   "line": 8,
                   "column": 0
                 },
@@ -6517,1050 +7581,20 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 85,
-                "end": 86
+                "start": 87,
+                "end": 88
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 84,
-            "end": 85
+            "start": 86,
+            "end": 87
           }
         }
       },
-      "start": 84,
-      "end": 85,
-      "name": "CompileError"
-    },
-    {
-      "code": 3023,
-      "diagnostic": "Duplicate enum field a",
-      "nodeOrToken": {
-        "id": 33,
-        "kind": "<function-application>",
-        "startPos": {
-          "offset": 68,
-          "line": 7,
-          "column": 4
-        },
-        "fullStart": 64,
-        "endPos": {
-          "offset": 85,
-          "line": 7,
-          "column": 21
-        },
-        "fullEnd": 86,
-        "start": 68,
-        "end": 85,
-        "callee": {
-          "id": 25,
-          "kind": "<primary-expression>",
-          "startPos": {
-            "offset": 68,
-            "line": 7,
-            "column": 4
-          },
-          "fullStart": 64,
-          "endPos": {
-            "offset": 69,
-            "line": 7,
-            "column": 5
-          },
-          "fullEnd": 70,
-          "start": 68,
-          "end": 69,
-          "expression": {
-            "id": 24,
-            "kind": "<variable>",
-            "startPos": {
-              "offset": 68,
-              "line": 7,
-              "column": 4
-            },
-            "fullStart": 64,
-            "endPos": {
-              "offset": 69,
-              "line": 7,
-              "column": 5
-            },
-            "fullEnd": 70,
-            "start": 68,
-            "end": 69,
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 68,
-                "line": 7,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 69,
-                "line": 7,
-                "column": 5
-              },
-              "value": "a",
-              "leadingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 64,
-                    "line": 7,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 65,
-                    "line": 7,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 64,
-                  "end": 65
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 65,
-                    "line": 7,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 66,
-                    "line": 7,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 65,
-                  "end": 66
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 66,
-                    "line": 7,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 67,
-                    "line": 7,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 66,
-                  "end": 67
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 67,
-                    "line": 7,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 68,
-                    "line": 7,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 67,
-                  "end": 68
-                }
-              ],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 69,
-                    "line": 7,
-                    "column": 5
-                  },
-                  "endPos": {
-                    "offset": 70,
-                    "line": 7,
-                    "column": 6
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 69,
-                  "end": 70
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 68,
-              "end": 69
-            }
-          }
-        },
-        "args": [
-          {
-            "id": 30,
-            "kind": "<list-expression>",
-            "startPos": {
-              "offset": 70,
-              "line": 7,
-              "column": 6
-            },
-            "fullStart": 70,
-            "endPos": {
-              "offset": 83,
-              "line": 7,
-              "column": 19
-            },
-            "fullEnd": 84,
-            "start": 70,
-            "end": 83,
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 70,
-                "line": 7,
-                "column": 6
-              },
-              "endPos": {
-                "offset": 71,
-                "line": 7,
-                "column": 7
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 70,
-              "end": 71
-            },
-            "elementList": [
-              {
-                "id": 29,
-                "kind": "<attribute>",
-                "startPos": {
-                  "offset": 71,
-                  "line": 7,
-                  "column": 7
-                },
-                "fullStart": 71,
-                "endPos": {
-                  "offset": 82,
-                  "line": 7,
-                  "column": 18
-                },
-                "fullEnd": 82,
-                "start": 71,
-                "end": 82,
-                "name": {
-                  "id": 26,
-                  "kind": "<identifer-stream>",
-                  "startPos": {
-                    "offset": 71,
-                    "line": 7,
-                    "column": 7
-                  },
-                  "fullStart": 71,
-                  "endPos": {
-                    "offset": 75,
-                    "line": 7,
-                    "column": 11
-                  },
-                  "fullEnd": 75,
-                  "start": 71,
-                  "end": 75,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 71,
-                        "line": 7,
-                        "column": 7
-                      },
-                      "endPos": {
-                        "offset": 75,
-                        "line": 7,
-                        "column": 11
-                      },
-                      "value": "note",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 71,
-                      "end": 75
-                    }
-                  ]
-                },
-                "value": {
-                  "id": 28,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 77,
-                    "line": 7,
-                    "column": 13
-                  },
-                  "fullStart": 77,
-                  "endPos": {
-                    "offset": 82,
-                    "line": 7,
-                    "column": 18
-                  },
-                  "fullEnd": 82,
-                  "start": 77,
-                  "end": 82,
-                  "expression": {
-                    "id": 27,
-                    "kind": "<literal>",
-                    "startPos": {
-                      "offset": 77,
-                      "line": 7,
-                      "column": 13
-                    },
-                    "fullStart": 77,
-                    "endPos": {
-                      "offset": 82,
-                      "line": 7,
-                      "column": 18
-                    },
-                    "fullEnd": 82,
-                    "start": 77,
-                    "end": 82,
-                    "literal": {
-                      "kind": "<string>",
-                      "startPos": {
-                        "offset": 77,
-                        "line": 7,
-                        "column": 13
-                      },
-                      "endPos": {
-                        "offset": 82,
-                        "line": 7,
-                        "column": 18
-                      },
-                      "value": "abc",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 77,
-                      "end": 82
-                    }
-                  }
-                },
-                "colon": {
-                  "kind": "<colon>",
-                  "startPos": {
-                    "offset": 75,
-                    "line": 7,
-                    "column": 11
-                  },
-                  "endPos": {
-                    "offset": 76,
-                    "line": 7,
-                    "column": 12
-                  },
-                  "value": ":",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 76,
-                        "line": 7,
-                        "column": 12
-                      },
-                      "endPos": {
-                        "offset": 77,
-                        "line": 7,
-                        "column": 13
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 76,
-                      "end": 77
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 75,
-                  "end": 76
-                }
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 82,
-                "line": 7,
-                "column": 18
-              },
-              "endPos": {
-                "offset": 83,
-                "line": 7,
-                "column": 19
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 83,
-                    "line": 7,
-                    "column": 19
-                  },
-                  "endPos": {
-                    "offset": 84,
-                    "line": 7,
-                    "column": 20
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 83,
-                  "end": 84
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 82,
-              "end": 83
-            }
-          },
-          {
-            "id": 32,
-            "kind": "<primary-expression>",
-            "startPos": {
-              "offset": 84,
-              "line": 7,
-              "column": 20
-            },
-            "fullStart": 84,
-            "endPos": {
-              "offset": 85,
-              "line": 7,
-              "column": 21
-            },
-            "fullEnd": 86,
-            "start": 84,
-            "end": 85,
-            "expression": {
-              "id": 31,
-              "kind": "<variable>",
-              "startPos": {
-                "offset": 84,
-                "line": 7,
-                "column": 20
-              },
-              "fullStart": 84,
-              "endPos": {
-                "offset": 85,
-                "line": 7,
-                "column": 21
-              },
-              "fullEnd": 86,
-              "start": 84,
-              "end": 85,
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 84,
-                  "line": 7,
-                  "column": 20
-                },
-                "endPos": {
-                  "offset": 85,
-                  "line": 7,
-                  "column": 21
-                },
-                "value": "e",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<newline>",
-                    "startPos": {
-                      "offset": 85,
-                      "line": 7,
-                      "column": 21
-                    },
-                    "endPos": {
-                      "offset": 86,
-                      "line": 8,
-                      "column": 0
-                    },
-                    "value": "\n",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 85,
-                    "end": 86
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 84,
-                "end": 85
-              }
-            }
-          }
-        ],
-        "symbol": 6
-      },
-      "start": 68,
-      "end": 85,
-      "name": "CompileError"
-    },
-    {
-      "code": 3023,
-      "diagnostic": "Duplicate enum field a",
-      "nodeOrToken": {
-        "id": 23,
-        "kind": "<function-application>",
-        "startPos": {
-          "offset": 46,
-          "line": 6,
-          "column": 4
-        },
-        "fullStart": 42,
-        "endPos": {
-          "offset": 63,
-          "line": 6,
-          "column": 21
-        },
-        "fullEnd": 64,
-        "start": 46,
-        "end": 63,
-        "callee": {
-          "id": 15,
-          "kind": "<primary-expression>",
-          "startPos": {
-            "offset": 46,
-            "line": 6,
-            "column": 4
-          },
-          "fullStart": 42,
-          "endPos": {
-            "offset": 47,
-            "line": 6,
-            "column": 5
-          },
-          "fullEnd": 48,
-          "start": 46,
-          "end": 47,
-          "expression": {
-            "id": 14,
-            "kind": "<variable>",
-            "startPos": {
-              "offset": 46,
-              "line": 6,
-              "column": 4
-            },
-            "fullStart": 42,
-            "endPos": {
-              "offset": 47,
-              "line": 6,
-              "column": 5
-            },
-            "fullEnd": 48,
-            "start": 46,
-            "end": 47,
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 46,
-                "line": 6,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 47,
-                "line": 6,
-                "column": 5
-              },
-              "value": "a",
-              "leadingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 42,
-                    "line": 6,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 43,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 42,
-                  "end": 43
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 43,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 44,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 43,
-                  "end": 44
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 44,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 45,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 44,
-                  "end": 45
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 45,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 46,
-                    "line": 6,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 45,
-                  "end": 46
-                }
-              ],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 47,
-                    "line": 6,
-                    "column": 5
-                  },
-                  "endPos": {
-                    "offset": 48,
-                    "line": 6,
-                    "column": 6
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 47,
-                  "end": 48
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 46,
-              "end": 47
-            }
-          }
-        },
-        "args": [
-          {
-            "id": 17,
-            "kind": "<primary-expression>",
-            "startPos": {
-              "offset": 48,
-              "line": 6,
-              "column": 6
-            },
-            "fullStart": 48,
-            "endPos": {
-              "offset": 49,
-              "line": 6,
-              "column": 7
-            },
-            "fullEnd": 50,
-            "start": 48,
-            "end": 49,
-            "expression": {
-              "id": 16,
-              "kind": "<variable>",
-              "startPos": {
-                "offset": 48,
-                "line": 6,
-                "column": 6
-              },
-              "fullStart": 48,
-              "endPos": {
-                "offset": 49,
-                "line": 6,
-                "column": 7
-              },
-              "fullEnd": 50,
-              "start": 48,
-              "end": 49,
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 48,
-                  "line": 6,
-                  "column": 6
-                },
-                "endPos": {
-                  "offset": 49,
-                  "line": 6,
-                  "column": 7
-                },
-                "value": "e",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 49,
-                      "line": 6,
-                      "column": 7
-                    },
-                    "endPos": {
-                      "offset": 50,
-                      "line": 6,
-                      "column": 8
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 49,
-                    "end": 50
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 48,
-                "end": 49
-              }
-            }
-          },
-          {
-            "id": 22,
-            "kind": "<list-expression>",
-            "startPos": {
-              "offset": 50,
-              "line": 6,
-              "column": 8
-            },
-            "fullStart": 50,
-            "endPos": {
-              "offset": 63,
-              "line": 6,
-              "column": 21
-            },
-            "fullEnd": 64,
-            "start": 50,
-            "end": 63,
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 50,
-                "line": 6,
-                "column": 8
-              },
-              "endPos": {
-                "offset": 51,
-                "line": 6,
-                "column": 9
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 50,
-              "end": 51
-            },
-            "elementList": [
-              {
-                "id": 21,
-                "kind": "<attribute>",
-                "startPos": {
-                  "offset": 51,
-                  "line": 6,
-                  "column": 9
-                },
-                "fullStart": 51,
-                "endPos": {
-                  "offset": 62,
-                  "line": 6,
-                  "column": 20
-                },
-                "fullEnd": 62,
-                "start": 51,
-                "end": 62,
-                "name": {
-                  "id": 18,
-                  "kind": "<identifer-stream>",
-                  "startPos": {
-                    "offset": 51,
-                    "line": 6,
-                    "column": 9
-                  },
-                  "fullStart": 51,
-                  "endPos": {
-                    "offset": 55,
-                    "line": 6,
-                    "column": 13
-                  },
-                  "fullEnd": 55,
-                  "start": 51,
-                  "end": 55,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 51,
-                        "line": 6,
-                        "column": 9
-                      },
-                      "endPos": {
-                        "offset": 55,
-                        "line": 6,
-                        "column": 13
-                      },
-                      "value": "note",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 51,
-                      "end": 55
-                    }
-                  ]
-                },
-                "value": {
-                  "id": 20,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 57,
-                    "line": 6,
-                    "column": 15
-                  },
-                  "fullStart": 57,
-                  "endPos": {
-                    "offset": 62,
-                    "line": 6,
-                    "column": 20
-                  },
-                  "fullEnd": 62,
-                  "start": 57,
-                  "end": 62,
-                  "expression": {
-                    "id": 19,
-                    "kind": "<literal>",
-                    "startPos": {
-                      "offset": 57,
-                      "line": 6,
-                      "column": 15
-                    },
-                    "fullStart": 57,
-                    "endPos": {
-                      "offset": 62,
-                      "line": 6,
-                      "column": 20
-                    },
-                    "fullEnd": 62,
-                    "start": 57,
-                    "end": 62,
-                    "literal": {
-                      "kind": "<string>",
-                      "startPos": {
-                        "offset": 57,
-                        "line": 6,
-                        "column": 15
-                      },
-                      "endPos": {
-                        "offset": 62,
-                        "line": 6,
-                        "column": 20
-                      },
-                      "value": "abc",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 57,
-                      "end": 62
-                    }
-                  }
-                },
-                "colon": {
-                  "kind": "<colon>",
-                  "startPos": {
-                    "offset": 55,
-                    "line": 6,
-                    "column": 13
-                  },
-                  "endPos": {
-                    "offset": 56,
-                    "line": 6,
-                    "column": 14
-                  },
-                  "value": ":",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 56,
-                        "line": 6,
-                        "column": 14
-                      },
-                      "endPos": {
-                        "offset": 57,
-                        "line": 6,
-                        "column": 15
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 56,
-                      "end": 57
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 55,
-                  "end": 56
-                }
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 62,
-                "line": 6,
-                "column": 20
-              },
-              "endPos": {
-                "offset": 63,
-                "line": 6,
-                "column": 21
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<newline>",
-                  "startPos": {
-                    "offset": 63,
-                    "line": 6,
-                    "column": 21
-                  },
-                  "endPos": {
-                    "offset": 64,
-                    "line": 7,
-                    "column": 0
-                  },
-                  "value": "\n",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 63,
-                  "end": 64
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 62,
-              "end": 63
-            }
-          }
-        ],
-        "symbol": 5
-      },
-      "start": 46,
-      "end": 63,
+      "start": 86,
+      "end": 87,
       "name": "CompileError"
     },
     {
@@ -7570,47 +7604,47 @@
         "id": 37,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 92,
-          "line": 8,
-          "column": 6
-        },
-        "fullStart": 92,
-        "endPos": {
-          "offset": 93,
+          "offset": 95,
           "line": 8,
           "column": 7
         },
-        "fullEnd": 94,
-        "start": 92,
-        "end": 93,
+        "fullStart": 95,
+        "endPos": {
+          "offset": 96,
+          "line": 8,
+          "column": 8
+        },
+        "fullEnd": 97,
+        "start": 95,
+        "end": 96,
         "expression": {
           "id": 36,
           "kind": "<variable>",
           "startPos": {
-            "offset": 92,
-            "line": 8,
-            "column": 6
-          },
-          "fullStart": 92,
-          "endPos": {
-            "offset": 93,
+            "offset": 95,
             "line": 8,
             "column": 7
           },
-          "fullEnd": 94,
-          "start": 92,
-          "end": 93,
+          "fullStart": 95,
+          "endPos": {
+            "offset": 96,
+            "line": 8,
+            "column": 8
+          },
+          "fullEnd": 97,
+          "start": 95,
+          "end": 96,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 92,
-              "line": 8,
-              "column": 6
-            },
-            "endPos": {
-              "offset": 93,
+              "offset": 95,
               "line": 8,
               "column": 7
+            },
+            "endPos": {
+              "offset": 96,
+              "line": 8,
+              "column": 8
             },
             "value": "e",
             "leadingTrivia": [],
@@ -7618,14 +7652,14 @@
               {
                 "kind": "<space>",
                 "startPos": {
-                  "offset": 93,
-                  "line": 8,
-                  "column": 7
-                },
-                "endPos": {
-                  "offset": 94,
+                  "offset": 96,
                   "line": 8,
                   "column": 8
+                },
+                "endPos": {
+                  "offset": 97,
+                  "line": 8,
+                  "column": 9
                 },
                 "value": " ",
                 "leadingTrivia": [],
@@ -7633,20 +7667,20 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 93,
-                "end": 94
+                "start": 96,
+                "end": 97
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 92,
-            "end": 93
+            "start": 95,
+            "end": 96
           }
         }
       },
-      "start": 92,
-      "end": 93,
+      "start": 95,
+      "end": 96,
       "name": "CompileError"
     },
     {
@@ -7656,47 +7690,47 @@
         "id": 39,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 94,
-          "line": 8,
-          "column": 8
-        },
-        "fullStart": 94,
-        "endPos": {
-          "offset": 95,
+          "offset": 97,
           "line": 8,
           "column": 9
         },
-        "fullEnd": 96,
-        "start": 94,
-        "end": 95,
+        "fullStart": 97,
+        "endPos": {
+          "offset": 98,
+          "line": 8,
+          "column": 10
+        },
+        "fullEnd": 99,
+        "start": 97,
+        "end": 98,
         "expression": {
           "id": 38,
           "kind": "<variable>",
           "startPos": {
-            "offset": 94,
-            "line": 8,
-            "column": 8
-          },
-          "fullStart": 94,
-          "endPos": {
-            "offset": 95,
+            "offset": 97,
             "line": 8,
             "column": 9
           },
-          "fullEnd": 96,
-          "start": 94,
-          "end": 95,
+          "fullStart": 97,
+          "endPos": {
+            "offset": 98,
+            "line": 8,
+            "column": 10
+          },
+          "fullEnd": 99,
+          "start": 97,
+          "end": 98,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 94,
-              "line": 8,
-              "column": 8
-            },
-            "endPos": {
-              "offset": 95,
+              "offset": 97,
               "line": 8,
               "column": 9
+            },
+            "endPos": {
+              "offset": 98,
+              "line": 8,
+              "column": 10
             },
             "value": "f",
             "leadingTrivia": [],
@@ -7704,12 +7738,12 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 95,
+                  "offset": 98,
                   "line": 8,
-                  "column": 9
+                  "column": 10
                 },
                 "endPos": {
-                  "offset": 96,
+                  "offset": 99,
                   "line": 9,
                   "column": 0
                 },
@@ -7719,949 +7753,84 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 95,
-                "end": 96
+                "start": 98,
+                "end": 99
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 94,
-            "end": 95
+            "start": 97,
+            "end": 98
           }
         }
       },
-      "start": 94,
-      "end": 95,
+      "start": 97,
+      "end": 98,
       "name": "CompileError"
     },
     {
-      "code": 3023,
-      "diagnostic": "Duplicate enum field a",
+      "code": 3028,
+      "diagnostic": "An Enum must have only a field and optionally a setting list",
       "nodeOrToken": {
-        "id": 40,
-        "kind": "<function-application>",
-        "startPos": {
-          "offset": 90,
-          "line": 8,
-          "column": 4
-        },
-        "fullStart": 86,
-        "endPos": {
-          "offset": 95,
-          "line": 8,
-          "column": 9
-        },
-        "fullEnd": 96,
-        "start": 90,
-        "end": 95,
-        "callee": {
-          "id": 35,
-          "kind": "<primary-expression>",
-          "startPos": {
-            "offset": 90,
-            "line": 8,
-            "column": 4
-          },
-          "fullStart": 86,
-          "endPos": {
-            "offset": 91,
-            "line": 8,
-            "column": 5
-          },
-          "fullEnd": 92,
-          "start": 90,
-          "end": 91,
-          "expression": {
-            "id": 34,
-            "kind": "<variable>",
-            "startPos": {
-              "offset": 90,
-              "line": 8,
-              "column": 4
-            },
-            "fullStart": 86,
-            "endPos": {
-              "offset": 91,
-              "line": 8,
-              "column": 5
-            },
-            "fullEnd": 92,
-            "start": 90,
-            "end": 91,
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 90,
-                "line": 8,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 91,
-                "line": 8,
-                "column": 5
-              },
-              "value": "a",
-              "leadingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 86,
-                    "line": 8,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 87,
-                    "line": 8,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 86,
-                  "end": 87
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 87,
-                    "line": 8,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 88,
-                    "line": 8,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 87,
-                  "end": 88
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 88,
-                    "line": 8,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 89,
-                    "line": 8,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 88,
-                  "end": 89
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 89,
-                    "line": 8,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 90,
-                    "line": 8,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 89,
-                  "end": 90
-                }
-              ],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 91,
-                    "line": 8,
-                    "column": 5
-                  },
-                  "endPos": {
-                    "offset": 92,
-                    "line": 8,
-                    "column": 6
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 91,
-                  "end": 92
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 90,
-              "end": 91
-            }
-          }
-        },
-        "args": [
-          {
-            "id": 37,
-            "kind": "<primary-expression>",
-            "startPos": {
-              "offset": 92,
-              "line": 8,
-              "column": 6
-            },
-            "fullStart": 92,
-            "endPos": {
-              "offset": 93,
-              "line": 8,
-              "column": 7
-            },
-            "fullEnd": 94,
-            "start": 92,
-            "end": 93,
-            "expression": {
-              "id": 36,
-              "kind": "<variable>",
-              "startPos": {
-                "offset": 92,
-                "line": 8,
-                "column": 6
-              },
-              "fullStart": 92,
-              "endPos": {
-                "offset": 93,
-                "line": 8,
-                "column": 7
-              },
-              "fullEnd": 94,
-              "start": 92,
-              "end": 93,
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 92,
-                  "line": 8,
-                  "column": 6
-                },
-                "endPos": {
-                  "offset": 93,
-                  "line": 8,
-                  "column": 7
-                },
-                "value": "e",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 93,
-                      "line": 8,
-                      "column": 7
-                    },
-                    "endPos": {
-                      "offset": 94,
-                      "line": 8,
-                      "column": 8
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 93,
-                    "end": 94
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 92,
-                "end": 93
-              }
-            }
-          },
-          {
-            "id": 39,
-            "kind": "<primary-expression>",
-            "startPos": {
-              "offset": 94,
-              "line": 8,
-              "column": 8
-            },
-            "fullStart": 94,
-            "endPos": {
-              "offset": 95,
-              "line": 8,
-              "column": 9
-            },
-            "fullEnd": 96,
-            "start": 94,
-            "end": 95,
-            "expression": {
-              "id": 38,
-              "kind": "<variable>",
-              "startPos": {
-                "offset": 94,
-                "line": 8,
-                "column": 8
-              },
-              "fullStart": 94,
-              "endPos": {
-                "offset": 95,
-                "line": 8,
-                "column": 9
-              },
-              "fullEnd": 96,
-              "start": 94,
-              "end": 95,
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 94,
-                  "line": 8,
-                  "column": 8
-                },
-                "endPos": {
-                  "offset": 95,
-                  "line": 8,
-                  "column": 9
-                },
-                "value": "f",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<newline>",
-                    "startPos": {
-                      "offset": 95,
-                      "line": 8,
-                      "column": 9
-                    },
-                    "endPos": {
-                      "offset": 96,
-                      "line": 9,
-                      "column": 0
-                    },
-                    "value": "\n",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 95,
-                    "end": 96
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 94,
-                "end": 95
-              }
-            }
-          }
-        ],
-        "symbol": 7
-      },
-      "start": 90,
-      "end": 95,
-      "name": "CompileError"
-    },
-    {
-      "code": 3023,
-      "diagnostic": "Duplicate enum field a",
-      "nodeOrToken": {
-        "id": 23,
-        "kind": "<function-application>",
-        "startPos": {
-          "offset": 46,
-          "line": 6,
-          "column": 4
-        },
-        "fullStart": 42,
-        "endPos": {
-          "offset": 63,
-          "line": 6,
-          "column": 21
-        },
-        "fullEnd": 64,
-        "start": 46,
-        "end": 63,
-        "callee": {
-          "id": 15,
-          "kind": "<primary-expression>",
-          "startPos": {
-            "offset": 46,
-            "line": 6,
-            "column": 4
-          },
-          "fullStart": 42,
-          "endPos": {
-            "offset": 47,
-            "line": 6,
-            "column": 5
-          },
-          "fullEnd": 48,
-          "start": 46,
-          "end": 47,
-          "expression": {
-            "id": 14,
-            "kind": "<variable>",
-            "startPos": {
-              "offset": 46,
-              "line": 6,
-              "column": 4
-            },
-            "fullStart": 42,
-            "endPos": {
-              "offset": 47,
-              "line": 6,
-              "column": 5
-            },
-            "fullEnd": 48,
-            "start": 46,
-            "end": 47,
-            "variable": {
-              "kind": "<identifier>",
-              "startPos": {
-                "offset": 46,
-                "line": 6,
-                "column": 4
-              },
-              "endPos": {
-                "offset": 47,
-                "line": 6,
-                "column": 5
-              },
-              "value": "a",
-              "leadingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 42,
-                    "line": 6,
-                    "column": 0
-                  },
-                  "endPos": {
-                    "offset": 43,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 42,
-                  "end": 43
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 43,
-                    "line": 6,
-                    "column": 1
-                  },
-                  "endPos": {
-                    "offset": 44,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 43,
-                  "end": 44
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 44,
-                    "line": 6,
-                    "column": 2
-                  },
-                  "endPos": {
-                    "offset": 45,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 44,
-                  "end": 45
-                },
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 45,
-                    "line": 6,
-                    "column": 3
-                  },
-                  "endPos": {
-                    "offset": 46,
-                    "line": 6,
-                    "column": 4
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 45,
-                  "end": 46
-                }
-              ],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 47,
-                    "line": 6,
-                    "column": 5
-                  },
-                  "endPos": {
-                    "offset": 48,
-                    "line": 6,
-                    "column": 6
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 47,
-                  "end": 48
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 46,
-              "end": 47
-            }
-          }
-        },
-        "args": [
-          {
-            "id": 17,
-            "kind": "<primary-expression>",
-            "startPos": {
-              "offset": 48,
-              "line": 6,
-              "column": 6
-            },
-            "fullStart": 48,
-            "endPos": {
-              "offset": 49,
-              "line": 6,
-              "column": 7
-            },
-            "fullEnd": 50,
-            "start": 48,
-            "end": 49,
-            "expression": {
-              "id": 16,
-              "kind": "<variable>",
-              "startPos": {
-                "offset": 48,
-                "line": 6,
-                "column": 6
-              },
-              "fullStart": 48,
-              "endPos": {
-                "offset": 49,
-                "line": 6,
-                "column": 7
-              },
-              "fullEnd": 50,
-              "start": 48,
-              "end": 49,
-              "variable": {
-                "kind": "<identifier>",
-                "startPos": {
-                  "offset": 48,
-                  "line": 6,
-                  "column": 6
-                },
-                "endPos": {
-                  "offset": 49,
-                  "line": 6,
-                  "column": 7
-                },
-                "value": "e",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 49,
-                      "line": 6,
-                      "column": 7
-                    },
-                    "endPos": {
-                      "offset": 50,
-                      "line": 6,
-                      "column": 8
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 49,
-                    "end": 50
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 48,
-                "end": 49
-              }
-            }
-          },
-          {
-            "id": 22,
-            "kind": "<list-expression>",
-            "startPos": {
-              "offset": 50,
-              "line": 6,
-              "column": 8
-            },
-            "fullStart": 50,
-            "endPos": {
-              "offset": 63,
-              "line": 6,
-              "column": 21
-            },
-            "fullEnd": 64,
-            "start": 50,
-            "end": 63,
-            "listOpenBracket": {
-              "kind": "<lbracket>",
-              "startPos": {
-                "offset": 50,
-                "line": 6,
-                "column": 8
-              },
-              "endPos": {
-                "offset": 51,
-                "line": 6,
-                "column": 9
-              },
-              "value": "[",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 50,
-              "end": 51
-            },
-            "elementList": [
-              {
-                "id": 21,
-                "kind": "<attribute>",
-                "startPos": {
-                  "offset": 51,
-                  "line": 6,
-                  "column": 9
-                },
-                "fullStart": 51,
-                "endPos": {
-                  "offset": 62,
-                  "line": 6,
-                  "column": 20
-                },
-                "fullEnd": 62,
-                "start": 51,
-                "end": 62,
-                "name": {
-                  "id": 18,
-                  "kind": "<identifer-stream>",
-                  "startPos": {
-                    "offset": 51,
-                    "line": 6,
-                    "column": 9
-                  },
-                  "fullStart": 51,
-                  "endPos": {
-                    "offset": 55,
-                    "line": 6,
-                    "column": 13
-                  },
-                  "fullEnd": 55,
-                  "start": 51,
-                  "end": 55,
-                  "identifiers": [
-                    {
-                      "kind": "<identifier>",
-                      "startPos": {
-                        "offset": 51,
-                        "line": 6,
-                        "column": 9
-                      },
-                      "endPos": {
-                        "offset": 55,
-                        "line": 6,
-                        "column": 13
-                      },
-                      "value": "note",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 51,
-                      "end": 55
-                    }
-                  ]
-                },
-                "value": {
-                  "id": 20,
-                  "kind": "<primary-expression>",
-                  "startPos": {
-                    "offset": 57,
-                    "line": 6,
-                    "column": 15
-                  },
-                  "fullStart": 57,
-                  "endPos": {
-                    "offset": 62,
-                    "line": 6,
-                    "column": 20
-                  },
-                  "fullEnd": 62,
-                  "start": 57,
-                  "end": 62,
-                  "expression": {
-                    "id": 19,
-                    "kind": "<literal>",
-                    "startPos": {
-                      "offset": 57,
-                      "line": 6,
-                      "column": 15
-                    },
-                    "fullStart": 57,
-                    "endPos": {
-                      "offset": 62,
-                      "line": 6,
-                      "column": 20
-                    },
-                    "fullEnd": 62,
-                    "start": 57,
-                    "end": 62,
-                    "literal": {
-                      "kind": "<string>",
-                      "startPos": {
-                        "offset": 57,
-                        "line": 6,
-                        "column": 15
-                      },
-                      "endPos": {
-                        "offset": 62,
-                        "line": 6,
-                        "column": 20
-                      },
-                      "value": "abc",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 57,
-                      "end": 62
-                    }
-                  }
-                },
-                "colon": {
-                  "kind": "<colon>",
-                  "startPos": {
-                    "offset": 55,
-                    "line": 6,
-                    "column": 13
-                  },
-                  "endPos": {
-                    "offset": 56,
-                    "line": 6,
-                    "column": 14
-                  },
-                  "value": ":",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "<space>",
-                      "startPos": {
-                        "offset": 56,
-                        "line": 6,
-                        "column": 14
-                      },
-                      "endPos": {
-                        "offset": 57,
-                        "line": 6,
-                        "column": 15
-                      },
-                      "value": " ",
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "leadingInvalid": [],
-                      "trailingInvalid": [],
-                      "isInvalid": false,
-                      "start": 56,
-                      "end": 57
-                    }
-                  ],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 55,
-                  "end": 56
-                }
-              }
-            ],
-            "commaList": [],
-            "listCloseBracket": {
-              "kind": "<rbracket>",
-              "startPos": {
-                "offset": 62,
-                "line": 6,
-                "column": 20
-              },
-              "endPos": {
-                "offset": 63,
-                "line": 6,
-                "column": 21
-              },
-              "value": "]",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<newline>",
-                  "startPos": {
-                    "offset": 63,
-                    "line": 6,
-                    "column": 21
-                  },
-                  "endPos": {
-                    "offset": 64,
-                    "line": 7,
-                    "column": 0
-                  },
-                  "value": "\n",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 63,
-                  "end": 64
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 62,
-              "end": 63
-            }
-          }
-        ],
-        "symbol": 5
-      },
-      "start": 46,
-      "end": 63,
-      "name": "CompileError"
-    },
-    {
-      "code": 3017,
-      "diagnostic": "A TableGroup field should only have a single Table name",
-      "nodeOrToken": {
-        "id": 48,
+        "id": 44,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 120,
-          "line": 12,
-          "column": 6
-        },
-        "fullStart": 120,
-        "endPos": {
-          "offset": 121,
-          "line": 12,
+          "offset": 106,
+          "line": 9,
           "column": 7
         },
-        "fullEnd": 122,
-        "start": 120,
-        "end": 121,
+        "fullStart": 106,
+        "endPos": {
+          "offset": 107,
+          "line": 9,
+          "column": 8
+        },
+        "fullEnd": 108,
+        "start": 106,
+        "end": 107,
         "expression": {
-          "id": 47,
+          "id": 43,
           "kind": "<variable>",
           "startPos": {
-            "offset": 120,
-            "line": 12,
-            "column": 6
-          },
-          "fullStart": 120,
-          "endPos": {
-            "offset": 121,
-            "line": 12,
+            "offset": 106,
+            "line": 9,
             "column": 7
           },
-          "fullEnd": 122,
-          "start": 120,
-          "end": 121,
+          "fullStart": 106,
+          "endPos": {
+            "offset": 107,
+            "line": 9,
+            "column": 8
+          },
+          "fullEnd": 108,
+          "start": 106,
+          "end": 107,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 120,
-              "line": 12,
-              "column": 6
-            },
-            "endPos": {
-              "offset": 121,
-              "line": 12,
+              "offset": 106,
+              "line": 9,
               "column": 7
             },
-            "value": "a",
+            "endPos": {
+              "offset": 107,
+              "line": 9,
+              "column": 8
+            },
+            "value": "e",
             "leadingTrivia": [],
             "trailingTrivia": [
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 121,
-                  "line": 12,
-                  "column": 7
+                  "offset": 107,
+                  "line": 9,
+                  "column": 8
                 },
                 "endPos": {
-                  "offset": 122,
-                  "line": 13,
+                  "offset": 108,
+                  "line": 10,
                   "column": 0
                 },
                 "value": "\n",
@@ -8670,20 +7839,20 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 121,
-                "end": 122
+                "start": 107,
+                "end": 108
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 120,
-            "end": 121
+            "start": 106,
+            "end": 107
           }
         }
       },
-      "start": 120,
-      "end": 121,
+      "start": 106,
+      "end": 107,
       "name": "CompileError"
     },
     {
@@ -8693,45 +7862,45 @@
         "id": 53,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 128,
+          "offset": 132,
           "line": 13,
           "column": 6
         },
-        "fullStart": 128,
+        "fullStart": 132,
         "endPos": {
-          "offset": 129,
+          "offset": 133,
           "line": 13,
           "column": 7
         },
-        "fullEnd": 130,
-        "start": 128,
-        "end": 129,
+        "fullEnd": 134,
+        "start": 132,
+        "end": 133,
         "expression": {
           "id": 52,
           "kind": "<variable>",
           "startPos": {
-            "offset": 128,
+            "offset": 132,
             "line": 13,
             "column": 6
           },
-          "fullStart": 128,
+          "fullStart": 132,
           "endPos": {
-            "offset": 129,
+            "offset": 133,
             "line": 13,
             "column": 7
           },
-          "fullEnd": 130,
-          "start": 128,
-          "end": 129,
+          "fullEnd": 134,
+          "start": 132,
+          "end": 133,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 128,
+              "offset": 132,
               "line": 13,
               "column": 6
             },
             "endPos": {
-              "offset": 129,
+              "offset": 133,
               "line": 13,
               "column": 7
             },
@@ -8739,100 +7908,14 @@
             "leadingTrivia": [],
             "trailingTrivia": [
               {
-                "kind": "<space>",
+                "kind": "<newline>",
                 "startPos": {
-                  "offset": 129,
+                  "offset": 133,
                   "line": 13,
                   "column": 7
                 },
                 "endPos": {
-                  "offset": 130,
-                  "line": 13,
-                  "column": 8
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 129,
-                "end": 130
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 128,
-            "end": 129
-          }
-        }
-      },
-      "start": 128,
-      "end": 129,
-      "name": "CompileError"
-    },
-    {
-      "code": 3017,
-      "diagnostic": "A TableGroup field should only have a single Table name",
-      "nodeOrToken": {
-        "id": 55,
-        "kind": "<primary-expression>",
-        "startPos": {
-          "offset": 130,
-          "line": 13,
-          "column": 8
-        },
-        "fullStart": 130,
-        "endPos": {
-          "offset": 131,
-          "line": 13,
-          "column": 9
-        },
-        "fullEnd": 132,
-        "start": 130,
-        "end": 131,
-        "expression": {
-          "id": 54,
-          "kind": "<variable>",
-          "startPos": {
-            "offset": 130,
-            "line": 13,
-            "column": 8
-          },
-          "fullStart": 130,
-          "endPos": {
-            "offset": 131,
-            "line": 13,
-            "column": 9
-          },
-          "fullEnd": 132,
-          "start": 130,
-          "end": 131,
-          "variable": {
-            "kind": "<identifier>",
-            "startPos": {
-              "offset": 130,
-              "line": 13,
-              "column": 8
-            },
-            "endPos": {
-              "offset": 131,
-              "line": 13,
-              "column": 9
-            },
-            "value": "a",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<newline>",
-                "startPos": {
-                  "offset": 131,
-                  "line": 13,
-                  "column": 9
-                },
-                "endPos": {
-                  "offset": 132,
+                  "offset": 134,
                   "line": 14,
                   "column": 0
                 },
@@ -8842,69 +7925,241 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 131,
-                "end": 132
+                "start": 133,
+                "end": 134
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 130,
-            "end": 131
+            "start": 132,
+            "end": 133
           }
         }
       },
-      "start": 130,
-      "end": 131,
+      "start": 132,
+      "end": 133,
+      "name": "CompileError"
+    },
+    {
+      "code": 3017,
+      "diagnostic": "A TableGroup field should only have a single Table name",
+      "nodeOrToken": {
+        "id": 58,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 140,
+          "line": 14,
+          "column": 6
+        },
+        "fullStart": 140,
+        "endPos": {
+          "offset": 141,
+          "line": 14,
+          "column": 7
+        },
+        "fullEnd": 142,
+        "start": 140,
+        "end": 141,
+        "expression": {
+          "id": 57,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 140,
+            "line": 14,
+            "column": 6
+          },
+          "fullStart": 140,
+          "endPos": {
+            "offset": 141,
+            "line": 14,
+            "column": 7
+          },
+          "fullEnd": 142,
+          "start": 140,
+          "end": 141,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 140,
+              "line": 14,
+              "column": 6
+            },
+            "endPos": {
+              "offset": 141,
+              "line": 14,
+              "column": 7
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 141,
+                  "line": 14,
+                  "column": 7
+                },
+                "endPos": {
+                  "offset": 142,
+                  "line": 14,
+                  "column": 8
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 141,
+                "end": 142
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 140,
+            "end": 141
+          }
+        }
+      },
+      "start": 140,
+      "end": 141,
+      "name": "CompileError"
+    },
+    {
+      "code": 3017,
+      "diagnostic": "A TableGroup field should only have a single Table name",
+      "nodeOrToken": {
+        "id": 60,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 142,
+          "line": 14,
+          "column": 8
+        },
+        "fullStart": 142,
+        "endPos": {
+          "offset": 143,
+          "line": 14,
+          "column": 9
+        },
+        "fullEnd": 144,
+        "start": 142,
+        "end": 143,
+        "expression": {
+          "id": 59,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 142,
+            "line": 14,
+            "column": 8
+          },
+          "fullStart": 142,
+          "endPos": {
+            "offset": 143,
+            "line": 14,
+            "column": 9
+          },
+          "fullEnd": 144,
+          "start": 142,
+          "end": 143,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 142,
+              "line": 14,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 143,
+              "line": 14,
+              "column": 9
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 143,
+                  "line": 14,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 144,
+                  "line": 15,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 143,
+                "end": 144
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 142,
+            "end": 143
+          }
+        }
+      },
+      "start": 142,
+      "end": 143,
       "name": "CompileError"
     },
     {
       "code": 3039,
       "diagnostic": "A Ref field should only have a single binary relationship",
       "nodeOrToken": {
-        "id": 76,
+        "id": 81,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 175,
-          "line": 17,
+          "offset": 187,
+          "line": 18,
           "column": 34
         },
-        "fullStart": 175,
+        "fullStart": 187,
         "endPos": {
-          "offset": 176,
-          "line": 17,
+          "offset": 188,
+          "line": 18,
           "column": 35
         },
-        "fullEnd": 177,
-        "start": 175,
-        "end": 176,
+        "fullEnd": 189,
+        "start": 187,
+        "end": 188,
         "expression": {
-          "id": 75,
+          "id": 80,
           "kind": "<variable>",
           "startPos": {
-            "offset": 175,
-            "line": 17,
+            "offset": 187,
+            "line": 18,
             "column": 34
           },
-          "fullStart": 175,
+          "fullStart": 187,
           "endPos": {
-            "offset": 176,
-            "line": 17,
+            "offset": 188,
+            "line": 18,
             "column": 35
           },
-          "fullEnd": 177,
-          "start": 175,
-          "end": 176,
+          "fullEnd": 189,
+          "start": 187,
+          "end": 188,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 175,
-              "line": 17,
+              "offset": 187,
+              "line": 18,
               "column": 34
             },
             "endPos": {
-              "offset": 176,
-              "line": 17,
+              "offset": 188,
+              "line": 18,
               "column": 35
             },
             "value": "a",
@@ -8913,13 +8168,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 176,
-                  "line": 17,
+                  "offset": 188,
+                  "line": 18,
                   "column": 35
                 },
                 "endPos": {
-                  "offset": 177,
-                  "line": 18,
+                  "offset": 189,
+                  "line": 19,
                   "column": 0
                 },
                 "value": "\n",
@@ -8928,69 +8183,69 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 176,
-                "end": 177
+                "start": 188,
+                "end": 189
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 175,
-            "end": 176
+            "start": 187,
+            "end": 188
           }
         }
       },
-      "start": 175,
-      "end": 176,
+      "start": 187,
+      "end": 188,
       "name": "CompileError"
     },
     {
       "code": 3039,
       "diagnostic": "A Ref field should only have a single binary relationship",
       "nodeOrToken": {
-        "id": 92,
+        "id": 97,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 202,
-          "line": 21,
+          "offset": 214,
+          "line": 22,
           "column": 16
         },
-        "fullStart": 202,
+        "fullStart": 214,
         "endPos": {
-          "offset": 203,
-          "line": 21,
+          "offset": 215,
+          "line": 22,
           "column": 17
         },
-        "fullEnd": 204,
-        "start": 202,
-        "end": 203,
+        "fullEnd": 216,
+        "start": 214,
+        "end": 215,
         "expression": {
-          "id": 91,
+          "id": 96,
           "kind": "<variable>",
           "startPos": {
-            "offset": 202,
-            "line": 21,
+            "offset": 214,
+            "line": 22,
             "column": 16
           },
-          "fullStart": 202,
+          "fullStart": 214,
           "endPos": {
-            "offset": 203,
-            "line": 21,
+            "offset": 215,
+            "line": 22,
             "column": 17
           },
-          "fullEnd": 204,
-          "start": 202,
-          "end": 203,
+          "fullEnd": 216,
+          "start": 214,
+          "end": 215,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 202,
-              "line": 21,
+              "offset": 214,
+              "line": 22,
               "column": 16
             },
             "endPos": {
-              "offset": 203,
-              "line": 21,
+              "offset": 215,
+              "line": 22,
               "column": 17
             },
             "value": "a",
@@ -8999,13 +8254,13 @@
               {
                 "kind": "<space>",
                 "startPos": {
-                  "offset": 203,
-                  "line": 21,
+                  "offset": 215,
+                  "line": 22,
                   "column": 17
                 },
                 "endPos": {
-                  "offset": 204,
-                  "line": 21,
+                  "offset": 216,
+                  "line": 22,
                   "column": 18
                 },
                 "value": " ",
@@ -9014,69 +8269,155 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 203,
-                "end": 204
+                "start": 215,
+                "end": 216
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 202,
-            "end": 203
+            "start": 214,
+            "end": 215
           }
         }
       },
-      "start": 202,
-      "end": 203,
+      "start": 214,
+      "end": 215,
       "name": "CompileError"
     },
     {
       "code": 3039,
       "diagnostic": "A Ref field should only have a single binary relationship",
       "nodeOrToken": {
-        "id": 113,
+        "id": 118,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 247,
-          "line": 25,
+          "offset": 259,
+          "line": 26,
           "column": 16
         },
-        "fullStart": 247,
+        "fullStart": 259,
         "endPos": {
-          "offset": 248,
-          "line": 25,
+          "offset": 260,
+          "line": 26,
           "column": 17
         },
-        "fullEnd": 249,
-        "start": 247,
-        "end": 248,
+        "fullEnd": 261,
+        "start": 259,
+        "end": 260,
         "expression": {
-          "id": 112,
+          "id": 117,
           "kind": "<variable>",
           "startPos": {
-            "offset": 247,
-            "line": 25,
+            "offset": 259,
+            "line": 26,
             "column": 16
           },
-          "fullStart": 247,
+          "fullStart": 259,
           "endPos": {
-            "offset": 248,
-            "line": 25,
+            "offset": 260,
+            "line": 26,
             "column": 17
           },
-          "fullEnd": 249,
-          "start": 247,
-          "end": 248,
+          "fullEnd": 261,
+          "start": 259,
+          "end": 260,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 247,
-              "line": 25,
+              "offset": 259,
+              "line": 26,
               "column": 16
             },
             "endPos": {
-              "offset": 248,
-              "line": 25,
+              "offset": 260,
+              "line": 26,
+              "column": 17
+            },
+            "value": "a",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 260,
+                  "line": 26,
+                  "column": 17
+                },
+                "endPos": {
+                  "offset": 261,
+                  "line": 27,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 260,
+                "end": 261
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 259,
+            "end": 260
+          }
+        }
+      },
+      "start": 259,
+      "end": 260,
+      "name": "CompileError"
+    },
+    {
+      "code": 3039,
+      "diagnostic": "A Ref field should only have a single binary relationship",
+      "nodeOrToken": {
+        "id": 134,
+        "kind": "<primary-expression>",
+        "startPos": {
+          "offset": 286,
+          "line": 30,
+          "column": 16
+        },
+        "fullStart": 286,
+        "endPos": {
+          "offset": 287,
+          "line": 30,
+          "column": 17
+        },
+        "fullEnd": 288,
+        "start": 286,
+        "end": 287,
+        "expression": {
+          "id": 133,
+          "kind": "<variable>",
+          "startPos": {
+            "offset": 286,
+            "line": 30,
+            "column": 16
+          },
+          "fullStart": 286,
+          "endPos": {
+            "offset": 287,
+            "line": 30,
+            "column": 17
+          },
+          "fullEnd": 288,
+          "start": 286,
+          "end": 287,
+          "variable": {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 286,
+              "line": 30,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 287,
+              "line": 30,
               "column": 17
             },
             "value": "a",
@@ -9085,13 +8426,13 @@
               {
                 "kind": "<space>",
                 "startPos": {
-                  "offset": 248,
-                  "line": 25,
+                  "offset": 287,
+                  "line": 30,
                   "column": 17
                 },
                 "endPos": {
-                  "offset": 249,
-                  "line": 25,
+                  "offset": 288,
+                  "line": 30,
                   "column": 18
                 },
                 "value": " ",
@@ -9100,69 +8441,69 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 248,
-                "end": 249
+                "start": 287,
+                "end": 288
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 247,
-            "end": 248
+            "start": 286,
+            "end": 287
           }
         }
       },
-      "start": 247,
-      "end": 248,
+      "start": 286,
+      "end": 287,
       "name": "CompileError"
     },
     {
       "code": 3039,
       "diagnostic": "A Ref field should only have a single binary relationship",
       "nodeOrToken": {
-        "id": 115,
+        "id": 136,
         "kind": "<primary-expression>",
         "startPos": {
-          "offset": 249,
-          "line": 25,
+          "offset": 288,
+          "line": 30,
           "column": 18
         },
-        "fullStart": 249,
+        "fullStart": 288,
         "endPos": {
-          "offset": 250,
-          "line": 25,
+          "offset": 289,
+          "line": 30,
           "column": 19
         },
-        "fullEnd": 251,
-        "start": 249,
-        "end": 250,
+        "fullEnd": 290,
+        "start": 288,
+        "end": 289,
         "expression": {
-          "id": 114,
+          "id": 135,
           "kind": "<variable>",
           "startPos": {
-            "offset": 249,
-            "line": 25,
+            "offset": 288,
+            "line": 30,
             "column": 18
           },
-          "fullStart": 249,
+          "fullStart": 288,
           "endPos": {
-            "offset": 250,
-            "line": 25,
+            "offset": 289,
+            "line": 30,
             "column": 19
           },
-          "fullEnd": 251,
-          "start": 249,
-          "end": 250,
+          "fullEnd": 290,
+          "start": 288,
+          "end": 289,
           "variable": {
             "kind": "<identifier>",
             "startPos": {
-              "offset": 249,
-              "line": 25,
+              "offset": 288,
+              "line": 30,
               "column": 18
             },
             "endPos": {
-              "offset": 250,
-              "line": 25,
+              "offset": 289,
+              "line": 30,
               "column": 19
             },
             "value": "a",
@@ -9171,13 +8512,13 @@
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 250,
-                  "line": 25,
+                  "offset": 289,
+                  "line": 30,
                   "column": 19
                 },
                 "endPos": {
-                  "offset": 251,
-                  "line": 26,
+                  "offset": 290,
+                  "line": 31,
                   "column": 0
                 },
                 "value": "\n",
@@ -9186,20 +8527,20 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 250,
-                "end": 251
+                "start": 289,
+                "end": 290
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 249,
-            "end": 250
+            "start": 288,
+            "end": 289
           }
         }
       },
-      "start": 249,
-      "end": 250,
+      "start": 288,
+      "end": 289,
       "name": "CompileError"
     }
   ]


### PR DESCRIPTION
## Summary
* Fix the problem:
  ```
    Enum Person {
       id integer
    }
  ```
  go uncaught in the validator
* The old bug was because the optional setting list was not treated properly.
* Fix the error message of invalid enum field.
* Fix the uncaught error in this situation:
   
![image](https://github.com/holistics/dbml/assets/139191192/36de44cc-721d-4c39-8e2c-464632b48c33)

  
## Issue
(issue link here)

## Lasting Changes (Technical)

* `getMemberChain` takes `ArrayNode` into account
* Enum and Ref validator

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review