### PR TITLE
fix: unquoted update & delete ref setting

### DIFF
--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
@@ -70,9 +70,13 @@ export class RefInterpreter implements ElementInterpreter {
     if (field.args[0]) {
       const settingMap = aggregateSettingList(field.args[0] as ListExpressionNode).getValue();
       const deleteSetting = settingMap['delete']?.at(0)?.value;
-      this.ref.onDelete = deleteSetting instanceof IdentiferStreamNode ? extractStringFromIdentifierStream(deleteSetting).unwrap_or(undefined) : extractVariableFromExpression(deleteSetting).unwrap_or(undefined) as any
+      this.ref.onDelete = deleteSetting instanceof IdentiferStreamNode
+        ? extractStringFromIdentifierStream(deleteSetting).unwrap_or(undefined) 
+        : extractVariableFromExpression(deleteSetting).unwrap_or(undefined) as string;
       const updateSetting = settingMap['update']?.at(0)?.value;
-      this.ref.onUpdate = updateSetting instanceof IdentiferStreamNode ? extractStringFromIdentifierStream(updateSetting).unwrap_or(undefined) : extractVariableFromExpression(updateSetting).unwrap_or(undefined) as any
+      this.ref.onUpdate = updateSetting instanceof IdentiferStreamNode
+        ? extractStringFromIdentifierStream(updateSetting).unwrap_or(undefined)
+        : extractVariableFromExpression(updateSetting).unwrap_or(undefined) as string;
     }
     
     const multiplicities = getMultiplicities(op);

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
@@ -2,9 +2,10 @@ import _ from "lodash";
 import { destructureComplexVariable, extractVariableFromExpression } from "../../analyzer/utils";
 import { aggregateSettingList } from "../../analyzer/validator/utils";
 import { CompileError, CompileErrorCode } from "../../errors";
-import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, InfixExpressionNode, ListExpressionNode, SyntaxNode } from "../../parser/nodes";
+import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, IdentiferStreamNode, InfixExpressionNode, ListExpressionNode, SyntaxNode } from "../../parser/nodes";
 import { ElementInterpreter, InterpreterDatabase, Ref, Table } from "../types";
 import { extractNamesFromRefOperand, getColumnSymbolsOfRefOperand, getMultiplicities, getRefId, getTokenPosition, isSameEndpoint } from "../utils";
+import { extractStringFromIdentifierStream } from "../../parser/utils";
 
 export class RefInterpreter implements ElementInterpreter {
   private declarationNode: ElementDeclarationNode;
@@ -68,8 +69,10 @@ export class RefInterpreter implements ElementInterpreter {
 
     if (field.args[0]) {
       const settingMap = aggregateSettingList(field.args[0] as ListExpressionNode).getValue();
-      this.ref.onDelete = extractVariableFromExpression(settingMap['delete']?.at(0)?.value).unwrap_or(undefined) as any;
-      this.ref.onUpdate= extractVariableFromExpression(settingMap['update']?.at(0)?.value).unwrap_or(undefined) as any;
+      const deleteSetting = settingMap['delete']?.at(0)?.value;
+      this.ref.onDelete = deleteSetting instanceof IdentiferStreamNode ? extractStringFromIdentifierStream(deleteSetting).unwrap_or(undefined) : extractVariableFromExpression(deleteSetting).unwrap_or(undefined) as any
+      const updateSetting = settingMap['update']?.at(0)?.value;
+      this.ref.onUpdate = updateSetting instanceof IdentiferStreamNode ? extractStringFromIdentifierStream(updateSetting).unwrap_or(undefined) : extractVariableFromExpression(updateSetting).unwrap_or(undefined) as any
     }
     
     const multiplicities = getMultiplicities(op);

--- a/packages/dbml-parse/src/lib/interpreter/types.ts
+++ b/packages/dbml-parse/src/lib/interpreter/types.ts
@@ -102,8 +102,8 @@ export interface Ref {
   schemaName: string | null;
   name: string | null;
   endpoints: RefEndpointPair;
-  onDelete?: 'cascade' | 'no action' | 'restrict' | 'set default' | 'set null';
-  onUpdate?: 'cascade' | 'no action' | 'restrict' | 'set default' | 'set null';
+  onDelete?: string;
+  onUpdate?: string;
   token: TokenPosition;
 }
 

--- a/packages/dbml-parse/tests/interpreter/input/ref_settings.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/ref_settings.in.dbml
@@ -1,9 +1,12 @@
 Table A {
     id integer
+    code number
 }
 
 Table B {
     id integer
+    code number
 }
 
-Ref: A.id > B.id [update: cascade, delete: cascade]
+Ref: A.id > B.id [update: cascade, delete: no action]
+Ref: A.code > B.code [update: set null, delete: set default]

--- a/packages/dbml-parse/tests/interpreter/output/ref_settings.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/ref_settings.out.json
@@ -28,6 +28,29 @@
           "inline_refs": [],
           "pk": false,
           "unique": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "schemaName": null,
+            "type_name": "number",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 29,
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "offset": 40,
+              "line": 3,
+              "column": 16
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
         }
       ],
       "token": {
@@ -37,8 +60,8 @@
           "column": 1
         },
         "end": {
-          "offset": 26,
-          "line": 3,
+          "offset": 42,
+          "line": 4,
           "column": 2
         }
       },
