### PR TITLE
Fix postgres connector issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,44 +1,56 @@
 {
+  "root": true,
   "env": {
-      "es6": true,
-      "node": true,
-      "jest/globals": true
+    "es6": true,
+    "node": true,
+    "jest/globals": true
   },
   "extends": [
     "airbnb-base",
-    "plugin:jest/recommended"
+    "plugin:jest/recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
   "globals": {
-      "Atomics": "readonly",
-      "SharedArrayBuffer": "readonly"
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
   },
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2020
+    "ecmaVersion": 2020,
+    "project": "./tsconfig.json"
   },
-  "plugins": ["jest"],
+  "plugins": ["jest", "@typescript-eslint"],
   "rules": {
     "space-before-function-paren": ["error", "always"],
     "no-underscore-dangle": "off",
     "no-param-reassign": ["error", { "props": false }],
     "no-shadow": "warn",
-    "max-len": ["error", {
-      "code": 180,
-      "ignorePattern": "^\\s*/\\*.*\\*/\\s*$",
-      "ignoreComments": true
-    }],
+    "max-len": [
+      "error",
+      {
+        "code": 180,
+        "ignorePattern": "^\\s*/\\*.*\\*/\\s*$",
+        "ignoreComments": true
+      }
+    ],
     "radix": ["warn", "as-needed"],
     "arrow-parens": "off",
     "arrow-body-style": "off",
     "object-curly-newline": "warn",
-    "prefer-destructuring": ["error", {"object": true, "array": false}],
+    "prefer-destructuring": ["error", { "object": true, "array": false }],
     "func-names": "off",
-    "no-restricted-imports": ["error", {
-      "paths": [{
-        "name": "uiv",
-        "message": "Please use the globally registered component/directive instead"
-      }]
-    }],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "uiv",
+            "message": "Please use the globally registered component/directive instead"
+          }
+        ]
+      }
+    ],
     "import/prefer-default-export": "off"
   }
 }

