### PR TITLE
fix: safe unwrapping in suggesting attribute value when name is blank

### DIFF
--- a/packages/dbml-parse/src/services/suggestions/provider.ts
+++ b/packages/dbml-parse/src/services/suggestions/provider.ts
@@ -250,7 +250,7 @@ function suggestInAttribute(
     const res = suggestAttributeValue(
       compiler,
       offset,
-      extractStringFromIdentifierStream(container.name).unwrap(),
+      extractStringFromIdentifierStream(container.name).unwrap_or(''),
     );
 
     return (token?.kind === SyntaxTokenKind.COLON && shouldPrependSpace(token, offset)) ? prependSpace(res) : res;


### PR DESCRIPTION
## Summary
* Fix this error:

https://github.com/user-attachments/assets/2487ff80-461d-445f-aabf-65d6e38963e1

* This is due to when the attribute name is blank and the cursor is currently after the colon, the autocompletion provider will try to unwrap the non existent attribute name (which is `None`) to get the suggestions for the attribute value.

## Issue
(issue link here)

## Lasting Changes (Technical)

* `suggestInAttribute` in completion provider: `unwrap_or` instead of `unwrap`

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review