### PR TITLE
Fix circular ref

### DIFF
--- a/packages/dbml-parse/src/lib/interpreter/utils.ts
+++ b/packages/dbml-parse/src/lib/interpreter/utils.ts
@@ -93,7 +93,7 @@ export function getRefId(sym1: ColumnSymbol | ColumnSymbol[], sym2: ColumnSymbol
   if (Array.isArray(sym1)) {
     const firstIds = sym1.map(({ id }) => id).sort().join(',');  
     const secondIds = (sym2 as ColumnSymbol[]).map(({ id }) => id).sort().join(',');  
-    return firstIds < secondIds ? `${firstIds}-${secondIds}` : `${firstIds}-${secondIds}`;
+    return firstIds < secondIds ? `${firstIds}-${secondIds}` : `${secondIds}-${firstIds}`;
   }
 
   const firstId = sym1.id;

--- a/packages/dbml-parse/tests/interpreter/input/circular_ref_1_inline_1_element.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/circular_ref_1_inline_1_element.in.dbml
@@ -1,0 +1,12 @@
+Table A {
+    id int [ref: > B.id] // circular ref 0
+    name string [ref: > B.name] // circular ref 1
+}
+
+Table B {
+    id int
+    name string
+    Ref: name > A.name // circular ref 1
+}
+
+Ref: B.id > A.id // circular ref 0

--- a/packages/dbml-parse/tests/interpreter/input/circular_ref_2_elements.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/circular_ref_2_elements.in.dbml
@@ -1,0 +1,10 @@
+Table A {
+    id int
+}
+
+Table B {
+    id int
+}
+
+Ref: A.id > B.id
+Ref: B.id > A.id

--- a/packages/dbml-parse/tests/interpreter/input/circular_ref_2_inlines.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/circular_ref_2_inlines.in.dbml
@@ -1,0 +1,7 @@
+Table A {
+    id int [ref: > B.id]
+}
+
+Table B {
+    id int [ref: > A.id]
+}

--- a/packages/dbml-parse/tests/interpreter/output/circular_ref_1_inline_1_element.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/circular_ref_1_inline_1_element.out.json
@@ -1,0 +1,1760 @@
+[
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 53,
+      "kind": "<element-declaration>",
+      "startPos": {
+        "offset": 147,
+        "line": 8,
+        "column": 4
+      },
+      "fullStart": 143,
+      "endPos": {
+        "offset": 165,
+        "line": 8,
+        "column": 22
+      },
+      "fullEnd": 184,
+      "start": 147,
+      "end": 165,
+      "type": {
+        "kind": "<identifier>",
+        "startPos": {
+          "offset": 147,
+          "line": 8,
+          "column": 4
+        },
+        "endPos": {
+          "offset": 150,
+          "line": 8,
+          "column": 7
+        },
+        "value": "Ref",
+        "leadingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 143,
+              "line": 8,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 144,
+              "line": 8,
+              "column": 1
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 143,
+            "end": 144
+          },
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 144,
+              "line": 8,
+              "column": 1
+            },
+            "endPos": {
+              "offset": 145,
+              "line": 8,
+              "column": 2
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 144,
+            "end": 145
+          },
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 145,
+              "line": 8,
+              "column": 2
+            },
+            "endPos": {
+              "offset": 146,
+              "line": 8,
+              "column": 3
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 145,
+            "end": 146
+          },
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 146,
+              "line": 8,
+              "column": 3
+            },
+            "endPos": {
+              "offset": 147,
+              "line": 8,
+              "column": 4
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 146,
+            "end": 147
+          }
+        ],
+        "trailingTrivia": [],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 147,
+        "end": 150
+      },
+      "bodyColon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 150,
+          "line": 8,
+          "column": 7
+        },
+        "endPos": {
+          "offset": 151,
+          "line": 8,
+          "column": 8
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 151,
+              "line": 8,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 152,
+              "line": 8,
+              "column": 9
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 151,
+            "end": 152
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 150,
+        "end": 151
+      },
+      "body": {
+        "id": 52,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 152,
+          "line": 8,
+          "column": 9
+        },
+        "fullStart": 152,
+        "endPos": {
+          "offset": 165,
+          "line": 8,
+          "column": 22
+        },
+        "fullEnd": 184,
+        "start": 152,
+        "end": 165,
+        "callee": {
+          "id": 51,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 152,
+            "line": 8,
+            "column": 9
+          },
+          "fullStart": 152,
+          "endPos": {
+            "offset": 165,
+            "line": 8,
+            "column": 22
+          },
+          "fullEnd": 184,
+          "start": 152,
+          "end": 165,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 157,
+              "line": 8,
+              "column": 14
+            },
+            "endPos": {
+              "offset": 158,
+              "line": 8,
+              "column": 15
+            },
+            "value": ">",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 158,
+                  "line": 8,
+                  "column": 15
+                },
+                "endPos": {
+                  "offset": 159,
+                  "line": 8,
+                  "column": 16
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 158,
+                "end": 159
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 157,
+            "end": 158
+          },
+          "leftExpression": {
+            "id": 45,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 152,
+              "line": 8,
+              "column": 9
+            },
+            "fullStart": 152,
+            "endPos": {
+              "offset": 156,
+              "line": 8,
+              "column": 13
+            },
+            "fullEnd": 157,
+            "start": 152,
+            "end": 156,
+            "expression": {
+              "id": 44,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 152,
+                "line": 8,
+                "column": 9
+              },
+              "fullStart": 152,
+              "endPos": {
+                "offset": 156,
+                "line": 8,
+                "column": 13
+              },
+              "fullEnd": 157,
+              "start": 152,
+              "end": 156,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 152,
+                  "line": 8,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 156,
+                  "line": 8,
+                  "column": 13
+                },
+                "value": "name",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 156,
+                      "line": 8,
+                      "column": 13
+                    },
+                    "endPos": {
+                      "offset": 157,
+                      "line": 8,
+                      "column": 14
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 156,
+                    "end": 157
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 152,
+                "end": 156
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 50,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 159,
+              "line": 8,
+              "column": 16
+            },
+            "fullStart": 159,
+            "endPos": {
+              "offset": 165,
+              "line": 8,
+              "column": 22
+            },
+            "fullEnd": 184,
+            "start": 159,
+            "end": 165,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 160,
+                "line": 8,
+                "column": 17
+              },
+              "endPos": {
+                "offset": 161,
+                "line": 8,
+                "column": 18
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 160,
+              "end": 161
+            },
+            "leftExpression": {
+              "id": 47,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 159,
+                "line": 8,
+                "column": 16
+              },
+              "fullStart": 159,
+              "endPos": {
+                "offset": 160,
+                "line": 8,
+                "column": 17
+              },
+              "fullEnd": 160,
+              "start": 159,
+              "end": 160,
+              "expression": {
+                "id": 46,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 159,
+                  "line": 8,
+                  "column": 16
+                },
+                "fullStart": 159,
+                "endPos": {
+                  "offset": 160,
+                  "line": 8,
+                  "column": 17
+                },
+                "fullEnd": 160,
+                "start": 159,
+                "end": 160,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 159,
+                    "line": 8,
+                    "column": 16
+                  },
+                  "endPos": {
+                    "offset": 160,
+                    "line": 8,
+                    "column": 17
+                  },
+                  "value": "A",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 159,
+                  "end": 160
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 49,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 161,
+                "line": 8,
+                "column": 18
+              },
+              "fullStart": 161,
+              "endPos": {
+                "offset": 165,
+                "line": 8,
+                "column": 22
+              },
+              "fullEnd": 184,
+              "start": 161,
+              "end": 165,
+              "expression": {
+                "id": 48,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 161,
+                  "line": 8,
+                  "column": 18
+                },
+                "fullStart": 161,
+                "endPos": {
+                  "offset": 165,
+                  "line": 8,
+                  "column": 22
+                },
+                "fullEnd": 184,
+                "start": 161,
+                "end": 165,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 161,
+                    "line": 8,
+                    "column": 18
+                  },
+                  "endPos": {
+                    "offset": 165,
+                    "line": 8,
+                    "column": 22
+                  },
+                  "value": "name",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 165,
+                        "line": 8,
+                        "column": 22
+                      },
+                      "endPos": {
+                        "offset": 166,
+                        "line": 8,
+                        "column": 23
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 165,
+                      "end": 166
+                    },
+                    {
+                      "kind": "<single-line-comment>",
+                      "startPos": {
+                        "offset": 166,
+                        "line": 8,
+                        "column": 23
+                      },
+                      "endPos": {
+                        "offset": 183,
+                        "line": 8,
+                        "column": 40
+                      },
+                      "value": " circular ref 1",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 166,
+                      "end": 183
+                    },
+                    {
+                      "kind": "<newline>",
+                      "startPos": {
+                        "offset": 183,
+                        "line": 8,
+                        "column": 40
+                      },
+                      "endPos": {
+                        "offset": 184,
+                        "line": 9,
+                        "column": 0
+                      },
+                      "value": "\n",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 183,
+                      "end": 184
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 161,
+                  "end": 165
+                }
+              }
+            }
+          }
+        },
+        "args": []
+      }
+    },
+    "start": 147,
+    "end": 165,
+    "name": "CompileError"
+  },
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 27,
+      "kind": "<attribute>",
+      "startPos": {
+        "offset": 70,
+        "line": 2,
+        "column": 17
+      },
+      "fullStart": 70,
+      "endPos": {
+        "offset": 83,
+        "line": 2,
+        "column": 30
+      },
+      "fullEnd": 83,
+      "start": 70,
+      "end": 83,
+      "name": {
+        "id": 20,
+        "kind": "<identifer-stream>",
+        "startPos": {
+          "offset": 70,
+          "line": 2,
+          "column": 17
+        },
+        "fullStart": 70,
+        "endPos": {
+          "offset": 73,
+          "line": 2,
+          "column": 20
+        },
+        "fullEnd": 73,
+        "start": 70,
+        "end": 73,
+        "identifiers": [
+          {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 70,
+              "line": 2,
+              "column": 17
+            },
+            "endPos": {
+              "offset": 73,
+              "line": 2,
+              "column": 20
+            },
+            "value": "ref",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 70,
+            "end": 73
+          }
+        ]
+      },
+      "value": {
+        "id": 26,
+        "kind": "<prefix-expression>",
+        "startPos": {
+          "offset": 75,
+          "line": 2,
+          "column": 22
+        },
+        "fullStart": 75,
+        "endPos": {
+          "offset": 83,
+          "line": 2,
+          "column": 30
+        },
+        "fullEnd": 83,
+        "start": 75,
+        "end": 83,
+        "op": {
+          "kind": "<op>",
+          "startPos": {
+            "offset": 75,
+            "line": 2,
+            "column": 22
+          },
+          "endPos": {
+            "offset": 76,
+            "line": 2,
+            "column": 23
+          },
+          "value": ">",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 76,
+                "line": 2,
+                "column": 23
+              },
+              "endPos": {
+                "offset": 77,
+                "line": 2,
+                "column": 24
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 76,
+              "end": 77
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 75,
+          "end": 76
+        },
+        "expression": {
+          "id": 25,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 77,
+            "line": 2,
+            "column": 24
+          },
+          "fullStart": 77,
+          "endPos": {
+            "offset": 83,
+            "line": 2,
+            "column": 30
+          },
+          "fullEnd": 83,
+          "start": 77,
+          "end": 83,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 78,
+              "line": 2,
+              "column": 25
+            },
+            "endPos": {
+              "offset": 79,
+              "line": 2,
+              "column": 26
+            },
+            "value": ".",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 78,
+            "end": 79
+          },
+          "leftExpression": {
+            "id": 22,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 77,
+              "line": 2,
+              "column": 24
+            },
+            "fullStart": 77,
+            "endPos": {
+              "offset": 78,
+              "line": 2,
+              "column": 25
+            },
+            "fullEnd": 78,
+            "start": 77,
+            "end": 78,
+            "expression": {
+              "id": 21,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 77,
+                "line": 2,
+                "column": 24
+              },
+              "fullStart": 77,
+              "endPos": {
+                "offset": 78,
+                "line": 2,
+                "column": 25
+              },
+              "fullEnd": 78,
+              "start": 77,
+              "end": 78,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 77,
+                  "line": 2,
+                  "column": 24
+                },
+                "endPos": {
+                  "offset": 78,
+                  "line": 2,
+                  "column": 25
+                },
+                "value": "B",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 77,
+                "end": 78
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 24,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 79,
+              "line": 2,
+              "column": 26
+            },
+            "fullStart": 79,
+            "endPos": {
+              "offset": 83,
+              "line": 2,
+              "column": 30
+            },
+            "fullEnd": 83,
+            "start": 79,
+            "end": 83,
+            "expression": {
+              "id": 23,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 79,
+                "line": 2,
+                "column": 26
+              },
+              "fullStart": 79,
+              "endPos": {
+                "offset": 83,
+                "line": 2,
+                "column": 30
+              },
+              "fullEnd": 83,
+              "start": 79,
+              "end": 83,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 79,
+                  "line": 2,
+                  "column": 26
+                },
+                "endPos": {
+                  "offset": 83,
+                  "line": 2,
+                  "column": 30
+                },
+                "value": "name",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 79,
+                "end": 83
+              }
+            }
+          }
+        }
+      },
+      "colon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 73,
+          "line": 2,
+          "column": 20
+        },
+        "endPos": {
+          "offset": 74,
+          "line": 2,
+          "column": 21
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 74,
+              "line": 2,
+              "column": 21
+            },
+            "endPos": {
+              "offset": 75,
+              "line": 2,
+              "column": 22
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 74,
+            "end": 75
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 73,
+        "end": 74
+      }
+    },
+    "start": 70,
+    "end": 83,
+    "name": "CompileError"
+  },
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 68,
+      "kind": "<element-declaration>",
+      "startPos": {
+        "offset": 187,
+        "line": 11,
+        "column": 0
+      },
+      "fullStart": 186,
+      "endPos": {
+        "offset": 203,
+        "line": 11,
+        "column": 16
+      },
+      "fullEnd": 221,
+      "start": 187,
+      "end": 203,
+      "type": {
+        "kind": "<identifier>",
+        "startPos": {
+          "offset": 187,
+          "line": 11,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 190,
+          "line": 11,
+          "column": 3
+        },
+        "value": "Ref",
+        "leadingTrivia": [
+          {
+            "kind": "<newline>",
+            "startPos": {
+              "offset": 186,
+              "line": 10,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 187,
+              "line": 11,
+              "column": 0
+            },
+            "value": "\n",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 186,
+            "end": 187
+          }
+        ],
+        "trailingTrivia": [],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 187,
+        "end": 190
+      },
+      "bodyColon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 190,
+          "line": 11,
+          "column": 3
+        },
+        "endPos": {
+          "offset": 191,
+          "line": 11,
+          "column": 4
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 191,
+              "line": 11,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 192,
+              "line": 11,
+              "column": 5
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 191,
+            "end": 192
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 190,
+        "end": 191
+      },
+      "body": {
+        "id": 67,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 192,
+          "line": 11,
+          "column": 5
+        },
+        "fullStart": 192,
+        "endPos": {
+          "offset": 203,
+          "line": 11,
+          "column": 16
+        },
+        "fullEnd": 221,
+        "start": 192,
+        "end": 203,
+        "callee": {
+          "id": 66,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 192,
+            "line": 11,
+            "column": 5
+          },
+          "fullStart": 192,
+          "endPos": {
+            "offset": 203,
+            "line": 11,
+            "column": 16
+          },
+          "fullEnd": 221,
+          "start": 192,
+          "end": 203,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 197,
+              "line": 11,
+              "column": 10
+            },
+            "endPos": {
+              "offset": 198,
+              "line": 11,
+              "column": 11
+            },
+            "value": ">",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 198,
+                  "line": 11,
+                  "column": 11
+                },
+                "endPos": {
+                  "offset": 199,
+                  "line": 11,
+                  "column": 12
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 198,
+                "end": 199
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 197,
+            "end": 198
+          },
+          "leftExpression": {
+            "id": 60,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 192,
+              "line": 11,
+              "column": 5
+            },
+            "fullStart": 192,
+            "endPos": {
+              "offset": 196,
+              "line": 11,
+              "column": 9
+            },
+            "fullEnd": 197,
+            "start": 192,
+            "end": 196,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 193,
+                "line": 11,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 194,
+                "line": 11,
+                "column": 7
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 193,
+              "end": 194
+            },
+            "leftExpression": {
+              "id": 57,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 192,
+                "line": 11,
+                "column": 5
+              },
+              "fullStart": 192,
+              "endPos": {
+                "offset": 193,
+                "line": 11,
+                "column": 6
+              },
+              "fullEnd": 193,
+              "start": 192,
+              "end": 193,
+              "expression": {
+                "id": 56,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 192,
+                  "line": 11,
+                  "column": 5
+                },
+                "fullStart": 192,
+                "endPos": {
+                  "offset": 193,
+                  "line": 11,
+                  "column": 6
+                },
+                "fullEnd": 193,
+                "start": 192,
+                "end": 193,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 192,
+                    "line": 11,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 193,
+                    "line": 11,
+                    "column": 6
+                  },
+                  "value": "B",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 192,
+                  "end": 193
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 59,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 194,
+                "line": 11,
+                "column": 7
+              },
+              "fullStart": 194,
+              "endPos": {
+                "offset": 196,
+                "line": 11,
+                "column": 9
+              },
+              "fullEnd": 197,
+              "start": 194,
+              "end": 196,
+              "expression": {
+                "id": 58,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 194,
+                  "line": 11,
+                  "column": 7
+                },
+                "fullStart": 194,
+                "endPos": {
+                  "offset": 196,
+                  "line": 11,
+                  "column": 9
+                },
+                "fullEnd": 197,
+                "start": 194,
+                "end": 196,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 194,
+                    "line": 11,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 196,
+                    "line": 11,
+                    "column": 9
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 196,
+                        "line": 11,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 197,
+                        "line": 11,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 196,
+                      "end": 197
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 194,
+                  "end": 196
+                }
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 65,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 199,
+              "line": 11,
+              "column": 12
+            },
+            "fullStart": 199,
+            "endPos": {
+              "offset": 203,
+              "line": 11,
+              "column": 16
+            },
+            "fullEnd": 221,
+            "start": 199,
+            "end": 203,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 200,
+                "line": 11,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 201,
+                "line": 11,
+                "column": 14
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 200,
+              "end": 201
+            },
+            "leftExpression": {
+              "id": 62,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 199,
+                "line": 11,
+                "column": 12
+              },
+              "fullStart": 199,
+              "endPos": {
+                "offset": 200,
+                "line": 11,
+                "column": 13
+              },
+              "fullEnd": 200,
+              "start": 199,
+              "end": 200,
+              "expression": {
+                "id": 61,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 199,
+                  "line": 11,
+                  "column": 12
+                },
+                "fullStart": 199,
+                "endPos": {
+                  "offset": 200,
+                  "line": 11,
+                  "column": 13
+                },
+                "fullEnd": 200,
+                "start": 199,
+                "end": 200,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 199,
+                    "line": 11,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 200,
+                    "line": 11,
+                    "column": 13
+                  },
+                  "value": "A",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 199,
+                  "end": 200
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 64,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 201,
+                "line": 11,
+                "column": 14
+              },
+              "fullStart": 201,
+              "endPos": {
+                "offset": 203,
+                "line": 11,
+                "column": 16
+              },
+              "fullEnd": 221,
+              "start": 201,
+              "end": 203,
+              "expression": {
+                "id": 63,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 201,
+                  "line": 11,
+                  "column": 14
+                },
+                "fullStart": 201,
+                "endPos": {
+                  "offset": 203,
+                  "line": 11,
+                  "column": 16
+                },
+                "fullEnd": 221,
+                "start": 201,
+                "end": 203,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 201,
+                    "line": 11,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 203,
+                    "line": 11,
+                    "column": 16
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 203,
+                        "line": 11,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 204,
+                        "line": 11,
+                        "column": 17
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 203,
+                      "end": 204
+                    },
+                    {
+                      "kind": "<single-line-comment>",
+                      "startPos": {
+                        "offset": 204,
+                        "line": 11,
+                        "column": 17
+                      },
+                      "endPos": {
+                        "offset": 221,
+                        "line": 11,
+                        "column": 34
+                      },
+                      "value": " circular ref 0",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 204,
+                      "end": 221
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 201,
+                  "end": 203
+                }
+              }
+            }
+          }
+        },
+        "args": []
+      }
+    },
+    "start": 187,
+    "end": 203,
+    "name": "CompileError"
+  },
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 13,
+      "kind": "<attribute>",
+      "startPos": {
+        "offset": 22,
+        "line": 1,
+        "column": 12
+      },
+      "fullStart": 22,
+      "endPos": {
+        "offset": 33,
+        "line": 1,
+        "column": 23
+      },
+      "fullEnd": 33,
+      "start": 22,
+      "end": 33,
+      "name": {
+        "id": 6,
+        "kind": "<identifer-stream>",
+        "startPos": {
+          "offset": 22,
+          "line": 1,
+          "column": 12
+        },
+        "fullStart": 22,
+        "endPos": {
+          "offset": 25,
+          "line": 1,
+          "column": 15
+        },
+        "fullEnd": 25,
+        "start": 22,
+        "end": 25,
+        "identifiers": [
+          {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 22,
+              "line": 1,
+              "column": 12
+            },
+            "endPos": {
+              "offset": 25,
+              "line": 1,
+              "column": 15
+            },
+            "value": "ref",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 22,
+            "end": 25
+          }
+        ]
+      },
+      "value": {
+        "id": 12,
+        "kind": "<prefix-expression>",
+        "startPos": {
+          "offset": 27,
+          "line": 1,
+          "column": 17
+        },
+        "fullStart": 27,
+        "endPos": {
+          "offset": 33,
+          "line": 1,
+          "column": 23
+        },
+        "fullEnd": 33,
+        "start": 27,
+        "end": 33,
+        "op": {
+          "kind": "<op>",
+          "startPos": {
+            "offset": 27,
+            "line": 1,
+            "column": 17
+          },
+          "endPos": {
+            "offset": 28,
+            "line": 1,
+            "column": 18
+          },
+          "value": ">",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 28,
+                "line": 1,
+                "column": 18
+              },
+              "endPos": {
+                "offset": 29,
+                "line": 1,
+                "column": 19
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 28,
+              "end": 29
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 27,
+          "end": 28
+        },
+        "expression": {
+          "id": 11,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 29,
+            "line": 1,
+            "column": 19
+          },
+          "fullStart": 29,
+          "endPos": {
+            "offset": 33,
+            "line": 1,
+            "column": 23
+          },
+          "fullEnd": 33,
+          "start": 29,
+          "end": 33,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 30,
+              "line": 1,
+              "column": 20
+            },
+            "endPos": {
+              "offset": 31,
+              "line": 1,
+              "column": 21
+            },
+            "value": ".",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 30,
+            "end": 31
+          },
+          "leftExpression": {
+            "id": 8,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 29,
+              "line": 1,
+              "column": 19
+            },
+            "fullStart": 29,
+            "endPos": {
+              "offset": 30,
+              "line": 1,
+              "column": 20
+            },
+            "fullEnd": 30,
+            "start": 29,
+            "end": 30,
+            "expression": {
+              "id": 7,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 29,
+                "line": 1,
+                "column": 19
+              },
+              "fullStart": 29,
+              "endPos": {
+                "offset": 30,
+                "line": 1,
+                "column": 20
+              },
+              "fullEnd": 30,
+              "start": 29,
+              "end": 30,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 29,
+                  "line": 1,
+                  "column": 19
+                },
+                "endPos": {
+                  "offset": 30,
+                  "line": 1,
+                  "column": 20
+                },
+                "value": "B",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 29,
+                "end": 30
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 10,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 31,
+              "line": 1,
+              "column": 21
+            },
+            "fullStart": 31,
+            "endPos": {
+              "offset": 33,
+              "line": 1,
+              "column": 23
+            },
+            "fullEnd": 33,
+            "start": 31,
+            "end": 33,
+            "expression": {
+              "id": 9,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 31,
+                "line": 1,
+                "column": 21
+              },
+              "fullStart": 31,
+              "endPos": {
+                "offset": 33,
+                "line": 1,
+                "column": 23
+              },
+              "fullEnd": 33,
+              "start": 31,
+              "end": 33,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 31,
+                  "line": 1,
+                  "column": 21
+                },
+                "endPos": {
+                  "offset": 33,
+                  "line": 1,
+                  "column": 23
+                },
+                "value": "id",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 31,
+                "end": 33
+              }
+            }
+          }
+        }
+      },
+      "colon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 25,
+          "line": 1,
+          "column": 15
+        },
+        "endPos": {
+          "offset": 26,
+          "line": 1,
+          "column": 16
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 26,
+              "line": 1,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 27,
+              "line": 1,
+              "column": 17
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 26,
+            "end": 27
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 25,
+        "end": 26
+      }
+    },
+    "start": 22,
+    "end": 33,
+    "name": "CompileError"
+  }
+]