@@ -58,14 +81,37 @@
           },
           "token": {
             "start": {
-              "offset": 42,
-              "line": 6,
+              "offset": 58,
+              "line": 7,
               "column": 5
             },
             "end": {
-              "offset": 52,
-              "line": 6,
+              "offset": 68,
+              "line": 7,
               "column": 15
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "schemaName": null,
+            "type_name": "number",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 73,
+              "line": 8,
+              "column": 5
+            },
+            "end": {
+              "offset": 84,
+              "line": 8,
+              "column": 16
             }
           },
           "inline_refs": [],
@@ -75,13 +121,13 @@
       ],
       "token": {
         "start": {
-          "offset": 28,
-          "line": 5,
+          "offset": 44,
+          "line": 6,
           "column": 1
         },
         "end": {
-          "offset": 54,
-          "line": 7,
+          "offset": 86,
+          "line": 9,
           "column": 2
         }
       },
@@ -92,19 +138,19 @@
     {
       "token": {
         "start": {
-          "offset": 56,
-          "line": 9,
+          "offset": 88,
+          "line": 11,
           "column": 1
         },
         "end": {
-          "offset": 107,
-          "line": 9,
-          "column": 52
+          "offset": 141,
+          "line": 11,
+          "column": 54
         }
       },
       "name": null,
       "schemaName": null,
-      "onDelete": "cascade",
+      "onDelete": "no action",
       "onUpdate": "cascade",
       "endpoints": [
         {
@@ -116,13 +162,13 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 61,
-              "line": 9,
+              "offset": 93,
+              "line": 11,
               "column": 6
             },
             "end": {
-              "offset": 65,
-              "line": 9,
+              "offset": 97,
+              "line": 11,
               "column": 10
             }
           }
@@ -136,14 +182,74 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 68,
-              "line": 9,
+              "offset": 100,
+              "line": 11,
               "column": 13
             },
             "end": {
-              "offset": 72,
-              "line": 9,
+              "offset": 104,
+              "line": 11,
               "column": 17
+            }
+          }
+        }
+      ]
+    },
+    {
+      "token": {
+        "start": {
+          "offset": 142,
+          "line": 12,
+          "column": 1
+        },
+        "end": {
+          "offset": 202,
+          "line": 12,
+          "column": 61
+        }
+      },
+      "name": null,
+      "schemaName": null,
+      "onDelete": "set default",
+      "onUpdate": "set null",
+      "endpoints": [
+        {
+          "fieldNames": [
+            "code"
+          ],
+          "tableName": "A",
+          "schemaName": null,
+          "relation": "*",
+          "token": {
+            "start": {
+              "offset": 147,
+              "line": 12,
+              "column": 6
+            },
+            "end": {
+              "offset": 153,
+              "line": 12,
+              "column": 12
+            }
+          }
+        },
+        {
+          "fieldNames": [
+            "code"
+          ],
+          "tableName": "B",
+          "schemaName": null,
+          "relation": "1",
+          "token": {
+            "start": {
+              "offset": 156,
+              "line": 12,
+              "column": 15
+            },
+            "end": {
+              "offset": 162,
+              "line": 12,
+              "column": 21
             }
           }
         }

--- a/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
@@ -776,6 +776,7 @@
       },
       "name": null,
       "schemaName": null,
+      "onDelete": "set null",
       "endpoints": [
         {
           "tableName": "products",
@@ -836,6 +837,7 @@
       },
       "name": null,
       "schemaName": null,
+      "onDelete": "no action",
       "endpoints": [
         {
           "fieldNames": [

--- a/packages/dbml-parse/tests/old_tests/output/referential_actions.out.json
+++ b/packages/dbml-parse/tests/old_tests/output/referential_actions.out.json
@@ -776,6 +776,7 @@
       },
       "name": null,
       "schemaName": null,
+      "onDelete": "set null",
       "endpoints": [
         {
           "tableName": "products",
@@ -836,6 +837,7 @@
       },
       "name": null,
       "schemaName": null,
+      "onDelete": "no action",
       "endpoints": [
         {
           "fieldNames": [


### PR DESCRIPTION
## Summary
* This snippet does not get interpreted properly (unquoted delete and update value settings)
```
   Ref: A.id > B.id [update: set default, delete: set null]
```

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review