### PR TITLE
Fix: When the parameter format is JSON in Parser.parse, the first parameter 'parse' must be RawDatabase

### DIFF
--- a/packages/dbml-core/types/parse/Parser.d.ts
+++ b/packages/dbml-core/types/parse/Parser.d.ts
@@ -13,6 +13,6 @@ declare class Parser {
      * Should use parse() instance method instead of this static method whenever possible
      */
     static parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
-    parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
+    parse(str: string | RawDatabase, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
 }
 export default Parser;

--- a/packages/dbml-core/types/parse/Parser.d.ts
+++ b/packages/dbml-core/types/parse/Parser.d.ts
@@ -13,6 +13,8 @@ declare class Parser {
      * Should use parse() instance method instead of this static method whenever possible
      */
     static parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
-    parse(str: string | RawDatabase, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
+    static parse(str: RawDatabase, format: 'json'): Database;
+    parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
+    parse(str: RawDatabase, format: 'json'): Database;
 }
 export default Parser;


### PR DESCRIPTION
## Summary
The Database.constructor parameter requires RawDatabase because the Database.export method executed by ModelExporter.export (format=json) returns a regular object instead of RawDatabase, which is different from RawDatabase. Therefore, when using Parser.parse(str, format=json), str must be in RawDatabase or its json form to alert everyone about unexpected errors caused by their differences.

![image](https://github.com/user-attachments/assets/3653fed3-30ad-4867-b3ca-cb5685125e15)

The Database.constructor parameter requires RawDatabase 
<img width="431" alt="image" src="https://github.com/user-attachments/assets/28490c1d-f24d-4f5e-a503-ccf1491106e6"><img width="295" alt="image" src="https://github.com/user-attachments/assets/881d34cd-f094-443c-a0db-e85203dcbc68">

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review