### PR TITLE
fix(postgresql): properly handle definition of unique and PK constraints in ALTER TABLE statements

### DIFF
--- a/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/in-files/schema.sql
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/in-files/schema.sql
@@ -35,12 +35,14 @@ CREATE TABLE "products" (
 CREATE TABLE "users" (
   "id" int PRIMARY KEY,
   "full_name" varchar,
-  "email" varchar UNIQUE,
+  "email" varchar,
   "gender" varchar,
   "date_of_birth" varchar,
   "created_at" varchar,
   "country_code" int
 );
+
+ALTER TABLE ONLY "users" ADD CONSTRAINT email_must_be_unique UNIQUE (email);
 
 CREATE TABLE "merchants" (
   "id" int PRIMARY KEY,
@@ -51,10 +53,13 @@ CREATE TABLE "merchants" (
 );
 
 CREATE TABLE "countries" (
-  "code" int PRIMARY KEY,
+  "code" int,
   "name" varchar,
   "continent_name" varchar
 );
+
+ALTER TABLE ONLY "countries"
+    ADD CONSTRAINT countries_pk PRIMARY KEY ("code");
 
 ALTER TABLE "order_items" ADD FOREIGN KEY ("order_id") REFERENCES "orders" ("id");
 

--- a/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/in-files/schema.sql
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/in-files/schema.sql
@@ -76,3 +76,14 @@ ALTER TABLE "merchants" ADD FOREIGN KEY ("admin_id") REFERENCES "users" ("id");
 CREATE INDEX "product_status" ON "products" ("merchant_id", "status");
 
 CREATE UNIQUE INDEX ON "products" USING HASH ("id");
+
+CREATE TABLE "comment_on_product" (
+  "comment_id" int,
+  "product_family" int,
+  "delete" boolean,
+  "comment_value" varchar
+);
+
+ALTER TABLE "comment_on_product" ADD CONSTRAINT "comment_on_product_pk" PRIMARY KEY ("comment_id", "product_family");
+
+ALTER TABLE "comment_on_product" ADD CONSTRAINT "comment_on_product_idx_unique" UNIQUE("delete", "comment_id", "product_family"); 

--- a/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
@@ -45,6 +45,10 @@ Table "users" {
   "date_of_birth" varchar
   "created_at" varchar
   "country_code" int
+
+Indexes {
+  email [unique, name: "email_must_be_unique"]
+}
 }
 
 Table "merchants" {
@@ -59,6 +63,10 @@ Table "countries" {
   "code" int [pk]
   "name" varchar
   "continent_name" varchar
+
+Indexes {
+  code [pk, name: "countries_pk"]
+}
 }
 
 Ref:"orders"."id" < "order_items"."order_id"

--- a/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
@@ -45,10 +45,6 @@ Table "users" {
   "date_of_birth" varchar
   "created_at" varchar
   "country_code" int
-
-Indexes {
-  email [unique, name: "email_must_be_unique"]
-}
 }
 
 Table "merchants" {
@@ -63,10 +59,6 @@ Table "countries" {
   "code" int [pk]
   "name" varchar
   "continent_name" varchar
-
-Indexes {
-  code [pk, name: "countries_pk"]
-}
 }
 
 Ref:"orders"."id" < "order_items"."order_id"

--- a/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
+++ b/packages/dbml-cli/__test__/sql2dbml/filename --postgres stdout/stdout.txt
@@ -61,6 +61,18 @@ Table "countries" {
   "continent_name" varchar
 }
 
+Table "comment_on_product" {
+  "comment_id" int
+  "product_family" int
+  "delete" boolean
+  "comment_value" varchar
+
+Indexes {
+  (comment_id, product_family) [pk, name: "comment_on_product_pk"]
+  (delete, comment_id, product_family) [unique, name: "comment_on_product_idx_unique"]
+}
+}
+
 Ref:"orders"."id" < "order_items"."order_id"
 
 Ref:"products"."id" < "order_items"."product_id"

--- a/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
+++ b/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
@@ -26,21 +26,29 @@ Table "humanresources"."employee" {
 }
 
 Table "humanresources"."employeedepartmenthistory" {
-  "businessentityid" integer [pk, not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
   "departmentid" smallint [not null, note: 'Department in which the employee worked including currently. Foreign key to Department.DepartmentID.']
   "shiftid" smallint [not null, note: 'Identifies which 8-hour shift the employee works. Foreign key to Shift.Shift.ID.']
   "startdate" date [not null, note: 'Date the employee started work in the department.']
   "enddate" date [note: 'Date the employee left the department. NULL = Current department.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, startdate, departmentid, shiftid) [pk, name: "PK_EmployeeDepartmentHistory_BusinessEntityID_StartDate_Departm"]
+}
   Note: 'Employee department transfers.'
 }
 
 Table "humanresources"."employeepayhistory" {
-  "businessentityid" integer [pk, not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
   "ratechangedate" timestamp [not null, note: 'Date the change in pay is effective']
   "rate" numeric [not null, note: 'Salary hourly rate.']
   "payfrequency" smallint [not null, note: '1 = Salary received monthly, 2 = Salary received biweekly']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, ratechangedate) [pk, name: "PK_EmployeePayHistory_BusinessEntityID_RateChangeDate"]
+}
   Note: 'Employee pay history.'
 }
 
@@ -75,11 +83,15 @@ Table "person"."address" {
 }
 
 Table "person"."businessentityaddress" {
-  "businessentityid" integer [pk, not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
   "addressid" integer [not null, note: 'Primary key. Foreign key to Address.AddressID.']
   "addresstypeid" integer [not null, note: 'Primary key. Foreign key to AddressType.AddressTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, addressid, addresstypeid) [pk, name: "PK_BusinessEntityAddress_BusinessEntityID_AddressID_AddressType"]
+}
   Note: 'Cross-reference table mapping customers, vendors, and employees to their addresses.'
 }
 
@@ -91,11 +103,15 @@ Table "person"."countryregion" {
 }
 
 Table "person"."emailaddress" {
-  "businessentityid" integer [pk, not null, note: 'Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID']
+  "businessentityid" integer [not null, note: 'Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID']
   "emailaddressid" integer [not null, note: 'Primary key. ID of this email address.']
   "emailaddress" "character varying(50)" [note: 'E-mail address for the person.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, emailaddressid) [pk, name: "PK_EmailAddress_BusinessEntityID_EmailAddressID"]
+}
   Note: 'Where to send a person email.'
 }
 
@@ -117,10 +133,14 @@ Table "person"."person" {
 }
 
 Table "person"."personphone" {
-  "businessentityid" integer [pk, not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
   "phonenumber" public.Phone [not null, note: 'Telephone number identification number.']
   "phonenumbertypeid" integer [not null, note: 'Kind of phone number. Foreign key to PhoneNumberType.PhoneNumberTypeID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, phonenumber, phonenumbertypeid) [pk, name: "PK_PersonPhone_BusinessEntityID_PhoneNumber_PhoneNumberTypeID"]
+}
   Note: 'Telephone number and type of a person.'
 }
 
@@ -159,11 +179,15 @@ Table "person"."businessentity" {
 }
 
 Table "person"."businessentitycontact" {
-  "businessentityid" integer [pk, not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
   "personid" integer [not null, note: 'Primary key. Foreign key to Person.BusinessEntityID.']
   "contacttypeid" integer [not null, note: 'Primary key.  Foreign key to ContactType.ContactTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, personid, contacttypeid) [pk, name: "PK_BusinessEntityContact_BusinessEntityID_PersonID_ContactTypeI"]
+}
   Note: 'Cross-reference table mapping stores, vendors, and employees to people'
 }
 
@@ -274,11 +298,15 @@ Table "production"."productcategory" {
 }
 
 Table "production"."productcosthistory" {
-  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID']
+  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID']
   "startdate" timestamp [not null, note: 'Product cost start date.']
   "enddate" timestamp [note: 'Product cost end date.']
   "standardcost" numeric [not null, note: 'Standard cost of the product.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, startdate) [pk, name: "PK_ProductCostHistory_ProductID_StartDate"]
+}
   Note: 'Changes in the cost of a product over time.'
 }
 
@@ -291,29 +319,41 @@ Table "production"."productdescription" {
 }
 
 Table "production"."productdocument" {
-  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "modifieddate" timestamp [not null, default: `now()`]
   "documentnode" "character varying" [not null, default: `'/'::charactervarying`, note: 'Document identification number. Foreign key to Document.DocumentNode.']
+
+Indexes {
+  (productid, documentnode) [pk, name: "PK_ProductDocument_ProductID_DocumentNode"]
+}
   Note: 'Cross-reference table mapping products to related product documents.'
 }
 
 Table "production"."productinventory" {
-  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "locationid" smallint [not null, note: 'Inventory location identification number. Foreign key to Location.LocationID.']
   "shelf" "character varying(10)" [not null, note: 'Storage compartment within an inventory location.']
   "bin" smallint [not null, note: 'Storage container on a shelf in an inventory location.']
   "quantity" smallint [not null, default: 0, note: 'Quantity of products in the inventory location.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, locationid) [pk, name: "PK_ProductInventory_ProductID_LocationID"]
+}
   Note: 'Product inventory information.'
 }
 
 Table "production"."productlistpricehistory" {
-  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID']
+  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID']
   "startdate" timestamp [not null, note: 'List price start date.']
   "enddate" timestamp [note: 'List price end date']
   "listprice" numeric [not null, note: 'Product list price.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, startdate) [pk, name: "PK_ProductListPriceHistory_ProductID_StartDate"]
+}
   Note: 'Changes in the list price of a product over time.'
 }
 
@@ -328,17 +368,25 @@ Table "production"."productmodel" {
 }
 
 Table "production"."productmodelillustration" {
-  "productmodelid" integer [pk, not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
+  "productmodelid" integer [not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
   "illustrationid" integer [not null, note: 'Primary key. Foreign key to Illustration.IllustrationID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productmodelid, illustrationid) [pk, name: "PK_ProductModelIllustration_ProductModelID_IllustrationID"]
+}
   Note: 'Cross-reference table mapping product models and illustrations.'
 }
 
 Table "production"."productmodelproductdescriptionculture" {
-  "productmodelid" integer [pk, not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
+  "productmodelid" integer [not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
   "productdescriptionid" integer [not null, note: 'Primary key. Foreign key to ProductDescription.ProductDescriptionID.']
   "cultureid" "character (6)" [not null, note: 'Culture identification number. Foreign key to Culture.CultureID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productmodelid, productdescriptionid, cultureid) [pk, name: "PK_ProductModelProductDescriptionCulture_ProductModelID_Product"]
+}
   Note: 'Cross-reference table mapping product descriptions and the language the description is written in.'
 }
 
@@ -353,10 +401,14 @@ Table "production"."productphoto" {
 }
 
 Table "production"."productproductphoto" {
-  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "productphotoid" integer [not null, note: 'Product photo identification number. Foreign key to ProductPhoto.ProductPhotoID.']
   "primary" public.Flag [not null, default: false, note: '0 = Photo is not the principal image. 1 = Photo is the principal image.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, productphotoid) [pk, name: "PK_ProductProductPhoto_ProductID_ProductPhotoID"]
+}
   Note: 'Cross-reference table mapping products and product photos.'
 }
 
@@ -436,7 +488,7 @@ Table "production"."workorder" {
 }
 
 Table "production"."workorderrouting" {
-  "workorderid" integer [pk, not null, note: 'Primary key. Foreign key to WorkOrder.WorkOrderID.']
+  "workorderid" integer [not null, note: 'Primary key. Foreign key to WorkOrder.WorkOrderID.']
   "productid" integer [not null, note: 'Primary key. Foreign key to Product.ProductID.']
   "operationsequence" smallint [not null, note: 'Primary key. Indicates the manufacturing process sequence.']
   "locationid" smallint [not null, note: 'Manufacturing location where the part is processed. Foreign key to Location.LocationID.']
@@ -448,11 +500,15 @@ Table "production"."workorderrouting" {
   "plannedcost" numeric [not null, note: 'Estimated manufacturing cost.']
   "actualcost" numeric [note: 'Actual manufacturing cost.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (workorderid, productid, operationsequence) [pk, name: "PK_WorkOrderRouting_WorkOrderID_ProductID_OperationSequence"]
+}
   Note: 'Work order details.'
 }
 
 Table "purchasing"."purchaseorderdetail" {
-  "purchaseorderid" integer [pk, not null, note: 'Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.']
+  "purchaseorderid" integer [not null, note: 'Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.']
   "purchaseorderdetailid" integer [not null, note: 'Primary key. One line number per purchased product.']
   "duedate" timestamp [not null, note: 'Date the product is expected to be received.']
   "orderqty" smallint [not null, note: 'Quantity ordered.']
@@ -461,6 +517,10 @@ Table "purchasing"."purchaseorderdetail" {
   "receivedqty" numeric(8,2) [not null, note: 'Quantity actually received from the vendor.']
   "rejectedqty" numeric(8,2) [not null, note: 'Quantity rejected during inspection.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (purchaseorderid, purchaseorderdetailid) [pk, name: "PK_PurchaseOrderDetail_PurchaseOrderID_PurchaseOrderDetailID"]
+}
   Note: 'Individual products associated with a specific purchase order. See PurchaseOrderHeader.'
 }
 
@@ -482,7 +542,7 @@ for more details.'''
 }
 
 Table "purchasing"."productvendor" {
-  "productid" integer [pk, not null, note: 'Primary key. Foreign key to Product.ProductID.']
+  "productid" integer [not null, note: 'Primary key. Foreign key to Product.ProductID.']
   "businessentityid" integer [not null, note: 'Primary key. Foreign key to Vendor.BusinessEntityID.']
   "averageleadtime" integer [not null, note: 'The average span of time (in days) between placing an order with the vendor and receiving the purchased product.']
   "standardprice" numeric [not null, note: '''The vendor's usual selling price.''']
@@ -493,6 +553,10 @@ Table "purchasing"."productvendor" {
   "onorderqty" integer [note: 'The quantity currently on order.']
   "unitmeasurecode" "character (3)" [not null, note: '''The product's unit of measure.''']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, businessentityid) [pk, name: "PK_ProductVendor_ProductID_BusinessEntityID"]
+}
   Note: 'Cross-reference table mapping vendors with the products they supply.'
 }
 
@@ -550,9 +614,13 @@ Table "sales"."currencyrate" {
 }
 
 Table "sales"."countryregioncurrency" {
-  "countryregioncode" "character varying(3)" [pk, not null, note: 'ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.']
+  "countryregioncode" "character varying(3)" [not null, note: 'ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.']
   "currencycode" "character (3)" [not null, note: 'ISO standard currency code. Foreign key to Currency.CurrencyCode.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (countryregioncode, currencycode) [pk, name: "PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode"]
+}
   Note: 'Cross-reference table mapping ISO currency codes to a country or region.'
 }
 
@@ -564,9 +632,13 @@ Table "sales"."currency" {
 }
 
 Table "sales"."personcreditcard" {
-  "businessentityid" integer [pk, not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
   "creditcardid" integer [not null, note: 'Credit card identification number. Foreign key to CreditCard.CreditCardID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, creditcardid) [pk, name: "PK_PersonCreditCard_BusinessEntityID_CreditCardID"]
+}
   Note: 'Cross-reference table mapping people to their credit card information in the CreditCard table.'
 }
 
@@ -606,7 +678,7 @@ Table "sales"."specialoffer" {
 }
 
 Table "sales"."salesorderdetail" {
-  "salesorderid" integer [pk, not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
+  "salesorderid" integer [not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
   "salesorderdetailid" integer [not null, note: 'Primary key. One incremental unique number per product sold.']
   "carriertrackingnumber" "character varying(25)" [note: 'Shipment tracking number supplied by the shipper.']
   "orderqty" smallint [not null, note: 'Quantity ordered per product.']
@@ -616,6 +688,10 @@ Table "sales"."salesorderdetail" {
   "unitpricediscount" numeric [not null, default: 0.0, note: 'Discount amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (salesorderid, salesorderdetailid) [pk, name: "PK_SalesOrderDetail_SalesOrderID_SalesOrderDetailID"]
+}
   Note: 'Individual products associated with a specific sales order. See SalesOrderHeader.'
 }
 
@@ -649,17 +725,25 @@ Table "sales"."salesorderheader" {
 }
 
 Table "sales"."salesorderheadersalesreason" {
-  "salesorderid" integer [pk, not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
+  "salesorderid" integer [not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
   "salesreasonid" integer [not null, note: 'Primary key. Foreign key to SalesReason.SalesReasonID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (salesorderid, salesreasonid) [pk, name: "PK_SalesOrderHeaderSalesReason_SalesOrderID_SalesReasonID"]
+}
   Note: 'Cross-reference table mapping sales orders to sales reason codes.'
 }
 
 Table "sales"."specialofferproduct" {
-  "specialofferid" integer [pk, not null, note: 'Primary key for SpecialOfferProduct records.']
+  "specialofferid" integer [not null, note: 'Primary key for SpecialOfferProduct records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (specialofferid, productid) [pk, name: "PK_SpecialOfferProduct_SpecialOfferID_ProductID"]
+}
   Note: 'Cross-reference table mapping products to special offer discounts.'
 }
 
@@ -677,11 +761,15 @@ Table "sales"."salesperson" {
 }
 
 Table "sales"."salespersonquotahistory" {
-  "businessentityid" integer [pk, not null, note: 'Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.']
   "quotadate" timestamp [not null, note: 'Sales quota date.']
   "salesquota" numeric [not null, note: 'Sales quota amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, quotadate) [pk, name: "PK_SalesPersonQuotaHistory_BusinessEntityID_QuotaDate"]
+}
   Note: 'Sales performance tracking.'
 }
 
@@ -708,12 +796,16 @@ Table "sales"."salesterritory" {
 }
 
 Table "sales"."salesterritoryhistory" {
-  "businessentityid" integer [pk, not null, note: 'Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.']
+  "businessentityid" integer [not null, note: 'Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.']
   "territoryid" integer [not null, note: 'Primary key. Territory identification number. Foreign key to SalesTerritory.SalesTerritoryID.']
   "startdate" timestamp [not null, note: 'Primary key. Date the sales representive started work in the territory.']
   "enddate" timestamp [note: 'Date the sales representative left work in the territory.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, startdate, territoryid) [pk, name: "PK_SalesTerritoryHistory_BusinessEntityID_StartDate_TerritoryID"]
+}
   Note: 'Sales representative transfers to other sales territories.'
 }
 

--- a/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
+++ b/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
@@ -1,13 +1,17 @@
 Table "humanresources"."department" {
-  "departmentid" integer [not null, note: 'Primary key for Department records.']
+  "departmentid" integer [pk, not null, note: 'Primary key for Department records.']
   "name" public.Name [not null, note: 'Name of the department.']
   "groupname" public.Name [not null, note: 'Name of the group to which the department belongs.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  departmentid [pk, name: "PK_Department_DepartmentID"]
+}
   Note: 'Lookup table containing the departments within the Adventure Works Cycles company.'
 }
 
 Table "humanresources"."employee" {
-  "businessentityid" integer [not null, note: 'Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.']
   "nationalidnumber" "character varying(15)" [not null, note: 'Unique national identification number such as a social security number.']
   "loginid" "character varying(256)" [not null, note: 'Network login.']
   "jobtitle" "character varying(50)" [not null, note: 'Work title such as Buyer or Sales Representative.']
@@ -22,6 +26,10 @@ Table "humanresources"."employee" {
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
   "organizationnode" "character varying" [default: `'/'::charactervarying`, note: 'Where the employee is located in corporate hierarchy.']
+
+Indexes {
+  businessentityid [pk, name: "PK_Employee_BusinessEntityID"]
+}
   Note: 'Employee information such as salary, department, and title.'
 }
 
@@ -32,6 +40,10 @@ Table "humanresources"."employeedepartmenthistory" {
   "startdate" date [not null, note: 'Date the employee started work in the department.']
   "enddate" date [note: 'Date the employee left the department. NULL = Current department.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, startdate, departmentid, shiftid) [pk, name: "PK_EmployeeDepartmentHistory_BusinessEntityID_StartDate_Departm"]
+}
   Note: 'Employee department transfers.'
 }
 
@@ -41,28 +53,40 @@ Table "humanresources"."employeepayhistory" {
   "rate" numeric [not null, note: 'Salary hourly rate.']
   "payfrequency" smallint [not null, note: '1 = Salary received monthly, 2 = Salary received biweekly']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, ratechangedate) [pk, name: "PK_EmployeePayHistory_BusinessEntityID_RateChangeDate"]
+}
   Note: 'Employee pay history.'
 }
 
 Table "humanresources"."jobcandidate" {
-  "jobcandidateid" integer [not null, note: 'Primary key for JobCandidate records.']
+  "jobcandidateid" integer [pk, not null, note: 'Primary key for JobCandidate records.']
   "businessentityid" integer [note: 'Employee identification number if applicant was hired. Foreign key to Employee.BusinessEntityID.']
   "resume" xml [note: 'RÃ©sumÃ© in XML format.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  jobcandidateid [pk, name: "PK_JobCandidate_JobCandidateID"]
+}
   Note: 'RÃ©sumÃ©s submitted to Human Resources by job applicants.'
 }
 
 Table "humanresources"."shift" {
-  "shiftid" integer [not null, note: 'Primary key for Shift records.']
+  "shiftid" integer [pk, not null, note: 'Primary key for Shift records.']
   "name" public.Name [not null, note: 'Shift description.']
   "starttime" time [not null, note: 'Shift start time.']
   "endtime" time [not null, note: 'Shift end time.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  shiftid [pk, name: "PK_Shift_ShiftID"]
+}
   Note: 'Work shift lookup table.'
 }
 
 Table "person"."address" {
-  "addressid" integer [not null, note: 'Primary key for Address records.']
+  "addressid" integer [pk, not null, note: 'Primary key for Address records.']
   "addressline1" "character varying(60)" [not null, note: 'First street address line.']
   "addressline2" "character varying(60)" [note: 'Second street address line.']
   "city" "character varying(30)" [not null, note: 'Name of the city.']
@@ -71,6 +95,10 @@ Table "person"."address" {
   "spatiallocation" "character varying(44)" [note: 'Latitude and longitude of this address.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  addressid [pk, name: "PK_Address_AddressID"]
+}
   Note: 'Street address information for customers, employees, and vendors.'
 }
 
@@ -80,13 +108,21 @@ Table "person"."businessentityaddress" {
   "addresstypeid" integer [not null, note: 'Primary key. Foreign key to AddressType.AddressTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, addressid, addresstypeid) [pk, name: "PK_BusinessEntityAddress_BusinessEntityID_AddressID_AddressType"]
+}
   Note: 'Cross-reference table mapping customers, vendors, and employees to their addresses.'
 }
 
 Table "person"."countryregion" {
-  "countryregioncode" "character varying(3)" [not null, note: 'ISO standard code for countries and regions.']
+  "countryregioncode" "character varying(3)" [pk, not null, note: 'ISO standard code for countries and regions.']
   "name" public.Name [not null, note: 'Country or region name.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  countryregioncode [pk, name: "PK_CountryRegion_CountryRegionCode"]
+}
   Note: 'Lookup table containing the ISO standard codes for countries and regions.'
 }
 
@@ -96,11 +132,15 @@ Table "person"."emailaddress" {
   "emailaddress" "character varying(50)" [note: 'E-mail address for the person.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, emailaddressid) [pk, name: "PK_EmailAddress_BusinessEntityID_EmailAddressID"]
+}
   Note: 'Where to send a person email.'
 }
 
 Table "person"."person" {
-  "businessentityid" integer [not null, note: 'Primary key for Person records.']
+  "businessentityid" integer [pk, not null, note: 'Primary key for Person records.']
   "persontype" "character (2)" [not null, note: 'Primary type of person: SC = Store Contact, IN = Individual (retail) customer, SP = Sales person, EM = Employee (non-sales), VC = Vendor contact, GC = General contact']
   "namestyle" public.NameStyle [not null, default: false, note: '0 = The data in FirstName and LastName are stored in western style (first name, last name) order.  1 = Eastern style (last name, first name) order.']
   "title" "character varying(8)" [note: 'A courtesy title. For example, Mr. or Ms.']
@@ -113,6 +153,10 @@ Table "person"."person" {
   "demographics" xml [note: 'Personal information such as hobbies, and income collected from online shoppers. Used for sales analysis.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_Person_BusinessEntityID"]
+}
   Note: 'Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.'
 }
 
@@ -121,18 +165,26 @@ Table "person"."personphone" {
   "phonenumber" public.Phone [not null, note: 'Telephone number identification number.']
   "phonenumbertypeid" integer [not null, note: 'Kind of phone number. Foreign key to PhoneNumberType.PhoneNumberTypeID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, phonenumber, phonenumbertypeid) [pk, name: "PK_PersonPhone_BusinessEntityID_PhoneNumber_PhoneNumberTypeID"]
+}
   Note: 'Telephone number and type of a person.'
 }
 
 Table "person"."phonenumbertype" {
-  "phonenumbertypeid" integer [not null, note: 'Primary key for telephone number type records.']
+  "phonenumbertypeid" integer [pk, not null, note: 'Primary key for telephone number type records.']
   "name" public.Name [not null, note: 'Name of the telephone number type']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  phonenumbertypeid [pk, name: "PK_PhoneNumberType_PhoneNumberTypeID"]
+}
   Note: 'Type of phone number of a person.'
 }
 
 Table "person"."stateprovince" {
-  "stateprovinceid" integer [not null, note: 'Primary key for StateProvince records.']
+  "stateprovinceid" integer [pk, not null, note: 'Primary key for StateProvince records.']
   "stateprovincecode" "character (3)" [not null, note: 'ISO standard state or province code.']
   "countryregioncode" "character varying(3)" [not null, note: 'ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode.']
   "isonlystateprovinceflag" public.Flag [not null, default: true, note: '0 = StateProvinceCode exists. 1 = StateProvinceCode unavailable, using CountryRegionCode.']
@@ -140,21 +192,33 @@ Table "person"."stateprovince" {
   "territoryid" integer [not null, note: 'ID of the territory in which the state or province is located. Foreign key to SalesTerritory.SalesTerritoryID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  stateprovinceid [pk, name: "PK_StateProvince_StateProvinceID"]
+}
   Note: 'State and province lookup table.'
 }
 
 Table "person"."addresstype" {
-  "addresstypeid" integer [not null, note: 'Primary key for AddressType records.']
+  "addresstypeid" integer [pk, not null, note: 'Primary key for AddressType records.']
   "name" public.Name [not null, note: 'Address type description. For example, Billing, Home, or Shipping.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  addresstypeid [pk, name: "PK_AddressType_AddressTypeID"]
+}
   Note: 'Types of addresses stored in the Address table.'
 }
 
 Table "person"."businessentity" {
-  "businessentityid" integer [not null, note: 'Primary key for all customers, vendors, and employees.']
+  "businessentityid" integer [pk, not null, note: 'Primary key for all customers, vendors, and employees.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_BusinessEntity_BusinessEntityID"]
+}
   Note: 'Source of the ID that connects vendors, customers, and employees with address and contact information.'
 }
 
@@ -164,27 +228,39 @@ Table "person"."businessentitycontact" {
   "contacttypeid" integer [not null, note: 'Primary key.  Foreign key to ContactType.ContactTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, personid, contacttypeid) [pk, name: "PK_BusinessEntityContact_BusinessEntityID_PersonID_ContactTypeI"]
+}
   Note: 'Cross-reference table mapping stores, vendors, and employees to people'
 }
 
 Table "person"."contacttype" {
-  "contacttypeid" integer [not null, note: 'Primary key for ContactType records.']
+  "contacttypeid" integer [pk, not null, note: 'Primary key for ContactType records.']
   "name" public.Name [not null, note: 'Contact type description.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  contacttypeid [pk, name: "PK_ContactType_ContactTypeID"]
+}
   Note: 'Lookup table containing the types of business entity contacts.'
 }
 
 Table "person"."password" {
-  "businessentityid" integer [not null]
+  "businessentityid" integer [pk, not null]
   "passwordhash" "character varying(128)" [not null, note: 'Password for the e-mail account.']
   "passwordsalt" "character varying(10)" [not null, note: 'Random value concatenated with the password string before the password is hashed.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_Password_BusinessEntityID"]
+}
   Note: 'One way hashed authentication information'
 }
 
 Table "production"."billofmaterials" {
-  "billofmaterialsid" integer [not null, note: 'Primary key for BillOfMaterials records.']
+  "billofmaterialsid" integer [pk, not null, note: 'Primary key for BillOfMaterials records.']
   "productassemblyid" integer [note: 'Parent product identification number. Foreign key to Product.ProductID.']
   "componentid" integer [not null, note: 'Component identification number. Foreign key to Product.ProductID.']
   "startdate" timestamp [not null, default: `now()`, note: 'Date the component started being used in the assembly item.']
@@ -193,13 +269,21 @@ Table "production"."billofmaterials" {
   "bomlevel" smallint [not null, note: 'Indicates the depth the component is from its parent (AssemblyID).']
   "perassemblyqty" numeric(8,2) [not null, default: 1.00, note: 'Quantity of the component needed to create the assembly.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  billofmaterialsid [pk, name: "PK_BillOfMaterials_BillOfMaterialsID"]
+}
   Note: 'Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.'
 }
 
 Table "production"."culture" {
-  "cultureid" "character (6)" [not null, note: 'Primary key for Culture records.']
+  "cultureid" "character (6)" [pk, not null, note: 'Primary key for Culture records.']
   "name" public.Name [not null, note: 'Culture description.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  cultureid [pk, name: "PK_Culture_CultureID"]
+}
   Note: 'Lookup table containing the languages in which some AdventureWorks data is stored.'
 }
 
@@ -214,30 +298,43 @@ Table "production"."document" {
   "status" smallint [not null, note: '1 = Pending approval, 2 = Approved, 3 = Obsolete']
   "documentsummary" text [note: 'Document abstract.']
   "document" bytea [note: 'Complete document.']
-  "rowguid" uuid [not null, default: `public.uuid_generate_v1()`, note: 'ROWGUIDCOL number uniquely identifying the record. Required for FileStream.']
+  "rowguid" uuid [unique, not null, default: `public.uuid_generate_v1()`, note: 'ROWGUIDCOL number uniquely identifying the record. Required for FileStream.']
   "modifieddate" timestamp [not null, default: `now()`]
-  "documentnode" "character varying" [not null, default: `'/'::charactervarying`, note: 'Primary key for Document records.']
+  "documentnode" "character varying" [pk, not null, default: `'/'::charactervarying`, note: 'Primary key for Document records.']
+
+Indexes {
+  documentnode [pk, name: "PK_Document_DocumentNode"]
+  rowguid [unique, name: "document_rowguid_key"]
+}
   Note: 'Product maintenance documents.'
 }
 
 Table "production"."illustration" {
-  "illustrationid" integer [not null, note: 'Primary key for Illustration records.']
+  "illustrationid" integer [pk, not null, note: 'Primary key for Illustration records.']
   "diagram" xml [note: 'Illustrations used in manufacturing instructions. Stored as XML.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  illustrationid [pk, name: "PK_Illustration_IllustrationID"]
+}
   Note: 'Bicycle assembly diagrams.'
 }
 
 Table "production"."location" {
-  "locationid" integer [not null, note: 'Primary key for Location records.']
+  "locationid" integer [pk, not null, note: 'Primary key for Location records.']
   "name" public.Name [not null, note: 'Location description.']
   "costrate" numeric [not null, default: 0.00, note: 'Standard hourly cost of the manufacturing location.']
   "availability" numeric(8,2) [not null, default: 0.00, note: 'Work capacity (in hours) of the manufacturing location.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  locationid [pk, name: "PK_Location_LocationID"]
+}
   Note: 'Product inventory and manufacturing locations.'
 }
 
 Table "production"."product" {
-  "productid" integer [not null, note: 'Primary key for Product records.']
+  "productid" integer [pk, not null, note: 'Primary key for Product records.']
   "name" public.Name [not null, note: 'Name of the product.']
   "productnumber" "character varying(25)" [not null, note: 'Unique product identification number.']
   "makeflag" public.Flag [not null, default: true, note: '0 = Product is purchased, 1 = Product is manufactured in-house.']
@@ -262,14 +359,22 @@ Table "production"."product" {
   "discontinueddate" timestamp [note: 'Date the product was discontinued.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productid [pk, name: "PK_Product_ProductID"]
+}
   Note: 'Products sold or used in the manfacturing of sold products.'
 }
 
 Table "production"."productcategory" {
-  "productcategoryid" integer [not null, note: 'Primary key for ProductCategory records.']
+  "productcategoryid" integer [pk, not null, note: 'Primary key for ProductCategory records.']
   "name" public.Name [not null, note: 'Category description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productcategoryid [pk, name: "PK_ProductCategory_ProductCategoryID"]
+}
   Note: 'High-level product categorization.'
 }
 
@@ -279,14 +384,22 @@ Table "production"."productcosthistory" {
   "enddate" timestamp [note: 'Product cost end date.']
   "standardcost" numeric [not null, note: 'Standard cost of the product.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, startdate) [pk, name: "PK_ProductCostHistory_ProductID_StartDate"]
+}
   Note: 'Changes in the cost of a product over time.'
 }
 
 Table "production"."productdescription" {
-  "productdescriptionid" integer [not null, note: 'Primary key for ProductDescription records.']
+  "productdescriptionid" integer [pk, not null, note: 'Primary key for ProductDescription records.']
   "description" "character varying(400)" [not null, note: 'Description of the product.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productdescriptionid [pk, name: "PK_ProductDescription_ProductDescriptionID"]
+}
   Note: 'Product descriptions in several languages.'
 }
 
@@ -294,6 +407,10 @@ Table "production"."productdocument" {
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "modifieddate" timestamp [not null, default: `now()`]
   "documentnode" "character varying" [not null, default: `'/'::charactervarying`, note: 'Document identification number. Foreign key to Document.DocumentNode.']
+
+Indexes {
+  (productid, documentnode) [pk, name: "PK_ProductDocument_ProductID_DocumentNode"]
+}
   Note: 'Cross-reference table mapping products to related product documents.'
 }
 
@@ -305,6 +422,10 @@ Table "production"."productinventory" {
   "quantity" smallint [not null, default: 0, note: 'Quantity of products in the inventory location.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, locationid) [pk, name: "PK_ProductInventory_ProductID_LocationID"]
+}
   Note: 'Product inventory information.'
 }
 
@@ -314,16 +435,24 @@ Table "production"."productlistpricehistory" {
   "enddate" timestamp [note: 'List price end date']
   "listprice" numeric [not null, note: 'Product list price.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, startdate) [pk, name: "PK_ProductListPriceHistory_ProductID_StartDate"]
+}
   Note: 'Changes in the list price of a product over time.'
 }
 
 Table "production"."productmodel" {
-  "productmodelid" integer [not null, note: 'Primary key for ProductModel records.']
+  "productmodelid" integer [pk, not null, note: 'Primary key for ProductModel records.']
   "name" public.Name [not null, note: 'Product model description.']
   "catalogdescription" xml [note: 'Detailed product catalog information in xml format.']
   "instructions" xml [note: 'Manufacturing instructions in xml format.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productmodelid [pk, name: "PK_ProductModel_ProductModelID"]
+}
   Note: 'Product model classification.'
 }
 
@@ -331,6 +460,10 @@ Table "production"."productmodelillustration" {
   "productmodelid" integer [not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
   "illustrationid" integer [not null, note: 'Primary key. Foreign key to Illustration.IllustrationID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productmodelid, illustrationid) [pk, name: "PK_ProductModelIllustration_ProductModelID_IllustrationID"]
+}
   Note: 'Cross-reference table mapping product models and illustrations.'
 }
 
@@ -339,16 +472,24 @@ Table "production"."productmodelproductdescriptionculture" {
   "productdescriptionid" integer [not null, note: 'Primary key. Foreign key to ProductDescription.ProductDescriptionID.']
   "cultureid" "character (6)" [not null, note: 'Culture identification number. Foreign key to Culture.CultureID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productmodelid, productdescriptionid, cultureid) [pk, name: "PK_ProductModelProductDescriptionCulture_ProductModelID_Product"]
+}
   Note: 'Cross-reference table mapping product descriptions and the language the description is written in.'
 }
 
 Table "production"."productphoto" {
-  "productphotoid" integer [not null, note: 'Primary key for ProductPhoto records.']
+  "productphotoid" integer [pk, not null, note: 'Primary key for ProductPhoto records.']
   "thumbnailphoto" bytea [note: 'Small image of the product.']
   "thumbnailphotofilename" "character varying(50)" [note: 'Small image file name.']
   "largephoto" bytea [note: 'Large image of the product.']
   "largephotofilename" "character varying(50)" [note: 'Large image file name.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productphotoid [pk, name: "PK_ProductPhoto_ProductPhotoID"]
+}
   Note: 'Product images.'
 }
 
@@ -357,11 +498,15 @@ Table "production"."productproductphoto" {
   "productphotoid" integer [not null, note: 'Product photo identification number. Foreign key to ProductPhoto.ProductPhotoID.']
   "primary" public.Flag [not null, default: false, note: '0 = Photo is not the principal image. 1 = Photo is the principal image.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, productphotoid) [pk, name: "PK_ProductProductPhoto_ProductID_ProductPhotoID"]
+}
   Note: 'Cross-reference table mapping products and product photos.'
 }
 
 Table "production"."productreview" {
-  "productreviewid" integer [not null, note: 'Primary key for ProductReview records.']
+  "productreviewid" integer [pk, not null, note: 'Primary key for ProductReview records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "reviewername" public.Name [not null, note: 'Name of the reviewer.']
   "reviewdate" timestamp [not null, default: `now()`, note: 'Date review was submitted.']
@@ -370,27 +515,39 @@ Table "production"."productreview" {
   "comments" "character varying(3850)" [note: '''Reviewer's comments
 WARNING: can have several lines!''']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productreviewid [pk, name: "PK_ProductReview_ProductReviewID"]
+}
   Note: 'Customer reviews of products they have purchased.'
 }
 
 Table "production"."productsubcategory" {
-  "productsubcategoryid" integer [not null, note: 'Primary key for ProductSubcategory records.']
+  "productsubcategoryid" integer [pk, not null, note: 'Primary key for ProductSubcategory records.']
   "productcategoryid" integer [not null, note: 'Product category identification number. Foreign key to ProductCategory.ProductCategoryID.']
   "name" public.Name [not null, note: 'Subcategory description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  productsubcategoryid [pk, name: "PK_ProductSubcategory_ProductSubcategoryID"]
+}
   Note: 'Product subcategories. See ProductCategory table.'
 }
 
 Table "production"."scrapreason" {
-  "scrapreasonid" integer [not null, note: 'Primary key for ScrapReason records.']
+  "scrapreasonid" integer [pk, not null, note: 'Primary key for ScrapReason records.']
   "name" public.Name [not null, note: 'Failure description.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  scrapreasonid [pk, name: "PK_ScrapReason_ScrapReasonID"]
+}
   Note: 'Manufacturing failure reasons lookup table.'
 }
 
 Table "production"."transactionhistory" {
-  "transactionid" integer [not null, note: 'Primary key for TransactionHistory records.']
+  "transactionid" integer [pk, not null, note: 'Primary key for TransactionHistory records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "referenceorderid" integer [not null, note: 'Purchase order, sales order, or work order identification number.']
   "referenceorderlineid" integer [not null, default: 0, note: 'Line number associated with the purchase order, sales order, or work order.']
@@ -399,11 +556,15 @@ Table "production"."transactionhistory" {
   "quantity" integer [not null, note: 'Product quantity.']
   "actualcost" numeric [not null, note: 'Product cost.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  transactionid [pk, name: "PK_TransactionHistory_TransactionID"]
+}
   Note: 'Record of each purchase order, sales order, or work order transaction year to date.'
 }
 
 Table "production"."transactionhistoryarchive" {
-  "transactionid" integer [not null, note: 'Primary key for TransactionHistoryArchive records.']
+  "transactionid" integer [pk, not null, note: 'Primary key for TransactionHistoryArchive records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "referenceorderid" integer [not null, note: 'Purchase order, sales order, or work order identification number.']
   "referenceorderlineid" integer [not null, default: 0, note: 'Line number associated with the purchase order, sales order, or work order.']
@@ -412,18 +573,26 @@ Table "production"."transactionhistoryarchive" {
   "quantity" integer [not null, note: 'Product quantity.']
   "actualcost" numeric [not null, note: 'Product cost.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  transactionid [pk, name: "PK_TransactionHistoryArchive_TransactionID"]
+}
   Note: 'Transactions for previous years.'
 }
 
 Table "production"."unitmeasure" {
-  "unitmeasurecode" "character (3)" [not null, note: 'Primary key.']
+  "unitmeasurecode" "character (3)" [pk, not null, note: 'Primary key.']
   "name" public.Name [not null, note: 'Unit of measure description.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  unitmeasurecode [pk, name: "PK_UnitMeasure_UnitMeasureCode"]
+}
   Note: 'Unit of measure lookup table.'
 }
 
 Table "production"."workorder" {
-  "workorderid" integer [not null, note: 'Primary key for WorkOrder records.']
+  "workorderid" integer [pk, not null, note: 'Primary key for WorkOrder records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "orderqty" integer [not null, note: 'Product quantity to build.']
   "scrappedqty" smallint [not null, note: 'Quantity that failed inspection.']
@@ -432,6 +601,10 @@ Table "production"."workorder" {
   "duedate" timestamp [not null, note: 'Work order due date.']
   "scrapreasonid" smallint [note: 'Reason for inspection failure.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  workorderid [pk, name: "PK_WorkOrder_WorkOrderID"]
+}
   Note: 'Manufacturing work orders.'
 }
 
@@ -448,6 +621,10 @@ Table "production"."workorderrouting" {
   "plannedcost" numeric [not null, note: 'Estimated manufacturing cost.']
   "actualcost" numeric [note: 'Actual manufacturing cost.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (workorderid, productid, operationsequence) [pk, name: "PK_WorkOrderRouting_WorkOrderID_ProductID_OperationSequence"]
+}
   Note: 'Work order details.'
 }
 
@@ -461,11 +638,15 @@ Table "purchasing"."purchaseorderdetail" {
   "receivedqty" numeric(8,2) [not null, note: 'Quantity actually received from the vendor.']
   "rejectedqty" numeric(8,2) [not null, note: 'Quantity rejected during inspection.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (purchaseorderid, purchaseorderdetailid) [pk, name: "PK_PurchaseOrderDetail_PurchaseOrderID_PurchaseOrderDetailID"]
+}
   Note: 'Individual products associated with a specific purchase order. See PurchaseOrderHeader.'
 }
 
 Table "purchasing"."purchaseorderheader" {
-  "purchaseorderid" integer [not null, note: 'Primary key.']
+  "purchaseorderid" integer [pk, not null, note: 'Primary key.']
   "revisionnumber" smallint [not null, default: 0, note: 'Incremental number to track changes to the purchase order over time.']
   "status" smallint [not null, default: 1, note: 'Order current status. 1 = Pending; 2 = Approved; 3 = Rejected; 4 = Complete']
   "employeeid" integer [not null, note: 'Employee who created the purchase order. Foreign key to Employee.BusinessEntityID.']
@@ -477,6 +658,10 @@ Table "purchasing"."purchaseorderheader" {
   "taxamt" numeric [not null, default: 0.00, note: 'Tax amount.']
   "freight" numeric [not null, default: 0.00, note: 'Shipping cost.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  purchaseorderid [pk, name: "PK_PurchaseOrderHeader_PurchaseOrderID"]
+}
   Note: '''General purchase order information. See PurchaseOrderDetail
 for more details.'''
 }
@@ -493,21 +678,29 @@ Table "purchasing"."productvendor" {
   "onorderqty" integer [note: 'The quantity currently on order.']
   "unitmeasurecode" "character (3)" [not null, note: '''The product's unit of measure.''']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (productid, businessentityid) [pk, name: "PK_ProductVendor_ProductID_BusinessEntityID"]
+}
   Note: 'Cross-reference table mapping vendors with the products they supply.'
 }
 
 Table "purchasing"."shipmethod" {
-  "shipmethodid" integer [not null, note: 'Primary key for ShipMethod records.']
+  "shipmethodid" integer [pk, not null, note: 'Primary key for ShipMethod records.']
   "name" public.Name [not null, note: 'Shipping company name.']
   "shipbase" numeric [not null, default: 0.00, note: 'Minimum shipping charge.']
   "shiprate" numeric [not null, default: 0.00, note: 'Shipping charge per pound.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  shipmethodid [pk, name: "PK_ShipMethod_ShipMethodID"]
+}
   Note: 'Shipping company lookup table.'
 }
 
 Table "purchasing"."vendor" {
-  "businessentityid" integer [not null, note: 'Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID']
+  "businessentityid" integer [pk, not null, note: 'Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID']
   "accountnumber" public.AccountNumber [not null, note: 'Vendor account (identification) number.']
   "name" public.Name [not null, note: 'Company name.']
   "creditrating" smallint [not null, note: '1 = Superior, 2 = Excellent, 3 = Above average, 4 = Average, 5 = Below average']
@@ -515,37 +708,53 @@ Table "purchasing"."vendor" {
   "activeflag" public.Flag [not null, default: true, note: '0 = Vendor no longer used. 1 = Vendor is actively used.']
   "purchasingwebserviceurl" "character varying(1024)" [note: 'Vendor URL.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_Vendor_BusinessEntityID"]
+}
   Note: 'Companies from whom Adventure Works Cycles purchases parts or other goods.'
 }
 
 Table "sales"."customer" {
-  "customerid" integer [not null, note: 'Primary key.']
+  "customerid" integer [pk, not null, note: 'Primary key.']
   "personid" integer [note: 'Foreign key to Person.BusinessEntityID']
   "storeid" integer [note: 'Foreign key to Store.BusinessEntityID']
   "territoryid" integer [note: 'ID of the territory in which the customer is located. Foreign key to SalesTerritory.SalesTerritoryID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  customerid [pk, name: "PK_Customer_CustomerID"]
+}
   Note: 'Current customer information. Also see the Person and Store tables.'
 }
 
 Table "sales"."creditcard" {
-  "creditcardid" integer [not null, note: 'Primary key for CreditCard records.']
+  "creditcardid" integer [pk, not null, note: 'Primary key for CreditCard records.']
   "cardtype" "character varying(50)" [not null, note: 'Credit card name.']
   "cardnumber" "character varying(25)" [not null, note: 'Credit card number.']
   "expmonth" smallint [not null, note: 'Credit card expiration month.']
   "expyear" smallint [not null, note: 'Credit card expiration year.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  creditcardid [pk, name: "PK_CreditCard_CreditCardID"]
+}
   Note: 'Customer credit card information.'
 }
 
 Table "sales"."currencyrate" {
-  "currencyrateid" integer [not null, note: 'Primary key for CurrencyRate records.']
+  "currencyrateid" integer [pk, not null, note: 'Primary key for CurrencyRate records.']
   "currencyratedate" timestamp [not null, note: 'Date and time the exchange rate was obtained.']
   "fromcurrencycode" "character (3)" [not null, note: 'Exchange rate was converted from this currency code.']
   "tocurrencycode" "character (3)" [not null, note: 'Exchange rate was converted to this currency code.']
   "averagerate" numeric [not null, note: 'Average exchange rate for the day.']
   "endofdayrate" numeric [not null, note: 'Final exchange rate for the day.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  currencyrateid [pk, name: "PK_CurrencyRate_CurrencyRateID"]
+}
   Note: 'Currency exchange rates.'
 }
 
@@ -553,13 +762,21 @@ Table "sales"."countryregioncurrency" {
   "countryregioncode" "character varying(3)" [not null, note: 'ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.']
   "currencycode" "character (3)" [not null, note: 'ISO standard currency code. Foreign key to Currency.CurrencyCode.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (countryregioncode, currencycode) [pk, name: "PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode"]
+}
   Note: 'Cross-reference table mapping ISO currency codes to a country or region.'
 }
 
 Table "sales"."currency" {
-  "currencycode" "character (3)" [not null, note: 'The ISO code for the Currency.']
+  "currencycode" "character (3)" [pk, not null, note: 'The ISO code for the Currency.']
   "name" public.Name [not null, note: 'Currency name.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  currencycode [pk, name: "PK_Currency_CurrencyCode"]
+}
   Note: 'Lookup table containing standard ISO currencies.'
 }
 
@@ -567,31 +784,43 @@ Table "sales"."personcreditcard" {
   "businessentityid" integer [not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
   "creditcardid" integer [not null, note: 'Credit card identification number. Foreign key to CreditCard.CreditCardID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, creditcardid) [pk, name: "PK_PersonCreditCard_BusinessEntityID_CreditCardID"]
+}
   Note: 'Cross-reference table mapping people to their credit card information in the CreditCard table.'
 }
 
 Table "sales"."store" {
-  "businessentityid" integer [not null, note: 'Primary key. Foreign key to Customer.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Primary key. Foreign key to Customer.BusinessEntityID.']
   "name" public.Name [not null, note: 'Name of the store.']
   "salespersonid" integer [note: 'ID of the sales person assigned to the customer. Foreign key to SalesPerson.BusinessEntityID.']
   "demographics" xml [note: 'Demographic informationg about the store such as the number of employees, annual sales and store type.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_Store_BusinessEntityID"]
+}
   Note: 'Customers (resellers) of Adventure Works products.'
 }
 
 Table "sales"."shoppingcartitem" {
-  "shoppingcartitemid" integer [not null, note: 'Primary key for ShoppingCartItem records.']
+  "shoppingcartitemid" integer [pk, not null, note: 'Primary key for ShoppingCartItem records.']
   "shoppingcartid" "character varying(50)" [not null, note: 'Shopping cart identification number.']
   "quantity" integer [not null, default: 1, note: 'Product quantity ordered.']
   "productid" integer [not null, note: 'Product ordered. Foreign key to Product.ProductID.']
   "datecreated" timestamp [not null, default: `now()`, note: 'Date the time the record was created.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  shoppingcartitemid [pk, name: "PK_ShoppingCartItem_ShoppingCartItemID"]
+}
   Note: 'Contains online customer orders until the order is submitted or cancelled.'
 }
 
 Table "sales"."specialoffer" {
-  "specialofferid" integer [not null, note: 'Primary key for SpecialOffer records.']
+  "specialofferid" integer [pk, not null, note: 'Primary key for SpecialOffer records.']
   "description" "character varying(255)" [not null, note: 'Discount description.']
   "discountpct" numeric [not null, default: 0.00, note: 'Discount precentage.']
   "type" "character varying(50)" [not null, note: 'Discount type category.']
@@ -602,6 +831,10 @@ Table "sales"."specialoffer" {
   "maxqty" integer [note: 'Maximum discount percent allowed.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  specialofferid [pk, name: "PK_SpecialOffer_SpecialOfferID"]
+}
   Note: 'Sale discounts lookup table.'
 }
 
@@ -616,11 +849,15 @@ Table "sales"."salesorderdetail" {
   "unitpricediscount" numeric [not null, default: 0.0, note: 'Discount amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (salesorderid, salesorderdetailid) [pk, name: "PK_SalesOrderDetail_SalesOrderID_SalesOrderDetailID"]
+}
   Note: 'Individual products associated with a specific sales order. See SalesOrderHeader.'
 }
 
 Table "sales"."salesorderheader" {
-  "salesorderid" integer [not null, note: 'Primary key.']
+  "salesorderid" integer [pk, not null, note: 'Primary key.']
   "revisionnumber" smallint [not null, default: 0, note: 'Incremental number to track changes to the sales order over time.']
   "orderdate" timestamp [not null, default: `now()`, note: 'Dates the sales order was created.']
   "duedate" timestamp [not null, note: 'Date the order is due to the customer.']
@@ -645,6 +882,10 @@ Table "sales"."salesorderheader" {
   "comment" "character varying(128)" [note: 'Sales representative comments.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  salesorderid [pk, name: "PK_SalesOrderHeader_SalesOrderID"]
+}
   Note: 'General sales order information.'
 }
 
@@ -652,6 +893,10 @@ Table "sales"."salesorderheadersalesreason" {
   "salesorderid" integer [not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
   "salesreasonid" integer [not null, note: 'Primary key. Foreign key to SalesReason.SalesReasonID.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (salesorderid, salesreasonid) [pk, name: "PK_SalesOrderHeaderSalesReason_SalesOrderID_SalesReasonID"]
+}
   Note: 'Cross-reference table mapping sales orders to sales reason codes.'
 }
 
@@ -660,11 +905,15 @@ Table "sales"."specialofferproduct" {
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (specialofferid, productid) [pk, name: "PK_SpecialOfferProduct_SpecialOfferID_ProductID"]
+}
   Note: 'Cross-reference table mapping products to special offer discounts.'
 }
 
 Table "sales"."salesperson" {
-  "businessentityid" integer [not null, note: 'Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID']
+  "businessentityid" integer [pk, not null, note: 'Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID']
   "territoryid" integer [note: 'Territory currently assigned to. Foreign key to SalesTerritory.SalesTerritoryID.']
   "salesquota" numeric [note: 'Projected yearly sales.']
   "bonus" numeric [not null, default: 0.00, note: 'Bonus due if quota is met.']
@@ -673,6 +922,10 @@ Table "sales"."salesperson" {
   "saleslastyear" numeric [not null, default: 0.00, note: 'Sales total of previous year.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  businessentityid [pk, name: "PK_SalesPerson_BusinessEntityID"]
+}
   Note: 'Sales representative current information.'
 }
 
@@ -682,19 +935,27 @@ Table "sales"."salespersonquotahistory" {
   "salesquota" numeric [not null, note: 'Sales quota amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, quotadate) [pk, name: "PK_SalesPersonQuotaHistory_BusinessEntityID_QuotaDate"]
+}
   Note: 'Sales performance tracking.'
 }
 
 Table "sales"."salesreason" {
-  "salesreasonid" integer [not null, note: 'Primary key for SalesReason records.']
+  "salesreasonid" integer [pk, not null, note: 'Primary key for SalesReason records.']
   "name" public.Name [not null, note: 'Sales reason description.']
   "reasontype" public.Name [not null, note: 'Category the sales reason belongs to.']
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  salesreasonid [pk, name: "PK_SalesReason_SalesReasonID"]
+}
   Note: 'Lookup table of customer purchase reasons.'
 }
 
 Table "sales"."salesterritory" {
-  "territoryid" integer [not null, note: 'Primary key for SalesTerritory records.']
+  "territoryid" integer [pk, not null, note: 'Primary key for SalesTerritory records.']
   "name" public.Name [not null, note: 'Sales territory description']
   "countryregioncode" "character varying(3)" [not null, note: 'ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode.']
   "group" "character varying(50)" [not null, note: 'Geographic area to which the sales territory belong.']
@@ -704,6 +965,10 @@ Table "sales"."salesterritory" {
   "costlastyear" numeric [not null, default: 0.00, note: 'Business costs in the territory the previous year.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  territoryid [pk, name: "PK_SalesTerritory_TerritoryID"]
+}
   Note: 'Sales territory lookup table.'
 }
 
@@ -714,17 +979,25 @@ Table "sales"."salesterritoryhistory" {
   "enddate" timestamp [note: 'Date the sales representative left work in the territory.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  (businessentityid, startdate, territoryid) [pk, name: "PK_SalesTerritoryHistory_BusinessEntityID_StartDate_TerritoryID"]
+}
   Note: 'Sales representative transfers to other sales territories.'
 }
 
 Table "sales"."salestaxrate" {
-  "salestaxrateid" integer [not null, note: 'Primary key for SalesTaxRate records.']
+  "salestaxrateid" integer [pk, not null, note: 'Primary key for SalesTaxRate records.']
   "stateprovinceid" integer [not null, note: 'State, province, or country/region the sales tax applies to.']
   "taxtype" smallint [not null, note: '1 = Tax applied to retail transactions, 2 = Tax applied to wholesale transactions, 3 = Tax applied to all sales (retail and wholesale) transactions.']
   "taxrate" numeric [not null, default: 0.00, note: 'Tax rate amount.']
   "name" public.Name [not null, note: 'Tax rate description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
+
+Indexes {
+  salestaxrateid [pk, name: "PK_SalesTaxRate_SalesTaxRateID"]
+}
   Note: 'Tax rate lookup table.'
 }
 

--- a/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
+++ b/packages/dbml-core/__tests__/importer/postgres_importer/output/db_dump.out.dbml
@@ -3,10 +3,6 @@ Table "humanresources"."department" {
   "name" public.Name [not null, note: 'Name of the department.']
   "groupname" public.Name [not null, note: 'Name of the group to which the department belongs.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  departmentid [pk, name: "PK_Department_DepartmentID"]
-}
   Note: 'Lookup table containing the departments within the Adventure Works Cycles company.'
 }
 
@@ -26,37 +22,25 @@ Table "humanresources"."employee" {
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
   "organizationnode" "character varying" [default: `'/'::charactervarying`, note: 'Where the employee is located in corporate hierarchy.']
-
-Indexes {
-  businessentityid [pk, name: "PK_Employee_BusinessEntityID"]
-}
   Note: 'Employee information such as salary, department, and title.'
 }
 
 Table "humanresources"."employeedepartmenthistory" {
-  "businessentityid" integer [not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
   "departmentid" smallint [not null, note: 'Department in which the employee worked including currently. Foreign key to Department.DepartmentID.']
   "shiftid" smallint [not null, note: 'Identifies which 8-hour shift the employee works. Foreign key to Shift.Shift.ID.']
   "startdate" date [not null, note: 'Date the employee started work in the department.']
   "enddate" date [note: 'Date the employee left the department. NULL = Current department.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, startdate, departmentid, shiftid) [pk, name: "PK_EmployeeDepartmentHistory_BusinessEntityID_StartDate_Departm"]
-}
   Note: 'Employee department transfers.'
 }
 
 Table "humanresources"."employeepayhistory" {
-  "businessentityid" integer [not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Employee identification number. Foreign key to Employee.BusinessEntityID.']
   "ratechangedate" timestamp [not null, note: 'Date the change in pay is effective']
   "rate" numeric [not null, note: 'Salary hourly rate.']
   "payfrequency" smallint [not null, note: '1 = Salary received monthly, 2 = Salary received biweekly']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, ratechangedate) [pk, name: "PK_EmployeePayHistory_BusinessEntityID_RateChangeDate"]
-}
   Note: 'Employee pay history.'
 }
 
@@ -65,10 +49,6 @@ Table "humanresources"."jobcandidate" {
   "businessentityid" integer [note: 'Employee identification number if applicant was hired. Foreign key to Employee.BusinessEntityID.']
   "resume" xml [note: 'RÃ©sumÃ© in XML format.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  jobcandidateid [pk, name: "PK_JobCandidate_JobCandidateID"]
-}
   Note: 'RÃ©sumÃ©s submitted to Human Resources by job applicants.'
 }
 
@@ -78,10 +58,6 @@ Table "humanresources"."shift" {
   "starttime" time [not null, note: 'Shift start time.']
   "endtime" time [not null, note: 'Shift end time.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  shiftid [pk, name: "PK_Shift_ShiftID"]
-}
   Note: 'Work shift lookup table.'
 }
 
@@ -95,23 +71,15 @@ Table "person"."address" {
   "spatiallocation" "character varying(44)" [note: 'Latitude and longitude of this address.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  addressid [pk, name: "PK_Address_AddressID"]
-}
   Note: 'Street address information for customers, employees, and vendors.'
 }
 
 Table "person"."businessentityaddress" {
-  "businessentityid" integer [not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
   "addressid" integer [not null, note: 'Primary key. Foreign key to Address.AddressID.']
   "addresstypeid" integer [not null, note: 'Primary key. Foreign key to AddressType.AddressTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, addressid, addresstypeid) [pk, name: "PK_BusinessEntityAddress_BusinessEntityID_AddressID_AddressType"]
-}
   Note: 'Cross-reference table mapping customers, vendors, and employees to their addresses.'
 }
 
@@ -119,23 +87,15 @@ Table "person"."countryregion" {
   "countryregioncode" "character varying(3)" [pk, not null, note: 'ISO standard code for countries and regions.']
   "name" public.Name [not null, note: 'Country or region name.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  countryregioncode [pk, name: "PK_CountryRegion_CountryRegionCode"]
-}
   Note: 'Lookup table containing the ISO standard codes for countries and regions.'
 }
 
 Table "person"."emailaddress" {
-  "businessentityid" integer [not null, note: 'Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID']
+  "businessentityid" integer [pk, not null, note: 'Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID']
   "emailaddressid" integer [not null, note: 'Primary key. ID of this email address.']
   "emailaddress" "character varying(50)" [note: 'E-mail address for the person.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, emailaddressid) [pk, name: "PK_EmailAddress_BusinessEntityID_EmailAddressID"]
-}
   Note: 'Where to send a person email.'
 }
 
@@ -153,22 +113,14 @@ Table "person"."person" {
   "demographics" xml [note: 'Personal information such as hobbies, and income collected from online shoppers. Used for sales analysis.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_Person_BusinessEntityID"]
-}
   Note: 'Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.'
 }
 
 Table "person"."personphone" {
-  "businessentityid" integer [not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
   "phonenumber" public.Phone [not null, note: 'Telephone number identification number.']
   "phonenumbertypeid" integer [not null, note: 'Kind of phone number. Foreign key to PhoneNumberType.PhoneNumberTypeID.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, phonenumber, phonenumbertypeid) [pk, name: "PK_PersonPhone_BusinessEntityID_PhoneNumber_PhoneNumberTypeID"]
-}
   Note: 'Telephone number and type of a person.'
 }
 
@@ -176,10 +128,6 @@ Table "person"."phonenumbertype" {
   "phonenumbertypeid" integer [pk, not null, note: 'Primary key for telephone number type records.']
   "name" public.Name [not null, note: 'Name of the telephone number type']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  phonenumbertypeid [pk, name: "PK_PhoneNumberType_PhoneNumberTypeID"]
-}
   Note: 'Type of phone number of a person.'
 }
 
@@ -192,10 +140,6 @@ Table "person"."stateprovince" {
   "territoryid" integer [not null, note: 'ID of the territory in which the state or province is located. Foreign key to SalesTerritory.SalesTerritoryID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  stateprovinceid [pk, name: "PK_StateProvince_StateProvinceID"]
-}
   Note: 'State and province lookup table.'
 }
 
@@ -204,10 +148,6 @@ Table "person"."addresstype" {
   "name" public.Name [not null, note: 'Address type description. For example, Billing, Home, or Shipping.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  addresstypeid [pk, name: "PK_AddressType_AddressTypeID"]
-}
   Note: 'Types of addresses stored in the Address table.'
 }
 
@@ -215,23 +155,15 @@ Table "person"."businessentity" {
   "businessentityid" integer [pk, not null, note: 'Primary key for all customers, vendors, and employees.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_BusinessEntity_BusinessEntityID"]
-}
   Note: 'Source of the ID that connects vendors, customers, and employees with address and contact information.'
 }
 
 Table "person"."businessentitycontact" {
-  "businessentityid" integer [not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Primary key. Foreign key to BusinessEntity.BusinessEntityID.']
   "personid" integer [not null, note: 'Primary key. Foreign key to Person.BusinessEntityID.']
   "contacttypeid" integer [not null, note: 'Primary key.  Foreign key to ContactType.ContactTypeID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, personid, contacttypeid) [pk, name: "PK_BusinessEntityContact_BusinessEntityID_PersonID_ContactTypeI"]
-}
   Note: 'Cross-reference table mapping stores, vendors, and employees to people'
 }
 
@@ -239,10 +171,6 @@ Table "person"."contacttype" {
   "contacttypeid" integer [pk, not null, note: 'Primary key for ContactType records.']
   "name" public.Name [not null, note: 'Contact type description.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  contacttypeid [pk, name: "PK_ContactType_ContactTypeID"]
-}
   Note: 'Lookup table containing the types of business entity contacts.'
 }
 
@@ -252,10 +180,6 @@ Table "person"."password" {
   "passwordsalt" "character varying(10)" [not null, note: 'Random value concatenated with the password string before the password is hashed.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_Password_BusinessEntityID"]
-}
   Note: 'One way hashed authentication information'
 }
 
@@ -269,10 +193,6 @@ Table "production"."billofmaterials" {
   "bomlevel" smallint [not null, note: 'Indicates the depth the component is from its parent (AssemblyID).']
   "perassemblyqty" numeric(8,2) [not null, default: 1.00, note: 'Quantity of the component needed to create the assembly.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  billofmaterialsid [pk, name: "PK_BillOfMaterials_BillOfMaterialsID"]
-}
   Note: 'Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.'
 }
 
@@ -280,10 +200,6 @@ Table "production"."culture" {
   "cultureid" "character (6)" [pk, not null, note: 'Primary key for Culture records.']
   "name" public.Name [not null, note: 'Culture description.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  cultureid [pk, name: "PK_Culture_CultureID"]
-}
   Note: 'Lookup table containing the languages in which some AdventureWorks data is stored.'
 }
 
@@ -301,11 +217,6 @@ Table "production"."document" {
   "rowguid" uuid [unique, not null, default: `public.uuid_generate_v1()`, note: 'ROWGUIDCOL number uniquely identifying the record. Required for FileStream.']
   "modifieddate" timestamp [not null, default: `now()`]
   "documentnode" "character varying" [pk, not null, default: `'/'::charactervarying`, note: 'Primary key for Document records.']
-
-Indexes {
-  documentnode [pk, name: "PK_Document_DocumentNode"]
-  rowguid [unique, name: "document_rowguid_key"]
-}
   Note: 'Product maintenance documents.'
 }
 
@@ -313,10 +224,6 @@ Table "production"."illustration" {
   "illustrationid" integer [pk, not null, note: 'Primary key for Illustration records.']
   "diagram" xml [note: 'Illustrations used in manufacturing instructions. Stored as XML.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  illustrationid [pk, name: "PK_Illustration_IllustrationID"]
-}
   Note: 'Bicycle assembly diagrams.'
 }
 
@@ -326,10 +233,6 @@ Table "production"."location" {
   "costrate" numeric [not null, default: 0.00, note: 'Standard hourly cost of the manufacturing location.']
   "availability" numeric(8,2) [not null, default: 0.00, note: 'Work capacity (in hours) of the manufacturing location.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  locationid [pk, name: "PK_Location_LocationID"]
-}
   Note: 'Product inventory and manufacturing locations.'
 }
 
@@ -359,10 +262,6 @@ Table "production"."product" {
   "discontinueddate" timestamp [note: 'Date the product was discontinued.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productid [pk, name: "PK_Product_ProductID"]
-}
   Note: 'Products sold or used in the manfacturing of sold products.'
 }
 
@@ -371,23 +270,15 @@ Table "production"."productcategory" {
   "name" public.Name [not null, note: 'Category description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productcategoryid [pk, name: "PK_ProductCategory_ProductCategoryID"]
-}
   Note: 'High-level product categorization.'
 }
 
 Table "production"."productcosthistory" {
-  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID']
+  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID']
   "startdate" timestamp [not null, note: 'Product cost start date.']
   "enddate" timestamp [note: 'Product cost end date.']
   "standardcost" numeric [not null, note: 'Standard cost of the product.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productid, startdate) [pk, name: "PK_ProductCostHistory_ProductID_StartDate"]
-}
   Note: 'Changes in the cost of a product over time.'
 }
 
@@ -396,49 +287,33 @@ Table "production"."productdescription" {
   "description" "character varying(400)" [not null, note: 'Description of the product.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productdescriptionid [pk, name: "PK_ProductDescription_ProductDescriptionID"]
-}
   Note: 'Product descriptions in several languages.'
 }
 
 Table "production"."productdocument" {
-  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "modifieddate" timestamp [not null, default: `now()`]
   "documentnode" "character varying" [not null, default: `'/'::charactervarying`, note: 'Document identification number. Foreign key to Document.DocumentNode.']
-
-Indexes {
-  (productid, documentnode) [pk, name: "PK_ProductDocument_ProductID_DocumentNode"]
-}
   Note: 'Cross-reference table mapping products to related product documents.'
 }
 
 Table "production"."productinventory" {
-  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "locationid" smallint [not null, note: 'Inventory location identification number. Foreign key to Location.LocationID.']
   "shelf" "character varying(10)" [not null, note: 'Storage compartment within an inventory location.']
   "bin" smallint [not null, note: 'Storage container on a shelf in an inventory location.']
   "quantity" smallint [not null, default: 0, note: 'Quantity of products in the inventory location.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productid, locationid) [pk, name: "PK_ProductInventory_ProductID_LocationID"]
-}
   Note: 'Product inventory information.'
 }
 
 Table "production"."productlistpricehistory" {
-  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID']
+  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID']
   "startdate" timestamp [not null, note: 'List price start date.']
   "enddate" timestamp [note: 'List price end date']
   "listprice" numeric [not null, note: 'Product list price.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productid, startdate) [pk, name: "PK_ProductListPriceHistory_ProductID_StartDate"]
-}
   Note: 'Changes in the list price of a product over time.'
 }
 
@@ -449,33 +324,21 @@ Table "production"."productmodel" {
   "instructions" xml [note: 'Manufacturing instructions in xml format.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productmodelid [pk, name: "PK_ProductModel_ProductModelID"]
-}
   Note: 'Product model classification.'
 }
 
 Table "production"."productmodelillustration" {
-  "productmodelid" integer [not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
+  "productmodelid" integer [pk, not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
   "illustrationid" integer [not null, note: 'Primary key. Foreign key to Illustration.IllustrationID.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productmodelid, illustrationid) [pk, name: "PK_ProductModelIllustration_ProductModelID_IllustrationID"]
-}
   Note: 'Cross-reference table mapping product models and illustrations.'
 }
 
 Table "production"."productmodelproductdescriptionculture" {
-  "productmodelid" integer [not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
+  "productmodelid" integer [pk, not null, note: 'Primary key. Foreign key to ProductModel.ProductModelID.']
   "productdescriptionid" integer [not null, note: 'Primary key. Foreign key to ProductDescription.ProductDescriptionID.']
   "cultureid" "character (6)" [not null, note: 'Culture identification number. Foreign key to Culture.CultureID.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productmodelid, productdescriptionid, cultureid) [pk, name: "PK_ProductModelProductDescriptionCulture_ProductModelID_Product"]
-}
   Note: 'Cross-reference table mapping product descriptions and the language the description is written in.'
 }
 
@@ -486,22 +349,14 @@ Table "production"."productphoto" {
   "largephoto" bytea [note: 'Large image of the product.']
   "largephotofilename" "character varying(50)" [note: 'Large image file name.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productphotoid [pk, name: "PK_ProductPhoto_ProductPhotoID"]
-}
   Note: 'Product images.'
 }
 
 Table "production"."productproductphoto" {
-  "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
+  "productid" integer [pk, not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "productphotoid" integer [not null, note: 'Product photo identification number. Foreign key to ProductPhoto.ProductPhotoID.']
   "primary" public.Flag [not null, default: false, note: '0 = Photo is not the principal image. 1 = Photo is the principal image.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productid, productphotoid) [pk, name: "PK_ProductProductPhoto_ProductID_ProductPhotoID"]
-}
   Note: 'Cross-reference table mapping products and product photos.'
 }
 
@@ -515,10 +370,6 @@ Table "production"."productreview" {
   "comments" "character varying(3850)" [note: '''Reviewer's comments
 WARNING: can have several lines!''']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productreviewid [pk, name: "PK_ProductReview_ProductReviewID"]
-}
   Note: 'Customer reviews of products they have purchased.'
 }
 
@@ -528,10 +379,6 @@ Table "production"."productsubcategory" {
   "name" public.Name [not null, note: 'Subcategory description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  productsubcategoryid [pk, name: "PK_ProductSubcategory_ProductSubcategoryID"]
-}
   Note: 'Product subcategories. See ProductCategory table.'
 }
 
@@ -539,10 +386,6 @@ Table "production"."scrapreason" {
   "scrapreasonid" integer [pk, not null, note: 'Primary key for ScrapReason records.']
   "name" public.Name [not null, note: 'Failure description.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  scrapreasonid [pk, name: "PK_ScrapReason_ScrapReasonID"]
-}
   Note: 'Manufacturing failure reasons lookup table.'
 }
 
@@ -556,10 +399,6 @@ Table "production"."transactionhistory" {
   "quantity" integer [not null, note: 'Product quantity.']
   "actualcost" numeric [not null, note: 'Product cost.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  transactionid [pk, name: "PK_TransactionHistory_TransactionID"]
-}
   Note: 'Record of each purchase order, sales order, or work order transaction year to date.'
 }
 
@@ -573,10 +412,6 @@ Table "production"."transactionhistoryarchive" {
   "quantity" integer [not null, note: 'Product quantity.']
   "actualcost" numeric [not null, note: 'Product cost.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  transactionid [pk, name: "PK_TransactionHistoryArchive_TransactionID"]
-}
   Note: 'Transactions for previous years.'
 }
 
@@ -584,10 +419,6 @@ Table "production"."unitmeasure" {
   "unitmeasurecode" "character (3)" [pk, not null, note: 'Primary key.']
   "name" public.Name [not null, note: 'Unit of measure description.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  unitmeasurecode [pk, name: "PK_UnitMeasure_UnitMeasureCode"]
-}
   Note: 'Unit of measure lookup table.'
 }
 
@@ -601,15 +432,11 @@ Table "production"."workorder" {
   "duedate" timestamp [not null, note: 'Work order due date.']
   "scrapreasonid" smallint [note: 'Reason for inspection failure.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  workorderid [pk, name: "PK_WorkOrder_WorkOrderID"]
-}
   Note: 'Manufacturing work orders.'
 }
 
 Table "production"."workorderrouting" {
-  "workorderid" integer [not null, note: 'Primary key. Foreign key to WorkOrder.WorkOrderID.']
+  "workorderid" integer [pk, not null, note: 'Primary key. Foreign key to WorkOrder.WorkOrderID.']
   "productid" integer [not null, note: 'Primary key. Foreign key to Product.ProductID.']
   "operationsequence" smallint [not null, note: 'Primary key. Indicates the manufacturing process sequence.']
   "locationid" smallint [not null, note: 'Manufacturing location where the part is processed. Foreign key to Location.LocationID.']
@@ -621,15 +448,11 @@ Table "production"."workorderrouting" {
   "plannedcost" numeric [not null, note: 'Estimated manufacturing cost.']
   "actualcost" numeric [note: 'Actual manufacturing cost.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (workorderid, productid, operationsequence) [pk, name: "PK_WorkOrderRouting_WorkOrderID_ProductID_OperationSequence"]
-}
   Note: 'Work order details.'
 }
 
 Table "purchasing"."purchaseorderdetail" {
-  "purchaseorderid" integer [not null, note: 'Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.']
+  "purchaseorderid" integer [pk, not null, note: 'Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.']
   "purchaseorderdetailid" integer [not null, note: 'Primary key. One line number per purchased product.']
   "duedate" timestamp [not null, note: 'Date the product is expected to be received.']
   "orderqty" smallint [not null, note: 'Quantity ordered.']
@@ -638,10 +461,6 @@ Table "purchasing"."purchaseorderdetail" {
   "receivedqty" numeric(8,2) [not null, note: 'Quantity actually received from the vendor.']
   "rejectedqty" numeric(8,2) [not null, note: 'Quantity rejected during inspection.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (purchaseorderid, purchaseorderdetailid) [pk, name: "PK_PurchaseOrderDetail_PurchaseOrderID_PurchaseOrderDetailID"]
-}
   Note: 'Individual products associated with a specific purchase order. See PurchaseOrderHeader.'
 }
 
@@ -658,16 +477,12 @@ Table "purchasing"."purchaseorderheader" {
   "taxamt" numeric [not null, default: 0.00, note: 'Tax amount.']
   "freight" numeric [not null, default: 0.00, note: 'Shipping cost.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  purchaseorderid [pk, name: "PK_PurchaseOrderHeader_PurchaseOrderID"]
-}
   Note: '''General purchase order information. See PurchaseOrderDetail
 for more details.'''
 }
 
 Table "purchasing"."productvendor" {
-  "productid" integer [not null, note: 'Primary key. Foreign key to Product.ProductID.']
+  "productid" integer [pk, not null, note: 'Primary key. Foreign key to Product.ProductID.']
   "businessentityid" integer [not null, note: 'Primary key. Foreign key to Vendor.BusinessEntityID.']
   "averageleadtime" integer [not null, note: 'The average span of time (in days) between placing an order with the vendor and receiving the purchased product.']
   "standardprice" numeric [not null, note: '''The vendor's usual selling price.''']
@@ -678,10 +493,6 @@ Table "purchasing"."productvendor" {
   "onorderqty" integer [note: 'The quantity currently on order.']
   "unitmeasurecode" "character (3)" [not null, note: '''The product's unit of measure.''']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (productid, businessentityid) [pk, name: "PK_ProductVendor_ProductID_BusinessEntityID"]
-}
   Note: 'Cross-reference table mapping vendors with the products they supply.'
 }
 
@@ -692,10 +503,6 @@ Table "purchasing"."shipmethod" {
   "shiprate" numeric [not null, default: 0.00, note: 'Shipping charge per pound.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  shipmethodid [pk, name: "PK_ShipMethod_ShipMethodID"]
-}
   Note: 'Shipping company lookup table.'
 }
 
@@ -708,10 +515,6 @@ Table "purchasing"."vendor" {
   "activeflag" public.Flag [not null, default: true, note: '0 = Vendor no longer used. 1 = Vendor is actively used.']
   "purchasingwebserviceurl" "character varying(1024)" [note: 'Vendor URL.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_Vendor_BusinessEntityID"]
-}
   Note: 'Companies from whom Adventure Works Cycles purchases parts or other goods.'
 }
 
@@ -722,10 +525,6 @@ Table "sales"."customer" {
   "territoryid" integer [note: 'ID of the territory in which the customer is located. Foreign key to SalesTerritory.SalesTerritoryID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  customerid [pk, name: "PK_Customer_CustomerID"]
-}
   Note: 'Current customer information. Also see the Person and Store tables.'
 }
 
@@ -736,10 +535,6 @@ Table "sales"."creditcard" {
   "expmonth" smallint [not null, note: 'Credit card expiration month.']
   "expyear" smallint [not null, note: 'Credit card expiration year.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  creditcardid [pk, name: "PK_CreditCard_CreditCardID"]
-}
   Note: 'Customer credit card information.'
 }
 
@@ -751,21 +546,13 @@ Table "sales"."currencyrate" {
   "averagerate" numeric [not null, note: 'Average exchange rate for the day.']
   "endofdayrate" numeric [not null, note: 'Final exchange rate for the day.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  currencyrateid [pk, name: "PK_CurrencyRate_CurrencyRateID"]
-}
   Note: 'Currency exchange rates.'
 }
 
 Table "sales"."countryregioncurrency" {
-  "countryregioncode" "character varying(3)" [not null, note: 'ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.']
+  "countryregioncode" "character varying(3)" [pk, not null, note: 'ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.']
   "currencycode" "character (3)" [not null, note: 'ISO standard currency code. Foreign key to Currency.CurrencyCode.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (countryregioncode, currencycode) [pk, name: "PK_CountryRegionCurrency_CountryRegionCode_CurrencyCode"]
-}
   Note: 'Cross-reference table mapping ISO currency codes to a country or region.'
 }
 
@@ -773,21 +560,13 @@ Table "sales"."currency" {
   "currencycode" "character (3)" [pk, not null, note: 'The ISO code for the Currency.']
   "name" public.Name [not null, note: 'Currency name.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  currencycode [pk, name: "PK_Currency_CurrencyCode"]
-}
   Note: 'Lookup table containing standard ISO currencies.'
 }
 
 Table "sales"."personcreditcard" {
-  "businessentityid" integer [not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Business entity identification number. Foreign key to Person.BusinessEntityID.']
   "creditcardid" integer [not null, note: 'Credit card identification number. Foreign key to CreditCard.CreditCardID.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, creditcardid) [pk, name: "PK_PersonCreditCard_BusinessEntityID_CreditCardID"]
-}
   Note: 'Cross-reference table mapping people to their credit card information in the CreditCard table.'
 }
 
@@ -798,10 +577,6 @@ Table "sales"."store" {
   "demographics" xml [note: 'Demographic informationg about the store such as the number of employees, annual sales and store type.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_Store_BusinessEntityID"]
-}
   Note: 'Customers (resellers) of Adventure Works products.'
 }
 
@@ -812,10 +587,6 @@ Table "sales"."shoppingcartitem" {
   "productid" integer [not null, note: 'Product ordered. Foreign key to Product.ProductID.']
   "datecreated" timestamp [not null, default: `now()`, note: 'Date the time the record was created.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  shoppingcartitemid [pk, name: "PK_ShoppingCartItem_ShoppingCartItemID"]
-}
   Note: 'Contains online customer orders until the order is submitted or cancelled.'
 }
 
@@ -831,15 +602,11 @@ Table "sales"."specialoffer" {
   "maxqty" integer [note: 'Maximum discount percent allowed.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  specialofferid [pk, name: "PK_SpecialOffer_SpecialOfferID"]
-}
   Note: 'Sale discounts lookup table.'
 }
 
 Table "sales"."salesorderdetail" {
-  "salesorderid" integer [not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
+  "salesorderid" integer [pk, not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
   "salesorderdetailid" integer [not null, note: 'Primary key. One incremental unique number per product sold.']
   "carriertrackingnumber" "character varying(25)" [note: 'Shipment tracking number supplied by the shipper.']
   "orderqty" smallint [not null, note: 'Quantity ordered per product.']
@@ -849,10 +616,6 @@ Table "sales"."salesorderdetail" {
   "unitpricediscount" numeric [not null, default: 0.0, note: 'Discount amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (salesorderid, salesorderdetailid) [pk, name: "PK_SalesOrderDetail_SalesOrderID_SalesOrderDetailID"]
-}
   Note: 'Individual products associated with a specific sales order. See SalesOrderHeader.'
 }
 
@@ -882,33 +645,21 @@ Table "sales"."salesorderheader" {
   "comment" "character varying(128)" [note: 'Sales representative comments.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  salesorderid [pk, name: "PK_SalesOrderHeader_SalesOrderID"]
-}
   Note: 'General sales order information.'
 }
 
 Table "sales"."salesorderheadersalesreason" {
-  "salesorderid" integer [not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
+  "salesorderid" integer [pk, not null, note: 'Primary key. Foreign key to SalesOrderHeader.SalesOrderID.']
   "salesreasonid" integer [not null, note: 'Primary key. Foreign key to SalesReason.SalesReasonID.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (salesorderid, salesreasonid) [pk, name: "PK_SalesOrderHeaderSalesReason_SalesOrderID_SalesReasonID"]
-}
   Note: 'Cross-reference table mapping sales orders to sales reason codes.'
 }
 
 Table "sales"."specialofferproduct" {
-  "specialofferid" integer [not null, note: 'Primary key for SpecialOfferProduct records.']
+  "specialofferid" integer [pk, not null, note: 'Primary key for SpecialOfferProduct records.']
   "productid" integer [not null, note: 'Product identification number. Foreign key to Product.ProductID.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (specialofferid, productid) [pk, name: "PK_SpecialOfferProduct_SpecialOfferID_ProductID"]
-}
   Note: 'Cross-reference table mapping products to special offer discounts.'
 }
 
@@ -922,23 +673,15 @@ Table "sales"."salesperson" {
   "saleslastyear" numeric [not null, default: 0.00, note: 'Sales total of previous year.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  businessentityid [pk, name: "PK_SalesPerson_BusinessEntityID"]
-}
   Note: 'Sales representative current information.'
 }
 
 Table "sales"."salespersonquotahistory" {
-  "businessentityid" integer [not null, note: 'Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.']
   "quotadate" timestamp [not null, note: 'Sales quota date.']
   "salesquota" numeric [not null, note: 'Sales quota amount.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, quotadate) [pk, name: "PK_SalesPersonQuotaHistory_BusinessEntityID_QuotaDate"]
-}
   Note: 'Sales performance tracking.'
 }
 
@@ -947,10 +690,6 @@ Table "sales"."salesreason" {
   "name" public.Name [not null, note: 'Sales reason description.']
   "reasontype" public.Name [not null, note: 'Category the sales reason belongs to.']
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  salesreasonid [pk, name: "PK_SalesReason_SalesReasonID"]
-}
   Note: 'Lookup table of customer purchase reasons.'
 }
 
@@ -965,24 +704,16 @@ Table "sales"."salesterritory" {
   "costlastyear" numeric [not null, default: 0.00, note: 'Business costs in the territory the previous year.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  territoryid [pk, name: "PK_SalesTerritory_TerritoryID"]
-}
   Note: 'Sales territory lookup table.'
 }
 
 Table "sales"."salesterritoryhistory" {
-  "businessentityid" integer [not null, note: 'Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.']
+  "businessentityid" integer [pk, not null, note: 'Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.']
   "territoryid" integer [not null, note: 'Primary key. Territory identification number. Foreign key to SalesTerritory.SalesTerritoryID.']
   "startdate" timestamp [not null, note: 'Primary key. Date the sales representive started work in the territory.']
   "enddate" timestamp [note: 'Date the sales representative left work in the territory.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  (businessentityid, startdate, territoryid) [pk, name: "PK_SalesTerritoryHistory_BusinessEntityID_StartDate_TerritoryID"]
-}
   Note: 'Sales representative transfers to other sales territories.'
 }
 
@@ -994,10 +725,6 @@ Table "sales"."salestaxrate" {
   "name" public.Name [not null, note: 'Tax rate description.']
   "rowguid" uuid [not null, default: `public.uuid_generate_v1()`]
   "modifieddate" timestamp [not null, default: `now()`]
-
-Indexes {
-  salestaxrateid [pk, name: "PK_SalesTaxRate_SalesTaxRateID"]
-}
   Note: 'Tax rate lookup table.'
 }
 

--- a/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
+++ b/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
@@ -810,6 +810,9 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
             if (cmd.value.pk || cmd.value.unique) {
               let set_prop = cmd.value.unique ? (obj) => obj["unique"] = true : (obj) => obj["pk"] = true;
               const table = findTable(this.data.tables, schemaName, tableName);
+              if (!table){
+                break;
+              }
               if (cmd.value.columns.length == 1) {
                 // We are in the single column case, we can update the column as well
                 let key = cmd.value.columns[0].value;

--- a/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
+++ b/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
@@ -805,6 +805,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
             this.data.refs.push(cmd.value);
             break;
           case TABLE_CONSTRAINT_KIND.UNIQUE:
+          case TABLE_CONSTRAINT_KIND.PK:
           case TABLE_CONSTRAINT_KIND.INDEX:
             {
               if (cmd.value.columns.length === 0) break;
@@ -814,7 +815,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
               const table = findTable(this.data.tables, schemaName, tableName);
               if (!table) break;
               // multi column constraint -> need to create new index
-              if (cmd.value.columns.lenght > 1) {
+              if (cmd.value.columns.length > 1) {
                 const index = new Index({
                   name: cmd.value.name,
                   columns: cmd.value.columns,

--- a/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
+++ b/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
@@ -808,11 +808,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
           case TABLE_CONSTRAINT_KIND.INDEX:
             kind = cmd.kind;
             if (cmd.value.pk || cmd.value.unique) {
-
-              let set_prop = (obj) => obj["pk"] = true;
-              if (cmd.value.unique) {
-                set_prop = (obj) => obj["unique"] = true;
-              }
+              let set_prop = cmd.value.unique ? (obj) => obj["unique"] = true : (obj) => obj["pk"] = true;
               const table = findTable(this.data.tables, schemaName, tableName);
               if (cmd.value.columns.length == 1) {
                 // We are in the single column case, we can update the column as well


### PR DESCRIPTION
Will fix https://github.com/holistics/dbml/issues/548

## Summary
* Implemented parsing of ALTER TABLE ... ADD CONSTRAINT for "UNIQUE|PRIMARY KEY"

## Issue
https://github.com/holistics/dbml/issues/548

## Lasting Changes (Technical)

This adds the constraints as indexes (with their names). If 1 single column is impacted, this will also add the attribute of the impacted column of the table model.

## Checklist

Please check directly on the box once each of these are done

- [x] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [x] Integration Tests Passed
- [x] Code Review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new table `comment_on_product` to enhance data structuring.
- **Enhancements**
	- Improved user data integrity by modifying the `email` field in the `users` table to be non-unique with a separate unique constraint.
	- Enhanced country identification by changing the `code` field in the `countries` table to have a dedicated primary key constraint.
- **Bug Fixes**
	- Fixed indexing issues by ensuring primary keys and unique constraints are correctly named and assigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->