--- a/packages/dbml-parse/tests/interpreter/output/circular_ref_2_elements.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/circular_ref_2_elements.out.json
@@ -1,0 +1,1040 @@
+[
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 43,
+      "kind": "<element-declaration>",
+      "startPos": {
+        "offset": 65,
+        "line": 9,
+        "column": 0
+      },
+      "fullStart": 65,
+      "endPos": {
+        "offset": 81,
+        "line": 9,
+        "column": 16
+      },
+      "fullEnd": 81,
+      "start": 65,
+      "end": 81,
+      "type": {
+        "kind": "<identifier>",
+        "startPos": {
+          "offset": 65,
+          "line": 9,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 68,
+          "line": 9,
+          "column": 3
+        },
+        "value": "Ref",
+        "leadingTrivia": [],
+        "trailingTrivia": [],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 65,
+        "end": 68
+      },
+      "bodyColon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 68,
+          "line": 9,
+          "column": 3
+        },
+        "endPos": {
+          "offset": 69,
+          "line": 9,
+          "column": 4
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 69,
+              "line": 9,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 70,
+              "line": 9,
+              "column": 5
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 69,
+            "end": 70
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 68,
+        "end": 69
+      },
+      "body": {
+        "id": 42,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 70,
+          "line": 9,
+          "column": 5
+        },
+        "fullStart": 70,
+        "endPos": {
+          "offset": 81,
+          "line": 9,
+          "column": 16
+        },
+        "fullEnd": 81,
+        "start": 70,
+        "end": 81,
+        "callee": {
+          "id": 41,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 70,
+            "line": 9,
+            "column": 5
+          },
+          "fullStart": 70,
+          "endPos": {
+            "offset": 81,
+            "line": 9,
+            "column": 16
+          },
+          "fullEnd": 81,
+          "start": 70,
+          "end": 81,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 75,
+              "line": 9,
+              "column": 10
+            },
+            "endPos": {
+              "offset": 76,
+              "line": 9,
+              "column": 11
+            },
+            "value": ">",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 76,
+                  "line": 9,
+                  "column": 11
+                },
+                "endPos": {
+                  "offset": 77,
+                  "line": 9,
+                  "column": 12
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 76,
+                "end": 77
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 75,
+            "end": 76
+          },
+          "leftExpression": {
+            "id": 35,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 70,
+              "line": 9,
+              "column": 5
+            },
+            "fullStart": 70,
+            "endPos": {
+              "offset": 74,
+              "line": 9,
+              "column": 9
+            },
+            "fullEnd": 75,
+            "start": 70,
+            "end": 74,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 71,
+                "line": 9,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 72,
+                "line": 9,
+                "column": 7
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 71,
+              "end": 72
+            },
+            "leftExpression": {
+              "id": 32,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 70,
+                "line": 9,
+                "column": 5
+              },
+              "fullStart": 70,
+              "endPos": {
+                "offset": 71,
+                "line": 9,
+                "column": 6
+              },
+              "fullEnd": 71,
+              "start": 70,
+              "end": 71,
+              "expression": {
+                "id": 31,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 70,
+                  "line": 9,
+                  "column": 5
+                },
+                "fullStart": 70,
+                "endPos": {
+                  "offset": 71,
+                  "line": 9,
+                  "column": 6
+                },
+                "fullEnd": 71,
+                "start": 70,
+                "end": 71,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 70,
+                    "line": 9,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 71,
+                    "line": 9,
+                    "column": 6
+                  },
+                  "value": "B",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 70,
+                  "end": 71
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 34,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 72,
+                "line": 9,
+                "column": 7
+              },
+              "fullStart": 72,
+              "endPos": {
+                "offset": 74,
+                "line": 9,
+                "column": 9
+              },
+              "fullEnd": 75,
+              "start": 72,
+              "end": 74,
+              "expression": {
+                "id": 33,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 72,
+                  "line": 9,
+                  "column": 7
+                },
+                "fullStart": 72,
+                "endPos": {
+                  "offset": 74,
+                  "line": 9,
+                  "column": 9
+                },
+                "fullEnd": 75,
+                "start": 72,
+                "end": 74,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 72,
+                    "line": 9,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 74,
+                    "line": 9,
+                    "column": 9
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 74,
+                        "line": 9,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 75,
+                        "line": 9,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 74,
+                      "end": 75
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 72,
+                  "end": 74
+                }
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 40,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 77,
+              "line": 9,
+              "column": 12
+            },
+            "fullStart": 77,
+            "endPos": {
+              "offset": 81,
+              "line": 9,
+              "column": 16
+            },
+            "fullEnd": 81,
+            "start": 77,
+            "end": 81,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 78,
+                "line": 9,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 79,
+                "line": 9,
+                "column": 14
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 78,
+              "end": 79
+            },
+            "leftExpression": {
+              "id": 37,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 77,
+                "line": 9,
+                "column": 12
+              },
+              "fullStart": 77,
+              "endPos": {
+                "offset": 78,
+                "line": 9,
+                "column": 13
+              },
+              "fullEnd": 78,
+              "start": 77,
+              "end": 78,
+              "expression": {
+                "id": 36,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 77,
+                  "line": 9,
+                  "column": 12
+                },
+                "fullStart": 77,
+                "endPos": {
+                  "offset": 78,
+                  "line": 9,
+                  "column": 13
+                },
+                "fullEnd": 78,
+                "start": 77,
+                "end": 78,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 77,
+                    "line": 9,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 78,
+                    "line": 9,
+                    "column": 13
+                  },
+                  "value": "A",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 77,
+                  "end": 78
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 39,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 79,
+                "line": 9,
+                "column": 14
+              },
+              "fullStart": 79,
+              "endPos": {
+                "offset": 81,
+                "line": 9,
+                "column": 16
+              },
+              "fullEnd": 81,
+              "start": 79,
+              "end": 81,
+              "expression": {
+                "id": 38,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 79,
+                  "line": 9,
+                  "column": 14
+                },
+                "fullStart": 79,
+                "endPos": {
+                  "offset": 81,
+                  "line": 9,
+                  "column": 16
+                },
+                "fullEnd": 81,
+                "start": 79,
+                "end": 81,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 79,
+                    "line": 9,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 81,
+                    "line": 9,
+                    "column": 16
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 79,
+                  "end": 81
+                }
+              }
+            }
+          }
+        },
+        "args": []
+      }
+    },
+    "start": 65,
+    "end": 81,
+    "name": "CompileError"
+  },
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 30,
+      "kind": "<element-declaration>",
+      "startPos": {
+        "offset": 48,
+        "line": 8,
+        "column": 0
+      },
+      "fullStart": 47,
+      "endPos": {
+        "offset": 64,
+        "line": 8,
+        "column": 16
+      },
+      "fullEnd": 65,
+      "start": 48,
+      "end": 64,
+      "type": {
+        "kind": "<identifier>",
+        "startPos": {
+          "offset": 48,
+          "line": 8,
+          "column": 0
+        },
+        "endPos": {
+          "offset": 51,
+          "line": 8,
+          "column": 3
+        },
+        "value": "Ref",
+        "leadingTrivia": [
+          {
+            "kind": "<newline>",
+            "startPos": {
+              "offset": 47,
+              "line": 7,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 48,
+              "line": 8,
+              "column": 0
+            },
+            "value": "\n",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 47,
+            "end": 48
+          }
+        ],
+        "trailingTrivia": [],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 48,
+        "end": 51
+      },
+      "bodyColon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 51,
+          "line": 8,
+          "column": 3
+        },
+        "endPos": {
+          "offset": 52,
+          "line": 8,
+          "column": 4
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 52,
+              "line": 8,
+              "column": 4
+            },
+            "endPos": {
+              "offset": 53,
+              "line": 8,
+              "column": 5
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 52,
+            "end": 53
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 51,
+        "end": 52
+      },
+      "body": {
+        "id": 29,
+        "kind": "<function-application>",
+        "startPos": {
+          "offset": 53,
+          "line": 8,
+          "column": 5
+        },
+        "fullStart": 53,
+        "endPos": {
+          "offset": 64,
+          "line": 8,
+          "column": 16
+        },
+        "fullEnd": 65,
+        "start": 53,
+        "end": 64,
+        "callee": {
+          "id": 28,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 53,
+            "line": 8,
+            "column": 5
+          },
+          "fullStart": 53,
+          "endPos": {
+            "offset": 64,
+            "line": 8,
+            "column": 16
+          },
+          "fullEnd": 65,
+          "start": 53,
+          "end": 64,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 58,
+              "line": 8,
+              "column": 10
+            },
+            "endPos": {
+              "offset": 59,
+              "line": 8,
+              "column": 11
+            },
+            "value": ">",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 59,
+                  "line": 8,
+                  "column": 11
+                },
+                "endPos": {
+                  "offset": 60,
+                  "line": 8,
+                  "column": 12
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 59,
+                "end": 60
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 58,
+            "end": 59
+          },
+          "leftExpression": {
+            "id": 22,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 53,
+              "line": 8,
+              "column": 5
+            },
+            "fullStart": 53,
+            "endPos": {
+              "offset": 57,
+              "line": 8,
+              "column": 9
+            },
+            "fullEnd": 58,
+            "start": 53,
+            "end": 57,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 54,
+                "line": 8,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 55,
+                "line": 8,
+                "column": 7
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 54,
+              "end": 55
+            },
+            "leftExpression": {
+              "id": 19,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 53,
+                "line": 8,
+                "column": 5
+              },
+              "fullStart": 53,
+              "endPos": {
+                "offset": 54,
+                "line": 8,
+                "column": 6
+              },
+              "fullEnd": 54,
+              "start": 53,
+              "end": 54,
+              "expression": {
+                "id": 18,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 53,
+                  "line": 8,
+                  "column": 5
+                },
+                "fullStart": 53,
+                "endPos": {
+                  "offset": 54,
+                  "line": 8,
+                  "column": 6
+                },
+                "fullEnd": 54,
+                "start": 53,
+                "end": 54,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 53,
+                    "line": 8,
+                    "column": 5
+                  },
+                  "endPos": {
+                    "offset": 54,
+                    "line": 8,
+                    "column": 6
+                  },
+                  "value": "A",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 53,
+                  "end": 54
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 21,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 55,
+                "line": 8,
+                "column": 7
+              },
+              "fullStart": 55,
+              "endPos": {
+                "offset": 57,
+                "line": 8,
+                "column": 9
+              },
+              "fullEnd": 58,
+              "start": 55,
+              "end": 57,
+              "expression": {
+                "id": 20,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 55,
+                  "line": 8,
+                  "column": 7
+                },
+                "fullStart": 55,
+                "endPos": {
+                  "offset": 57,
+                  "line": 8,
+                  "column": 9
+                },
+                "fullEnd": 58,
+                "start": 55,
+                "end": 57,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 55,
+                    "line": 8,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 57,
+                    "line": 8,
+                    "column": 9
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 57,
+                        "line": 8,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 58,
+                        "line": 8,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 57,
+                      "end": 58
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 55,
+                  "end": 57
+                }
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 27,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 60,
+              "line": 8,
+              "column": 12
+            },
+            "fullStart": 60,
+            "endPos": {
+              "offset": 64,
+              "line": 8,
+              "column": 16
+            },
+            "fullEnd": 65,
+            "start": 60,
+            "end": 64,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 61,
+                "line": 8,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 62,
+                "line": 8,
+                "column": 14
+              },
+              "value": ".",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 61,
+              "end": 62
+            },
+            "leftExpression": {
+              "id": 24,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 60,
+                "line": 8,
+                "column": 12
+              },
+              "fullStart": 60,
+              "endPos": {
+                "offset": 61,
+                "line": 8,
+                "column": 13
+              },
+              "fullEnd": 61,
+              "start": 60,
+              "end": 61,
+              "expression": {
+                "id": 23,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 60,
+                  "line": 8,
+                  "column": 12
+                },
+                "fullStart": 60,
+                "endPos": {
+                  "offset": 61,
+                  "line": 8,
+                  "column": 13
+                },
+                "fullEnd": 61,
+                "start": 60,
+                "end": 61,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 60,
+                    "line": 8,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 61,
+                    "line": 8,
+                    "column": 13
+                  },
+                  "value": "B",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 60,
+                  "end": 61
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 26,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 62,
+                "line": 8,
+                "column": 14
+              },
+              "fullStart": 62,
+              "endPos": {
+                "offset": 64,
+                "line": 8,
+                "column": 16
+              },
+              "fullEnd": 65,
+              "start": 62,
+              "end": 64,
+              "expression": {
+                "id": 25,
+                "kind": "<variable>",
+                "startPos": {
+                  "offset": 62,
+                  "line": 8,
+                  "column": 14
+                },
+                "fullStart": 62,
+                "endPos": {
+                  "offset": 64,
+                  "line": 8,
+                  "column": 16
+                },
+                "fullEnd": 65,
+                "start": 62,
+                "end": 64,
+                "variable": {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 62,
+                    "line": 8,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 64,
+                    "line": 8,
+                    "column": 16
+                  },
+                  "value": "id",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<newline>",
+                      "startPos": {
+                        "offset": 64,
+                        "line": 8,
+                        "column": 16
+                      },
+                      "endPos": {
+                        "offset": 65,
+                        "line": 9,
+                        "column": 0
+                      },
+                      "value": "\n",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 64,
+                      "end": 65
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 62,
+                  "end": 64
+                }
+              }
+            }
+          }
+        },
+        "args": []
+      }
+    },
+    "start": 48,
+    "end": 64,
+    "name": "CompileError"
+  }
+]

