### PR TITLE
parse/fix/throw undefined at primary expression

### DIFF
--- a/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
+++ b/packages/dbml-core/src/parse/ANTLR/ASTGeneration/postgres/PostgresASTGen.js
@@ -795,7 +795,7 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
       const cmds = ctx.alter_table_cmds().accept(this);
 
       return cmds.map((cmd) => {
-        if (!cmd) return;
+        if (!cmd) return null;
         let kind = null;
         switch (cmd.kind) {
           case TABLE_CONSTRAINT_KIND.FK:
@@ -806,38 +806,38 @@ export default class PostgresASTGen extends PostgreSQLParserVisitor {
             break;
           case TABLE_CONSTRAINT_KIND.UNIQUE:
           case TABLE_CONSTRAINT_KIND.PK:
-          case TABLE_CONSTRAINT_KIND.INDEX:
-            {
-              if (cmd.value.columns.length === 0) break;
-              if (!(cmd.value.pk || cmd.value.unique)) break;
-              // eslint-disable-next-line prefer-destructuring
-              kind = cmd.kind;
-              const table = findTable(this.data.tables, schemaName, tableName);
-              if (!table) break;
-              if (cmd.value.columns.length == 1 && (cmd.value.unique || cmd.value.pk)) {
-                const key = cmd.value.columns[0].value;
-                const fieldToUpdate = table.fields.find(f => f.name === key);
-                if (fieldToUpdate) {
-                  // If we have an exact match, this is a column, if not, might be an expression
-                  fieldToUpdate[cmd.value.unique ? 'unique' : 'pk'] = true;
-                  break;
-                }
+          case TABLE_CONSTRAINT_KIND.INDEX: {
+            if (cmd.value.columns.length === 0) break;
+            if (!(cmd.value.pk || cmd.value.unique)) break;
+            // eslint-disable-next-line prefer-destructuring
+            kind = cmd.kind;
+            const table = findTable(this.data.tables, schemaName, tableName);
+            if (!table) break;
+            if (cmd.value.columns.length === 1 && (cmd.value.unique || cmd.value.pk)) {
+              const key = cmd.value.columns[0].value;
+              const fieldToUpdate = table.fields.find(f => f.name === key);
+              if (fieldToUpdate) {
+                // If we have an exact match, this is a column, if not, might be an expression
+                fieldToUpdate[cmd.value.unique ? 'unique' : 'pk'] = true;
+                break;
               }
-              // multi column constraint -> need to create new index
-              const index = new Index({
-                name: cmd.value.name,
-                columns: cmd.value.columns,
-                note: cmd.value.note,
-                pk: cmd.value.pk,
-                type: cmd.value.type,
-                unique: cmd.value.unique,
-              });
-              table.indexes.push(index);
-              break;
             }
+            // multi column constraint -> need to create new index
+            const index = new Index({
+              name: cmd.value.name,
+              columns: cmd.value.columns,
+              note: cmd.value.note,
+              pk: cmd.value.pk,
+              type: cmd.value.type,
+              unique: cmd.value.unique,
+            });
+            table.indexes.push(index);
+            break;
+          }
           default:
             break;
         }
+
         return {
           kind,
           value: cmd.value,

--- a/packages/dbml-parse/src/lib/parser/parser.ts
+++ b/packages/dbml-parse/src/lib/parser/parser.ts
@@ -826,9 +826,7 @@ export default class Parser {
 
     throw new PartialParsingError(
       this.peek(),
-      this.nodeFactory.create(PrimaryExpressionNode, {
-        expression: this.nodeFactory.create(VariableNode, {}),
-      }),
+      undefined,
       this.contextStack.findHandlerContext(this.tokens, this.current),
     );
   }
@@ -1098,7 +1096,7 @@ export default class Parser {
 
   private attributeName(): IdentiferStreamNode | PrimaryExpressionNode {
     const identifiers: SyntaxToken[] = [];
-    
+
     if (this.peek().kind !== SyntaxTokenKind.IDENTIFIER) {
       return this.primaryExpression();
     }

--- a/packages/dbml-parse/tests/NaN_errors/input/empty_setting_name.in.dbml
+++ b/packages/dbml-parse/tests/NaN_errors/input/empty_setting_name.in.dbml
@@ -1,0 +1,3 @@
+Table M {
+    id int [  // this caused NaN
+}

--- a/packages/dbml-parse/tests/NaN_errors/interpreter_NaN.test.ts
+++ b/packages/dbml-parse/tests/NaN_errors/interpreter_NaN.test.ts
@@ -1,0 +1,57 @@
+import fs, { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { scanTestNames } from '../jestHelpers';
+import { NodeSymbolIdGenerator } from '../../src/lib/analyzer/symbol/symbols';
+import { SyntaxNodeIdGenerator } from '../../src/lib/parser/nodes';
+import Lexer from '../../src/lib/lexer/lexer';
+import Parser from '../../src/lib/parser/parser';
+import Analyzer from '../../src/lib/analyzer/analyzer';
+import Interpreter from '../../src/lib/interpreter/interpreter';
+
+describe('#interpreter - check for cases that previously cause NaN-positioned errors', () => {
+  const testNames = scanTestNames(path.resolve(__dirname, './input/'));
+
+  testNames.forEach((testName) => {
+    const program = readFileSync(path.resolve(__dirname, `./input/${testName}.in.dbml`), 'utf-8');
+    const symbolIdGenerator = new NodeSymbolIdGenerator();
+    const nodeIdGenerator = new SyntaxNodeIdGenerator();
+    let output: any = undefined;
+    const report = new Lexer(program)
+      .lex()
+      .chain((tokens) => {
+        return new Parser(tokens, nodeIdGenerator).parse();
+      })
+      .chain(({ ast }) => {
+        return new Analyzer(ast, symbolIdGenerator).analyze();
+      });
+
+    if (report.getErrors().length !== 0) {
+      output = JSON.stringify(
+        report.getErrors(),
+        (key, value) =>
+          ['symbol', 'references', 'referee', 'parent'].includes(key) ? undefined : value,
+        2,
+      );
+    } else {
+      const res = new Interpreter(report.getValue()).interpret();
+      if (res.getErrors().length > 0) {
+        output = JSON.stringify(
+          res.getErrors(),
+          (key, value) =>
+            ['symbol', 'references', 'referee', 'parent'].includes(key) ? undefined : value,
+          2,
+        );
+      } else {
+        output = JSON.stringify(
+          res.getValue(),
+          (key, value) => (['symbol', 'references', 'referee'].includes(key) ? undefined : value),
+          2,
+        );
+      }
+    }
+
+    it(testName, () =>
+      expect(output).toMatchFileSnapshot(path.resolve(__dirname, `./output/${testName}.out.json`)));
+  });
+});

--- a/packages/dbml-parse/tests/NaN_errors/output/empty_setting_name.out.json
+++ b/packages/dbml-parse/tests/NaN_errors/output/empty_setting_name.out.json
@@ -1,0 +1,30 @@
+[
+  {
+    "code": 1005,
+    "diagnostic": "Expect a variable or literal",
+    "nodeOrToken": {
+      "kind": "<rbrace>",
+      "startPos": {
+        "offset": 43,
+        "line": 2,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 44,
+        "line": 2,
+        "column": 1
+      },
+      "value": "}",
+      "leadingTrivia": [],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 43,
+      "end": 44
+    },
+    "start": 43,
+    "end": 44,
+    "name": "CompileError"
+  }
+]


### PR DESCRIPTION
## Summary
* Eliminate the NaN case for the empty setting name, potentially other cases too.
* An oversight in the elimination of NaN errors at the end of the primaryExpression of parser.
![image](https://github.com/holistics/dbml/assets/139191192/3788d1cc-4153-4c8e-bb63-f04cc938c019)

* Further comment:
![image](https://github.com/holistics/dbml/assets/139191192/a9f87056-168b-4e5f-9b37-409868991f69)

These lines here is an artifact of the old codebase where NaN can be thrown, there wasn't an explicit way to represent a dummy node (a node that was supposed to be there but otherwise non-existent). So I used an empty primary expression to represent them and an empty primary expression have NaN positions.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the parser to prevent NaN-related issues.
	- Fixed a bug where certain comments in DBML files caused errors.

- **Tests**
	- Added new test cases to ensure robust handling of NaN errors in DBML interpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->