### PR TITLE
Fix/silent errors in compiler api stack container

### DIFF
--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -192,7 +192,7 @@ export default class Compiler {
       (offset: number): readonly Readonly<SyntaxNode>[] => {
         const tokens = this.token.flatStream();
         const { index: startIndex, token } = this.container.token(offset);
-        const validIndex = startIndex === undefined ? -1 : findLastIndex(tokens, (token) => !token.isInvalid);
+        const validIndex = startIndex === undefined ? -1 : findLastIndex(tokens, (token) => !token.isInvalid, startIndex);
         if (validIndex === -1) {
           return [this.parse.ast()];
         }

--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -190,7 +190,7 @@ export default class Compiler {
     stack: this.createQuery(
       Query.Container_Stack,
       (offset: number): readonly Readonly<SyntaxNode>[] => {
-        const tokens = this.parse.tokens();
+        const tokens = this.token.flatStream();
         let { index } = this.container.token(offset);
         const { token } = this.container.token(offset);
         if (index === undefined) {

--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -190,7 +190,6 @@ export default class Compiler {
     stack: this.createQuery(
       Query.Container_Stack,
       (offset: number): readonly Readonly<SyntaxNode>[] => {
-        console.log('a');
         const tokens = this.token.flatStream();
         const { index: startIndex, token } = this.container.token(offset);
         const validIndex = startIndex === undefined ? -1 : findLastIndex(tokens, (token) => !token.isInvalid);

--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -196,7 +196,7 @@ export default class Compiler {
         if (index === undefined) {
           return [this.parse.ast()];
         }
-        while (tokens[index].isInvalid && index >= 0) {
+        while (index >= 0 && tokens[index].isInvalid) {
           index -= 1;
         }
         if (index === -1) {

--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { findLastIndex, last } from 'lodash';
 import { SymbolKind, destructureIndex } from './lib/analyzer/symbol/symbolIndex';
 import { generatePossibleIndexes } from './lib/analyzer/symbol/utils';
 import SymbolTable from './lib/analyzer/symbol/symbolTable';
@@ -191,19 +191,13 @@ export default class Compiler {
       Query.Container_Stack,
       (offset: number): readonly Readonly<SyntaxNode>[] => {
         const tokens = this.token.flatStream();
-        let { index } = this.container.token(offset);
-        const { token } = this.container.token(offset);
-        if (index === undefined) {
-          return [this.parse.ast()];
-        }
-        while (index >= 0 && tokens[index].isInvalid) {
-          index -= 1;
-        }
-        if (index === -1) {
+        const { index: startIndex, token } = this.container.token(offset);
+        const validIndex = findLastIndex(tokens, (token) => !token.isInvalid, startIndex || -1);
+        if (validIndex === -1) {
           return [this.parse.ast()];
         }
 
-        const searchOffset = tokens[index].start;
+        const searchOffset = tokens[validIndex].start;
 
         let curNode: Readonly<SyntaxNode> = this.parse.ast();
         const res: SyntaxNode[] = [curNode];
@@ -224,7 +218,7 @@ export default class Compiler {
 
         while (res.length > 0) {
           let popOnce = false;
-          const lastContainer = _.last(res)!;
+          const lastContainer = last(res)!;
 
           if (lastContainer instanceof FunctionApplicationNode) {
             const source = this.parse.source();
@@ -265,7 +259,7 @@ export default class Compiler {
           }
 
           if (popOnce) {
-            const maybeElement = _.last(res);
+            const maybeElement = last(res);
             if (maybeElement instanceof ElementDeclarationNode && maybeElement.end <= offset) {
               res.pop();
             }

--- a/packages/dbml-parse/src/compiler.ts
+++ b/packages/dbml-parse/src/compiler.ts
@@ -190,9 +190,10 @@ export default class Compiler {
     stack: this.createQuery(
       Query.Container_Stack,
       (offset: number): readonly Readonly<SyntaxNode>[] => {
+        console.log('a');
         const tokens = this.token.flatStream();
         const { index: startIndex, token } = this.container.token(offset);
-        const validIndex = findLastIndex(tokens, (token) => !token.isInvalid, startIndex || -1);
+        const validIndex = startIndex === undefined ? -1 : findLastIndex(tokens, (token) => !token.isInvalid);
         if (validIndex === -1) {
           return [this.parse.ast()];
         }


### PR DESCRIPTION
## Summary
* Fix silent error in this case:
![image](https://github.com/holistics/dbml/assets/139191192/77a31d82-5b60-4323-b680-ac3048343d2e)

* The reason is that:
1️⃣  `Compiler.container.token` return the offset in the flat token stream (the stream with all tokens and invalid, trivial tokens in the same level in a list.
2️⃣  `Compiler.container.stack` use the nested token stream (the stream with all nontrivial and valid tokens only, the invalid and trivial tokens are nested inside of these) -> Mismatch index and list -> index out of bound.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review