--- a/packages/dbml-parse/tests/interpreter/output/circular_ref_2_inlines.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/circular_ref_2_inlines.out.json
@@ -1,0 +1,648 @@
+[
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 31,
+      "kind": "<attribute>",
+      "startPos": {
+        "offset": 60,
+        "line": 5,
+        "column": 12
+      },
+      "fullStart": 60,
+      "endPos": {
+        "offset": 71,
+        "line": 5,
+        "column": 23
+      },
+      "fullEnd": 71,
+      "start": 60,
+      "end": 71,
+      "name": {
+        "id": 24,
+        "kind": "<identifer-stream>",
+        "startPos": {
+          "offset": 60,
+          "line": 5,
+          "column": 12
+        },
+        "fullStart": 60,
+        "endPos": {
+          "offset": 63,
+          "line": 5,
+          "column": 15
+        },
+        "fullEnd": 63,
+        "start": 60,
+        "end": 63,
+        "identifiers": [
+          {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 60,
+              "line": 5,
+              "column": 12
+            },
+            "endPos": {
+              "offset": 63,
+              "line": 5,
+              "column": 15
+            },
+            "value": "ref",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 60,
+            "end": 63
+          }
+        ]
+      },
+      "value": {
+        "id": 30,
+        "kind": "<prefix-expression>",
+        "startPos": {
+          "offset": 65,
+          "line": 5,
+          "column": 17
+        },
+        "fullStart": 65,
+        "endPos": {
+          "offset": 71,
+          "line": 5,
+          "column": 23
+        },
+        "fullEnd": 71,
+        "start": 65,
+        "end": 71,
+        "op": {
+          "kind": "<op>",
+          "startPos": {
+            "offset": 65,
+            "line": 5,
+            "column": 17
+          },
+          "endPos": {
+            "offset": 66,
+            "line": 5,
+            "column": 18
+          },
+          "value": ">",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 66,
+                "line": 5,
+                "column": 18
+              },
+              "endPos": {
+                "offset": 67,
+                "line": 5,
+                "column": 19
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 66,
+              "end": 67
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 65,
+          "end": 66
+        },
+        "expression": {
+          "id": 29,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 67,
+            "line": 5,
+            "column": 19
+          },
+          "fullStart": 67,
+          "endPos": {
+            "offset": 71,
+            "line": 5,
+            "column": 23
+          },
+          "fullEnd": 71,
+          "start": 67,
+          "end": 71,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 68,
+              "line": 5,
+              "column": 20
+            },
+            "endPos": {
+              "offset": 69,
+              "line": 5,
+              "column": 21
+            },
+            "value": ".",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 68,
+            "end": 69
+          },
+          "leftExpression": {
+            "id": 26,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 67,
+              "line": 5,
+              "column": 19
+            },
+            "fullStart": 67,
+            "endPos": {
+              "offset": 68,
+              "line": 5,
+              "column": 20
+            },
+            "fullEnd": 68,
+            "start": 67,
+            "end": 68,
+            "expression": {
+              "id": 25,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 67,
+                "line": 5,
+                "column": 19
+              },
+              "fullStart": 67,
+              "endPos": {
+                "offset": 68,
+                "line": 5,
+                "column": 20
+              },
+              "fullEnd": 68,
+              "start": 67,
+              "end": 68,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 67,
+                  "line": 5,
+                  "column": 19
+                },
+                "endPos": {
+                  "offset": 68,
+                  "line": 5,
+                  "column": 20
+                },
+                "value": "A",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 67,
+                "end": 68
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 28,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 69,
+              "line": 5,
+              "column": 21
+            },
+            "fullStart": 69,
+            "endPos": {
+              "offset": 71,
+              "line": 5,
+              "column": 23
+            },
+            "fullEnd": 71,
+            "start": 69,
+            "end": 71,
+            "expression": {
+              "id": 27,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 69,
+                "line": 5,
+                "column": 21
+              },
+              "fullStart": 69,
+              "endPos": {
+                "offset": 71,
+                "line": 5,
+                "column": 23
+              },
+              "fullEnd": 71,
+              "start": 69,
+              "end": 71,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 69,
+                  "line": 5,
+                  "column": 21
+                },
+                "endPos": {
+                  "offset": 71,
+                  "line": 5,
+                  "column": 23
+                },
+                "value": "id",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 69,
+                "end": 71
+              }
+            }
+          }
+        }
+      },
+      "colon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 63,
+          "line": 5,
+          "column": 15
+        },
+        "endPos": {
+          "offset": 64,
+          "line": 5,
+          "column": 16
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 64,
+              "line": 5,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 65,
+              "line": 5,
+              "column": 17
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 64,
+            "end": 65
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 63,
+        "end": 64
+      }
+    },
+    "start": 60,
+    "end": 71,
+    "name": "CompileError"
+  },
+  {
+    "code": 5001,
+    "diagnostic": "References with same endpoints exist",
+    "nodeOrToken": {
+      "id": 13,
+      "kind": "<attribute>",
+      "startPos": {
+        "offset": 22,
+        "line": 1,
+        "column": 12
+      },
+      "fullStart": 22,
+      "endPos": {
+        "offset": 33,
+        "line": 1,
+        "column": 23
+      },
+      "fullEnd": 33,
+      "start": 22,
+      "end": 33,
+      "name": {
+        "id": 6,
+        "kind": "<identifer-stream>",
+        "startPos": {
+          "offset": 22,
+          "line": 1,
+          "column": 12
+        },
+        "fullStart": 22,
+        "endPos": {
+          "offset": 25,
+          "line": 1,
+          "column": 15
+        },
+        "fullEnd": 25,
+        "start": 22,
+        "end": 25,
+        "identifiers": [
+          {
+            "kind": "<identifier>",
+            "startPos": {
+              "offset": 22,
+              "line": 1,
+              "column": 12
+            },
+            "endPos": {
+              "offset": 25,
+              "line": 1,
+              "column": 15
+            },
+            "value": "ref",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 22,
+            "end": 25
+          }
+        ]
+      },
+      "value": {
+        "id": 12,
+        "kind": "<prefix-expression>",
+        "startPos": {
+          "offset": 27,
+          "line": 1,
+          "column": 17
+        },
+        "fullStart": 27,
+        "endPos": {
+          "offset": 33,
+          "line": 1,
+          "column": 23
+        },
+        "fullEnd": 33,
+        "start": 27,
+        "end": 33,
+        "op": {
+          "kind": "<op>",
+          "startPos": {
+            "offset": 27,
+            "line": 1,
+            "column": 17
+          },
+          "endPos": {
+            "offset": 28,
+            "line": 1,
+            "column": 18
+          },
+          "value": ">",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 28,
+                "line": 1,
+                "column": 18
+              },
+              "endPos": {
+                "offset": 29,
+                "line": 1,
+                "column": 19
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 28,
+              "end": 29
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 27,
+          "end": 28
+        },
+        "expression": {
+          "id": 11,
+          "kind": "<infix-expression>",
+          "startPos": {
+            "offset": 29,
+            "line": 1,
+            "column": 19
+          },
+          "fullStart": 29,
+          "endPos": {
+            "offset": 33,
+            "line": 1,
+            "column": 23
+          },
+          "fullEnd": 33,
+          "start": 29,
+          "end": 33,
+          "op": {
+            "kind": "<op>",
+            "startPos": {
+              "offset": 30,
+              "line": 1,
+              "column": 20
+            },
+            "endPos": {
+              "offset": 31,
+              "line": 1,
+              "column": 21
+            },
+            "value": ".",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 30,
+            "end": 31
+          },
+          "leftExpression": {
+            "id": 8,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 29,
+              "line": 1,
+              "column": 19
+            },
+            "fullStart": 29,
+            "endPos": {
+              "offset": 30,
+              "line": 1,
+              "column": 20
+            },
+            "fullEnd": 30,
+            "start": 29,
+            "end": 30,
+            "expression": {
+              "id": 7,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 29,
+                "line": 1,
+                "column": 19
+              },
+              "fullStart": 29,
+              "endPos": {
+                "offset": 30,
+                "line": 1,
+                "column": 20
+              },
+              "fullEnd": 30,
+              "start": 29,
+              "end": 30,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 29,
+                  "line": 1,
+                  "column": 19
+                },
+                "endPos": {
+                  "offset": 30,
+                  "line": 1,
+                  "column": 20
+                },
+                "value": "B",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 29,
+                "end": 30
+              }
+            }
+          },
+          "rightExpression": {
+            "id": 10,
+            "kind": "<primary-expression>",
+            "startPos": {
+              "offset": 31,
+              "line": 1,
+              "column": 21
+            },
+            "fullStart": 31,
+            "endPos": {
+              "offset": 33,
+              "line": 1,
+              "column": 23
+            },
+            "fullEnd": 33,
+            "start": 31,
+            "end": 33,
+            "expression": {
+              "id": 9,
+              "kind": "<variable>",
+              "startPos": {
+                "offset": 31,
+                "line": 1,
+                "column": 21
+              },
+              "fullStart": 31,
+              "endPos": {
+                "offset": 33,
+                "line": 1,
+                "column": 23
+              },
+              "fullEnd": 33,
+              "start": 31,
+              "end": 33,
+              "variable": {
+                "kind": "<identifier>",
+                "startPos": {
+                  "offset": 31,
+                  "line": 1,
+                  "column": 21
+                },
+                "endPos": {
+                  "offset": 33,
+                  "line": 1,
+                  "column": 23
+                },
+                "value": "id",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 31,
+                "end": 33
+              }
+            }
+          }
+        }
+      },
+      "colon": {
+        "kind": "<colon>",
+        "startPos": {
+          "offset": 25,
+          "line": 1,
+          "column": 15
+        },
+        "endPos": {
+          "offset": 26,
+          "line": 1,
+          "column": 16
+        },
+        "value": ":",
+        "leadingTrivia": [],
+        "trailingTrivia": [
+          {
+            "kind": "<space>",
+            "startPos": {
+              "offset": 26,
+              "line": 1,
+              "column": 16
+            },
+            "endPos": {
+              "offset": 27,
+              "line": 1,
+              "column": 17
+            },
+            "value": " ",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 26,
+            "end": 27
+          }
+        ],
+        "leadingInvalid": [],
+        "trailingInvalid": [],
+        "isInvalid": false,
+        "start": 25,
+        "end": 26
+      }
+    },
+    "start": 22,
+    "end": 33,
+    "name": "CompileError"
+  }
+]


### PR DESCRIPTION
## Summary
* Circular refs with one inline and one element can not be detected
* Example:
  ```
     Table A {
        id int [ref: > B.id]
     }
     Table B {
        id int
     }
     Ref: A.id > B.id
  ```

## Issue
(issue link here)

## Lasting Changes (Technical)

* Fix a bug in the circular detection util

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review