### PR TITLE
fix: include dummy-node in helper functions

### DIFF
--- a/packages/dbml-parse/src/lib/parser/utils.ts
+++ b/packages/dbml-parse/src/lib/parser/utils.ts
@@ -271,9 +271,14 @@ export function getMemberChain(node: SyntaxNode): Readonly<(SyntaxNode | SyntaxT
     )
   }
 
+  if (node instanceof DummyNode) {
+    return [];
+  }
+
   if (node instanceof GroupExpressionNode) {
     throw new Error('This case is already handled by TupleExpressionNode');
   }
+
 
   throw new Error('Unreachable - no other possible cases');
 }

--- a/packages/dbml-parse/src/lib/parser/utils.ts
+++ b/packages/dbml-parse/src/lib/parser/utils.ts
@@ -8,6 +8,7 @@ import {
   AttributeNode,
   BlockExpressionNode,
   CallExpressionNode,
+  DummyNode,
   ElementDeclarationNode,
   ExpressionNode,
   FunctionApplicationNode,
@@ -167,7 +168,7 @@ function markInvalidNode(node: SyntaxNode) {
     markInvalid(node.literal);
   } else if (node instanceof GroupExpressionNode) {
     throw new Error('This case is handled by the TupleExpressionNode case');
-  } else {
+  } else if (!(node instanceof DummyNode)) {
     throw new Error('Unreachable case in markInvalidNode');
   }
 }


### PR DESCRIPTION
## Summary
* Cover cases in markInvalidNode & getMemberChain when the argument is a DummyNode.

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review