--- a/packages/dbml-cli/__test__/db2dbml/postgres/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/postgres/expect-out-files/schema.dbml
@@ -1,3 +1,33 @@
+Enum "dbml_test"."enum_type1" {
+  "value1"
+  "value2"
+}
+
+Enum "dbml_test"."enum_type3" {
+  "value4"
+  "value5"
+}
+
+Table "dbml_test"."table1" {
+  "id" int4 [pk, not null, increment]
+  "status" dbml_test.enum_type1
+}
+
+Table "dbml_test"."table3" {
+  "id" int4 [pk, not null, increment]
+  "status" dbml_test.enum_type3
+}
+
+Enum "enum_type1" {
+  "value1"
+  "value2"
+}
+
+Enum "enum_type2" {
+  "value1"
+  "value3"
+}
+
 Enum "gender_type" {
   "Male"
   "Female"
@@ -92,6 +122,16 @@ Table "products" {
   Indexes {
     category [type: btree, name: "idx_products_category"]
   }
+}
+
+Table "table1" {
+  "id" int4 [pk, not null, increment]
+  "status" enum_type1
+}
+
+Table "table2" {
+  "id" int4 [pk, not null, increment]
+  "status" enum_type2
 }
 
 Table "table_with_comments" {

--- a/packages/dbml-cli/__test__/db2dbml/postgres/schema.sql
+++ b/packages/dbml-cli/__test__/db2dbml/postgres/schema.sql
@@ -1,4 +1,6 @@
 -- Create users table
+CREATE SCHEMA dbml_test;
+
 CREATE TABLE users (
   user_id SERIAL PRIMARY KEY,
   username VARCHAR(50) UNIQUE NOT NULL,
@@ -153,4 +155,33 @@ CREATE TABLE Books (
   UNIQUE (ISBN),
   CONSTRAINT FK_AuthorNationality FOREIGN KEY (AuthorID, NationalityID)
     REFERENCES Authors (AuthorID, NationalityID) ON DELETE CASCADE
+);
+
+-- Create enum types in the public schema
+CREATE TYPE public.enum_type1 AS ENUM ('value1', 'value2');
+CREATE TYPE public.enum_type2 AS ENUM ('value1', 'value3');
+
+-- Create enum types in the dbml_test schema
+CREATE TYPE dbml_test.enum_type1 AS ENUM ('value1', 'value2');
+CREATE TYPE dbml_test.enum_type3 AS ENUM ('value4', 'value5');
+
+-- Optionally, create tables to use these enum types
+CREATE TABLE public.table1 (
+  id SERIAL PRIMARY KEY,
+  status public.enum_type1
+);
+
+CREATE TABLE public.table2 (
+  id SERIAL PRIMARY KEY,
+  status public.enum_type2
+);
+
+CREATE TABLE dbml_test.table1 (
+  id SERIAL PRIMARY KEY,
+  status dbml_test.enum_type1
+);
+
+CREATE TABLE dbml_test.table3 (
+  id SERIAL PRIMARY KEY,
+  status dbml_test.enum_type3
 );

--- a/packages/dbml-connector/__tests__/connector.test.ts
+++ b/packages/dbml-connector/__tests__/connector.test.ts
@@ -1,10 +1,10 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 import { scanDirNames } from '../jestHelpers.ts';
 import { connector } from '../src/index.ts';
 
 describe('@dbml/connector', () => {
-  const runTest = async (dirName) => {
+  const runTest = async (dirName: string) => {
     process.chdir(dirName);
 
     const connectionRaw = fs.readFileSync(path.join(dirName, './connection.json'), 'utf-8');

--- a/packages/dbml-connector/__tests__/connectors/postgres/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/postgres/expect-out-files/schema.json
@@ -1,6 +1,20 @@
 {
   "tables": [
     {
+      "name": "table1",
+      "schemaName": "dbml_test",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "table3",
+      "schemaName": "dbml_test",
+      "note": {
+        "value": ""
+      }
+    },
+    {
       "name": "all_default_values",
       "schemaName": "public",
       "note": {
@@ -50,6 +64,20 @@
       }
     },
     {
+      "name": "table1",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "table2",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
       "name": "table_with_comments",
       "schemaName": "public",
       "note": {
@@ -72,6 +100,62 @@
     }
   ],
   "fields": {
+    "dbml_test.table1": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "enum_type1",
+          "schemaName": "dbml_test"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbml_test.table3": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "enum_type3",
+          "schemaName": "dbml_test"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
     "public.all_default_values": [
       {
         "name": "id",
@@ -843,6 +927,62 @@
         }
       }
     ],
+    "public.table1": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "enum_type1",
+          "schemaName": "public"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.table2": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "enum_type2",
+          "schemaName": "public"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
     "public.table_with_comments": [
       {
         "name": "id",
@@ -1230,6 +1370,54 @@
   ],
   "enums": [
     {
+      "name": "enum_type1",
+      "schemaName": "dbml_test",
+      "values": [
+        {
+          "name": "value1"
+        },
+        {
+          "name": "value2"
+        }
+      ]
+    },
+    {
+      "name": "enum_type3",
+      "schemaName": "dbml_test",
+      "values": [
+        {
+          "name": "value4"
+        },
+        {
+          "name": "value5"
+        }
+      ]
+    },
+    {
+      "name": "enum_type1",
+      "schemaName": "public",
+      "values": [
+        {
+          "name": "value1"
+        },
+        {
+          "name": "value2"
+        }
+      ]
+    },
+    {
+      "name": "enum_type2",
+      "schemaName": "public",
+      "values": [
+        {
+          "name": "value1"
+        },
+        {
+          "name": "value3"
+        }
+      ]
+    },
+    {
       "name": "gender_type",
       "schemaName": "public",
       "values": [
@@ -1383,6 +1571,26 @@
     },
     "public.products": {
       "product_id": {
+        "pk": true
+      }
+    },
+    "public.table1": {
+      "id": {
+        "pk": true
+      }
+    },
+    "dbml_test.table1": {
+      "id": {
+        "pk": true
+      }
+    },
+    "public.table2": {
+      "id": {
+        "pk": true
+      }
+    },
+    "dbml_test.table3": {
+      "id": {
         "pk": true
       }
     },

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -1,20 +1,20 @@
 /* eslint-disable camelcase */
 import sql from 'mssql';
+import { buildSchemaQuery, parseConnectionString } from '../utils/parseSchema';
 import {
-  Field,
+  DatabaseSchema,
+  DefaultInfo,
   DefaultType,
-  FieldsDictionary,
   Enum,
+  EnumValue,
+  Field,
+  FieldsDictionary,
+  IndexesDictionary,
   Ref,
   RefEndpoint,
   Table,
-  IndexesDictionary,
-  EnumValue,
   TableConstraintsDictionary,
-  DatabaseSchema,
-  DefaultInfo,
 } from './types';
-import { buildSchemaQuery, parseConnectionString } from '../utils/parseSchema';
 
 const MSSQL_DATE_TYPES = [
   'date',
@@ -141,71 +141,99 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
   const fields: FieldsDictionary = {};
   const enums: Enum[] = [];
   const tablesAndFieldsSql = `
-  WITH tables_and_fields AS (
+    WITH tables_and_fields AS (
+      SELECT
+        s.name AS table_schema,
+        t.name AS table_name,
+        c.name AS column_name,
+        ty.name AS data_type,
+        c.max_length AS character_maximum_length,
+        c.precision AS numeric_precision,
+        c.scale AS numeric_scale,
+        c.is_identity AS identity_increment,
+        CASE
+          WHEN c.is_nullable = 1 THEN 'YES'
+          ELSE 'NO'
+        END AS is_nullable,
+        CASE
+          WHEN c.default_object_id = 0 THEN NULL
+          ELSE OBJECT_DEFINITION(c.default_object_id)
+        END AS column_default,
+        -- Fetching table comments
+        p.value AS table_comment,
+        ep.value AS column_comment
+      FROM
+        sys.tables t
+        JOIN sys.schemas s ON t.schema_id = s.schema_id
+        JOIN sys.columns c ON t.object_id = c.object_id
+        JOIN sys.types ty ON c.user_type_id = ty.user_type_id
+        LEFT JOIN sys.extended_properties p ON p.major_id = t.object_id
+          AND p.name = 'MS_Description'
+          AND p.minor_id = 0 -- Ensure minor_id is 0 for table comments
+        LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id
+          AND ep.minor_id = c.column_id
+          AND ep.name = 'MS_Description'
+      WHERE
+        t.type = 'U' -- User-defined tables
+    ),
+    constraints_with_nulls AS (
+      SELECT
+        tf.*,
+        cc.name AS check_constraint_name,
+        CASE
+          WHEN cc.definition LIKE '%[' + tf.column_name + ']%=''%' THEN cc.definition
+          ELSE NULL
+        END AS check_constraint_definition
+      FROM
+        tables_and_fields AS tf
+      LEFT JOIN sys.check_constraints cc
+        ON cc.parent_object_id = OBJECT_ID(tf.table_schema + '.' + tf.table_name)
+        AND cc.definition LIKE '%' + tf.column_name + '%' -- Ensure the constraint references the column
+    ),
+    constraints_with_row_number AS (
+      SELECT
+        *,
+        ROW_NUMBER() OVER (
+          PARTITION BY table_schema, table_name, column_name
+          ORDER BY
+            CASE
+              WHEN check_constraint_definition IS NOT NULL THEN 1
+              ELSE 2
+            END,
+            check_constraint_name
+        ) AS rn
+      FROM
+        constraints_with_nulls
+    )
     SELECT
-      s.name AS table_schema,
-      t.name AS table_name,
-      c.name AS column_name,
-      ty.name AS data_type,
-      c.max_length AS character_maximum_length,
-      c.precision AS numeric_precision,
-      c.scale AS numeric_scale,
-      c.is_identity AS identity_increment,
+      table_schema,
+      table_name,
+      column_name,
+      data_type,
+      character_maximum_length,
+      numeric_precision,
+      numeric_scale,
+      identity_increment,
+      is_nullable,
+      column_default,
+      table_comment,
+      column_comment,
+      check_constraint_name,
+      check_constraint_definition,
       CASE
-        WHEN c.is_nullable = 1 THEN 'YES'
-        ELSE 'NO'
-      END AS is_nullable,
-      CASE
-        WHEN c.default_object_id = 0 THEN NULL
-        ELSE OBJECT_DEFINITION(c.default_object_id)
-      END AS column_default,
-      -- Fetching table comments
-      p.value AS table_comment,
-      ep.value AS column_comment
+        WHEN column_default LIKE '((%))' THEN 'number'
+        WHEN column_default LIKE '(''%'')' THEN 'string'
+        ELSE 'expression'
+      END AS default_type
     FROM
-      sys.tables t
-      JOIN sys.schemas s ON t.schema_id = s.schema_id
-      JOIN sys.columns c ON t.object_id = c.object_id
-      JOIN sys.types ty ON c.user_type_id = ty.user_type_id
-      LEFT JOIN sys.extended_properties p ON p.major_id = t.object_id
-        AND p.name = 'MS_Description'
-        AND p.minor_id = 0 -- Ensure minor_id is 0 for table comments
-      LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id
-        AND ep.minor_id = c.column_id
-        AND ep.name = 'MS_Description'
+      constraints_with_row_number
     WHERE
-      t.type = 'U' -- User-defined tables
-  )
-  SELECT
-    tf.table_schema,
-    tf.table_name,
-    tf.column_name,
-    tf.data_type,
-    tf.character_maximum_length,
-    tf.numeric_precision,
-    tf.numeric_scale,
-    tf.identity_increment,
-    tf.is_nullable,
-    tf.column_default,
-    tf.table_comment,
-    tf.column_comment,
-    cc.name AS check_constraint_name, -- Adding CHECK constraint name
-    cc.definition AS check_constraint_definition, -- Adding CHECK constraint definition
-    CASE
-      WHEN tf.column_default LIKE '((%))' THEN 'number'
-      WHEN tf.column_default LIKE '(''%'')' THEN 'string'
-      ELSE 'expression'
-    END AS default_type
-  FROM
-    tables_and_fields AS tf
-  LEFT JOIN sys.check_constraints cc
-    ON cc.parent_object_id = OBJECT_ID(tf.table_schema + '.' + tf.table_name)
-    AND cc.definition LIKE '%' + tf.column_name + '%' -- Ensure the constraint references the column
-  ${buildSchemaQuery('tf.table_schema', schemas, 'WHERE')}
-  ORDER BY
-    tf.table_schema,
-    tf.table_name,
-    tf.column_name;
+      rn = 1
+      ${buildSchemaQuery('table_schema', schemas, 'WHERE')}
+    ORDER BY
+      table_schema,
+      table_name,
+      column_name;
   `;
 
   const tablesAndFieldsResult = await client.query(tablesAndFieldsSql);
@@ -521,5 +549,5 @@ const fetchSchemaJson = async (connection: string): Promise<DatabaseSchema> => {
 };
 
 export {
-  fetchSchemaJson,
+  fetchSchemaJson
 };


### PR DESCRIPTION
## Summary
Fix postgres connector issues related to:
- Duplicated fields
- Failed to fetch enums if there is the same enum_type name in different schemas.
Fix wrong enums when fetching in mssql.

## Issue
(issue link here)

## Lasting Changes (Technical)
- Fix the eslintrc to parse ts file correctly
- Remove wrong enums when fetching in mssql
- Update the sql which fetching tables, fields, and comments to  avoid fetching duplicated fields
- Update the sql which fetching enums to support the same enum_type name in different schema_name

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review