### PR TITLE
Fix - Clean build cache and required using node 18 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [18.x, 20.x, 22.x]
     services:
       postgres:
         image: postgres:15-bullseye

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x]
     services:
       postgres:
         image: postgres:15-bullseye

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   ],
   "scripts": {
     "test": "npx lerna run test",
-    "build": "npx lerna run build"
+    "build": "yarn clean-build && npx lerna run build",
+    "clean-build": "yarn clean-dbml-cli && yarn clean-dbml-core && yarn clean-dbml-parse",
+    "clean-dbml-cli": "rm -rf ./packages/dbml-cli/lib",
+    "clean-dbml-core": "rm -rf ./packages/dbml-core/lib",
+    "clean-dbml-parse": "rm -rf ./packages/dbml-parse/dist"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
   "scripts": {
     "test": "npx lerna run test",
     "build": "yarn clean-build && npx lerna run build",
-    "clean-build": "yarn clean-dbml-cli && yarn clean-dbml-core && yarn clean-dbml-parse",
-    "clean-dbml-cli": "rm -rf ./packages/dbml-cli/lib",
-    "clean-dbml-core": "rm -rf ./packages/dbml-core/lib",
-    "clean-dbml-parse": "rm -rf ./packages/dbml-parse/dist"
+    "clean-build": "rm -rf ./packages/dbml-cli/lib ./packages/dbml-core/lib ./packages/dbml-parse/dist"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
       "PR: Internal :house_with_garden:": ":house_with_garden: Internal",
       "PR: Dependencies Update :robot:": ":robot: Dependencies Update"
     }
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -54,5 +54,8 @@
       "^.+\\.js$": "babel-jest"
     }
   },
-  "gitHead": "5cb80e1aa38fb9a4dbe3079e39c9ef93cd4dc556"
+  "gitHead": "5cb80e1aa38fb9a4dbe3079e39c9ef93cd4dc556",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -63,5 +63,8 @@
       "\\.(?!json$)[^.]*$": "@glen/jest-raw-loader"
     }
   },
-  "gitHead": "5cb80e1aa38fb9a4dbe3079e39c9ef93cd4dc556"
+  "gitHead": "5cb80e1aa38fb9a4dbe3079e39c9ef93cd4dc556",
+  "engines": {
+    "node": ">=18"
+  }
 }


### PR DESCRIPTION
## Summary

- Clean build cache before build process
- Config to require using node 18 or higher

## Issue
- https://github.com/holistics/dbml/issues/607

## Lasting Changes (Technical)

- Add `clean-build` script in the root folder
- Add required engines

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review