### PR TITLE
Fix erroneous examples in document for Table Groups

### DIFF
--- a/dbml-homepage/docs/docs.md
+++ b/dbml-homepage/docs/docs.md
@@ -435,7 +435,7 @@ Table orders {
 ### TableGroup Notes
 
 ```text
-TableGroup e-commerce [note: 'Contains tables that are related to e-commerce system'] {
+TableGroup e_commerce [note: 'Contains tables that are related to e-commerce system'] {
   merchants
   countries
 
@@ -479,7 +479,7 @@ TableGroup tablegroup_name { // tablegroup is case-insensitive.
 }
 
 // example
-TableGroup e-commerce1 {
+TableGroup e_commerce1 {
   merchants
   countries
 }
@@ -490,7 +490,7 @@ TableGroup e-commerce1 {
 Table groupings can be annotated with notes that describe their meaning and purpose.
 
 ```text
-TableGroup e-commerce [note: 'Contains tables that are related to e-commerce system'] {
+TableGroup e_commerce [note: 'Contains tables that are related to e-commerce system'] {
   merchants
   countries
 
@@ -509,7 +509,7 @@ The list of table group settings you can use:
 
 Example,
 ```text
-TableGroup e-commerce [color: #345] {
+TableGroup e_commerce [color: #345] {
   merchants
   countries
 }

--- a/packages/dbml-core/types/model_structure/tableGroup.d.ts
+++ b/packages/dbml-core/types/model_structure/tableGroup.d.ts
@@ -21,6 +21,7 @@ declare class TableGroup extends Element {
     id: number;
     note: string;
     noteToken: Token;
+    color: string;
     constructor({ name, token, tables, schema, note, color }: RawTableGroup);
     generateId(): void;
     processTables(rawTables: any): void;


### PR DESCRIPTION
## Summary
* Change some example syntax from `e-commerce` to `e_commerce`
* Add missing property `color` for `TableGroup`'s type definition

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review