### PR TITLE
Fix mssql connector - Missing data type size for numeric-based and string-based columns

### DIFF
--- a/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
@@ -55,6 +55,19 @@ Table "dbo"."NumberTypes" {
   "TINYINTCol" tinyint [default: 0]
 }
 
+Table "dbo"."NumberTypesNoDefault" {
+  "BIGINTCol" bigint
+  "BITCol" bit
+  "DECIMALCol" decimal(10,2)
+  "FLOATCol" float
+  "ID" int [pk, not null, increment]
+  "INTCol" int
+  "NUMERICCol" numeric(10,2)
+  "REALCol" real
+  "SMALLINTCol" smallint
+  "TINYINTCol" tinyint
+}
+
 Table "dbo"."ObjectTypes" {
   "BinaryField" binary [default: `0x00`]
   "Id" int [pk, not null, increment]
@@ -91,7 +104,7 @@ Table "dbo"."order_items" {
   "order_item_id" int [pk, not null, increment]
   "product_id" int [unique, not null]
   "quantity" int [not null]
-  "unit_price" decimal [not null]
+  "unit_price" decimal(10,2) [not null]
 
   Indexes {
     (order_id, product_id) [type: nonclustered, name: "idx_order_items_order_product"]
@@ -104,7 +117,7 @@ Table "dbo"."orders" {
   "order_id" int [pk, not null, increment]
   "shipping_address" text [not null]
   "status" dbo.chk_status [default: 'pending']
-  "total_amount" decimal [not null]
+  "total_amount" decimal(12,2) [not null]
   "user_id" int [not null]
 
   Indexes {
@@ -118,7 +131,7 @@ Table "dbo"."products" {
   "description" text
   "is_available" bit [default: 1]
   "name" varchar [not null]
-  "price" decimal [not null]
+  "price" decimal(10,2) [not null]
   "product_id" int [pk, not null, increment]
   "stock_quantity" int [not null, default: 0]
   "updated_at" datetime2 [default: `getdate()`]

--- a/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
@@ -13,18 +13,18 @@ Enum "dbo"."chk_gender" {
 }
 
 Table "dbo"."Authors" {
-  "AuthorID" int [pk, not null]
-  "AuthorName" nvarchar [unique]
-  "BirthYear" int [unique]
-  "NationalityID" int [pk, not null]
+  "AuthorID" int(10) [pk, not null]
+  "AuthorName" nvarchar(100) [unique]
+  "BirthYear" int(10) [unique]
+  "NationalityID" int(10) [pk, not null]
 }
 
 Table "dbo"."Books" {
-  "AuthorID" int [pk, not null]
-  "BookID" int [pk, not null]
-  "ISBN" nvarchar [unique]
-  "NationalityID" int
-  "Title" nvarchar
+  "AuthorID" int(10) [pk, not null]
+  "BookID" int(10) [pk, not null]
+  "ISBN" nvarchar(20) [unique]
+  "NationalityID" int(10)
+  "Title" nvarchar(200)
 }
 
 Table "dbo"."DatetimeTypes" {
@@ -32,49 +32,49 @@ Table "dbo"."DatetimeTypes" {
   "DATETIME2Col" datetime2 [default: `sysdatetime()`]
   "DATETIMECol" datetime [default: `getdate()`]
   "DATETIMEOFFSETCol" datetimeoffset [default: `sysdatetimeoffset()`]
-  "ID" int [pk, not null, increment]
-  "ROWVERSIONCol" timestamp [not null]
+  "ID" int(10) [pk, not null, increment]
+  "ROWVERSIONCol" rowversion [not null]
   "SMALLDATETIMECol" smalldatetime [default: `getdate()`]
   "TIMECol" time [default: `CONVERT([time],getdate())`]
 }
 
 Table "dbo"."gender_reference" {
-  "value" nvarchar [pk, not null]
+  "value" nvarchar(10) [pk, not null]
 }
 
 Table "dbo"."NumberTypes" {
-  "BIGINTCol" bigint [default: 0]
+  "BIGINTCol" bigint(19) [default: 0]
   "BITCol" bit [default: 0]
   "DECIMALCol" decimal(10,2) [default: 0.00]
-  "FLOATCol" float [default: 0.0]
-  "ID" int [pk, not null, increment]
-  "INTCol" int [default: 0]
+  "FLOATCol" float(53) [default: 0.0]
+  "ID" int(10) [pk, not null, increment]
+  "INTCol" int(10) [default: 0]
   "NUMERICCol" numeric(10,2) [default: 0.00]
-  "REALCol" real [default: 0.0]
-  "SMALLINTCol" smallint [default: 0]
-  "TINYINTCol" tinyint [default: 0]
+  "REALCol" real(24) [default: 0.0]
+  "SMALLINTCol" smallint(5) [default: 0]
+  "TINYINTCol" tinyint(3) [default: 0]
 }
 
 Table "dbo"."NumberTypesNoDefault" {
-  "BIGINTCol" bigint
+  "BIGINTCol" bigint(19)
   "BITCol" bit
   "DECIMALCol" decimal(10,2)
-  "FLOATCol" float
-  "ID" int [pk, not null, increment]
-  "INTCol" int
+  "FLOATCol" float(53)
+  "ID" int(10) [pk, not null, increment]
+  "INTCol" int(10)
   "NUMERICCol" numeric(10,2)
-  "REALCol" real
-  "SMALLINTCol" smallint
-  "TINYINTCol" tinyint
+  "REALCol" real(24)
+  "SMALLINTCol" smallint(5)
+  "TINYINTCol" tinyint(3)
 }
 
 Table "dbo"."ObjectTypes" {
-  "BinaryField" binary [default: `0x00`]
-  "Id" int [pk, not null, increment]
+  "BinaryField" binary(50) [default: `0x00`]
+  "Id" int(10) [pk, not null, increment]
   "ImageField" image [default: `0x00`]
-  "JsonField" nvarchar [default: `N'{"defaultKey": "defaultValue", "status": "active", "count": 0}'`]
-  "VarBinaryField" varbinary [default: `0x00`]
-  "VarBinaryMaxField" varbinary [default: `0x00`]
+  "JsonField" nvarchar(MAX) [default: `N'{"defaultKey": "defaultValue", "status": "active", "count": 0}'`]
+  "VarBinaryField" varbinary(50) [default: `0x00`]
+  "VarBinaryMaxField" varbinary(MAX) [default: `0x00`]
   "XmlField" xml [default: '''<Books>
     <Book>
       <Title>The Great Gatsby</Title>
@@ -100,10 +100,10 @@ Table "dbo"."ObjectTypes" {
 }
 
 Table "dbo"."order_items" {
-  "order_id" int [unique, not null]
-  "order_item_id" int [pk, not null, increment]
-  "product_id" int [unique, not null]
-  "quantity" int [not null]
+  "order_id" int(10) [unique, not null]
+  "order_item_id" int(10) [pk, not null, increment]
+  "product_id" int(10) [unique, not null]
+  "quantity" int(10) [not null]
   "unit_price" decimal(10,2) [not null]
 
   Indexes {
@@ -114,11 +114,11 @@ Table "dbo"."order_items" {
 Table "dbo"."orders" {
   "billing_address" text [not null]
   "order_date" datetime2 [default: `getdate()`]
-  "order_id" int [pk, not null, increment]
+  "order_id" int(10) [pk, not null, increment]
   "shipping_address" text [not null]
   "status" dbo.chk_status [default: 'pending']
   "total_amount" decimal(12,2) [not null]
-  "user_id" int [not null]
+  "user_id" int(10) [not null]
 
   Indexes {
     (user_id, order_date) [type: nonclustered, name: "idx_orders_user_date"]
@@ -126,14 +126,14 @@ Table "dbo"."orders" {
 }
 
 Table "dbo"."products" {
-  "category" varchar
+  "category" varchar(50)
   "created_at" datetime2 [default: `getdate()`]
   "description" text
   "is_available" bit [default: 1]
-  "name" varchar [not null]
+  "name" varchar(100) [not null]
   "price" decimal(10,2) [not null]
-  "product_id" int [pk, not null, increment]
-  "stock_quantity" int [not null, default: 0]
+  "product_id" int(10) [pk, not null, increment]
+  "stock_quantity" int(10) [not null, default: 0]
   "updated_at" datetime2 [default: `getdate()`]
 
   Indexes {
@@ -143,47 +143,47 @@ Table "dbo"."products" {
 
 Table "dbo"."StringTypes" {
   "CharField" char(10) [default: 'N/A']
-  "Id" int [pk, not null, increment]
-  "NCharField" nchar [default: `N'N/A'`]
+  "Id" int(10) [pk, not null, increment]
+  "NCharField" nchar(10) [default: `N'N/A'`]
   "NTextField" ntext [default: `N'N/A'`]
-  "NVarCharField" nvarchar [default: `N'N/A'`]
-  "NVarCharMaxField" nvarchar [default: `N'N/A'`]
-  "TextField" text(16) [default: 'N/A']
+  "NVarCharField" nvarchar(50) [default: `N'N/A'`]
+  "NVarCharMaxField" nvarchar(MAX) [default: `N'N/A'`]
+  "TextField" text [default: 'N/A']
   "VarcharField" varchar(50) [default: '{"default_key": "default_value"}']
-  "VarcharMaxField" varchar [default: 'N/A']
+  "VarcharMaxField" varchar(MAX) [default: 'N/A']
 }
 
 Table "dbo"."table_with_comments" {
   "created_at" datetime2 [default: `getdate()`, note: 'Timestamp when the item was created.']
   "description" text [note: '''Item\'s description''']
-  "id" int [pk, not null, increment, note: 'Unique identifier for each item.']
-  "name" varchar [note: 'Name of the item.']
+  "id" int(10) [pk, not null, increment, note: 'Unique identifier for each item.']
+  "name" varchar(100) [note: 'Name of the item.']
   Note: 'This table stores information about various items.'
 }
 
 Table "dbo"."user_define_data_types" {
-  "age_end" int
-  "age_start" int
+  "age_end" int(10)
+  "age_start" int(10)
   "gender" dbo.chk_gender
-  "height" float
-  "id" int [pk, not null, increment]
-  "name" nvarchar
-  "weight" float
+  "height" float(53)
+  "id" int(10) [pk, not null, increment]
+  "name" nvarchar(50)
+  "weight" float(53)
 }
 
 Table "dbo"."users" {
   "created_at" datetime2 [default: `getdate()`]
   "date_of_birth" date
-  "email" varchar [unique, not null]
-  "first_name" varchar
-  "full_name" varchar
-  "full_name_lower" varchar
+  "email" varchar(100) [unique, not null]
+  "first_name" varchar(50)
+  "full_name" varchar(100)
+  "full_name_lower" varchar(100)
   "is_active" bit [default: 1]
   "last_login" datetime2
-  "last_name" varchar
-  "password_hash" varchar [not null]
-  "user_id" int [pk, not null, increment]
-  "username" varchar [unique, not null]
+  "last_name" varchar(50)
+  "password_hash" varchar(255) [not null]
+  "user_id" int(10) [pk, not null, increment]
+  "username" varchar(50) [unique, not null]
 
   Indexes {
     email [type: nonclustered, name: "idx_users_email"]

--- a/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
@@ -33,7 +33,7 @@ Table "dbo"."DatetimeTypes" {
   "DATETIMECol" datetime [default: `getdate()`]
   "DATETIMEOFFSETCol" datetimeoffset [default: `sysdatetimeoffset()`]
   "ID" int(10) [pk, not null, increment]
-  "ROWVERSIONCol" rowversion [not null]
+  "ROWVERSIONCol" timestamp [not null]
   "SMALLDATETIMECol" smalldatetime [default: `getdate()`]
   "TIMECol" time [default: `CONVERT([time],getdate())`]
 }

--- a/packages/dbml-cli/__test__/db2dbml/mssql/schema.sql
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/schema.sql
@@ -132,6 +132,20 @@ CREATE TABLE NumberTypes (
 );
 GO
 
+CREATE TABLE NumberTypesNoDefault (
+  ID INT IDENTITY(1,1) PRIMARY KEY,
+  TINYINTCol TINYINT,
+  SMALLINTCol SMALLINT,
+  INTCol INT,
+  BIGINTCol BIGINT,
+  DECIMALCol DECIMAL(10, 2),
+  NUMERICCol NUMERIC(10, 2),
+  FLOATCol FLOAT,
+  REALCol REAL,
+  BITCol BIT
+);
+GO
+
 -- Create a table with default values for date and time types
 CREATE TABLE DatetimeTypes (
   ID INT IDENTITY(1,1) PRIMARY KEY,

--- a/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
@@ -302,7 +302,7 @@
       {
         "name": "ROWVERSIONCol",
         "type": {
-          "type_name": "rowversion",
+          "type_name": "timestamp",
           "schemaName": null
         },
         "dbdefault": null,

--- a/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
@@ -36,6 +36,13 @@
       }
     },
     {
+      "name": "NumberTypesNoDefault",
+      "schemaName": "dbo",
+      "note": {
+        "value": ""
+      }
+    },
+    {
       "name": "ObjectTypes",
       "schemaName": "dbo",
       "note": {
@@ -97,7 +104,7 @@
       {
         "name": "AuthorID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -123,7 +130,7 @@
       {
         "name": "BirthYear",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -136,7 +143,7 @@
       {
         "name": "NationalityID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -151,7 +158,7 @@
       {
         "name": "AuthorID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -164,7 +171,7 @@
       {
         "name": "BookID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -190,7 +197,7 @@
       {
         "name": "NationalityID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -282,7 +289,7 @@
       {
         "name": "ID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -357,7 +364,7 @@
       {
         "name": "BIGINTCol",
         "type": {
-          "type_name": "bigint",
+          "type_name": "bigint(19)",
           "schemaName": null
         },
         "dbdefault": {
@@ -405,7 +412,7 @@
       {
         "name": "FLOATCol",
         "type": {
-          "type_name": "float",
+          "type_name": "float(53)",
           "schemaName": null
         },
         "dbdefault": {
@@ -421,7 +428,7 @@
       {
         "name": "ID",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -434,7 +441,7 @@
       {
         "name": "INTCol",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": {
@@ -466,7 +473,7 @@
       {
         "name": "REALCol",
         "type": {
-          "type_name": "real",
+          "type_name": "real(24)",
           "schemaName": null
         },
         "dbdefault": {
@@ -482,7 +489,7 @@
       {
         "name": "SMALLINTCol",
         "type": {
-          "type_name": "smallint",
+          "type_name": "smallint(5)",
           "schemaName": null
         },
         "dbdefault": {
@@ -498,13 +505,145 @@
       {
         "name": "TINYINTCol",
         "type": {
-          "type_name": "tinyint",
+          "type_name": "tinyint(3)",
           "schemaName": null
         },
         "dbdefault": {
           "type": "number",
           "value": "0"
         },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.NumberTypesNoDefault": [
+      {
+        "name": "BIGINTCol",
+        "type": {
+          "type_name": "bigint(19)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BITCol",
+        "type": {
+          "type_name": "bit",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DECIMALCol",
+        "type": {
+          "type_name": "decimal(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "FLOATCol",
+        "type": {
+          "type_name": "float(53)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "ID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "INTCol",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "NUMERICCol",
+        "type": {
+          "type_name": "numeric(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "REALCol",
+        "type": {
+          "type_name": "real(24)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "SMALLINTCol",
+        "type": {
+          "type_name": "smallint(5)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "TINYINTCol",
+        "type": {
+          "type_name": "tinyint(3)",
+          "schemaName": null
+        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
@@ -532,7 +671,7 @@
       {
         "name": "Id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -627,7 +766,7 @@
       {
         "name": "order_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -640,7 +779,7 @@
       {
         "name": "order_item_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -653,7 +792,7 @@
       {
         "name": "product_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -666,7 +805,7 @@
       {
         "name": "quantity",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -679,7 +818,7 @@
       {
         "name": "unit_price",
         "type": {
-          "type_name": "decimal",
+          "type_name": "decimal(10,2)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -723,7 +862,7 @@
       {
         "name": "order_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -765,7 +904,7 @@
       {
         "name": "total_amount",
         "type": {
-          "type_name": "decimal",
+          "type_name": "decimal(12,2)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -778,7 +917,7 @@
       {
         "name": "user_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -864,7 +1003,7 @@
       {
         "name": "price",
         "type": {
-          "type_name": "decimal",
+          "type_name": "decimal(10,2)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -877,7 +1016,7 @@
       {
         "name": "product_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -890,7 +1029,7 @@
       {
         "name": "stock_quantity",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": {
@@ -940,7 +1079,7 @@
       {
         "name": "Id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1096,7 +1235,7 @@
       {
         "name": "id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1124,7 +1263,7 @@
       {
         "name": "age_end",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1137,7 +1276,7 @@
       {
         "name": "age_start",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1163,7 +1302,7 @@
       {
         "name": "height",
         "type": {
-          "type_name": "float",
+          "type_name": "float(53)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1176,7 +1315,7 @@
       {
         "name": "id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1202,7 +1341,7 @@
       {
         "name": "weight",
         "type": {
-          "type_name": "float",
+          "type_name": "float(53)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1353,7 +1492,7 @@
       {
         "name": "user_id",
         "type": {
-          "type_name": "int",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1654,6 +1793,11 @@
       }
     },
     "dbo.NumberTypes": {
+      "ID": {
+        "pk": true
+      }
+    },
+    "dbo.NumberTypesNoDefault": {
       "ID": {
         "pk": true
       }

--- a/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
@@ -117,7 +117,7 @@
       {
         "name": "AuthorName",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -184,7 +184,7 @@
       {
         "name": "ISBN",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(20)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -210,7 +210,7 @@
       {
         "name": "Title",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(200)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -302,7 +302,7 @@
       {
         "name": "ROWVERSIONCol",
         "type": {
-          "type_name": "timestamp",
+          "type_name": "rowversion",
           "schemaName": null
         },
         "dbdefault": null,
@@ -349,7 +349,7 @@
       {
         "name": "value",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(10)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -655,7 +655,7 @@
       {
         "name": "BinaryField",
         "type": {
-          "type_name": "binary",
+          "type_name": "binary(50)",
           "schemaName": null
         },
         "dbdefault": {
@@ -700,7 +700,7 @@
       {
         "name": "JsonField",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(MAX)",
           "schemaName": null
         },
         "dbdefault": {
@@ -716,7 +716,7 @@
       {
         "name": "VarBinaryField",
         "type": {
-          "type_name": "varbinary",
+          "type_name": "varbinary(50)",
           "schemaName": null
         },
         "dbdefault": {
@@ -732,7 +732,7 @@
       {
         "name": "VarBinaryMaxField",
         "type": {
-          "type_name": "varbinary",
+          "type_name": "varbinary(MAX)",
           "schemaName": null
         },
         "dbdefault": {
@@ -932,7 +932,7 @@
       {
         "name": "category",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -990,7 +990,7 @@
       {
         "name": "name",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1092,7 +1092,7 @@
       {
         "name": "NCharField",
         "type": {
-          "type_name": "nchar",
+          "type_name": "nchar(10)",
           "schemaName": null
         },
         "dbdefault": {
@@ -1124,7 +1124,7 @@
       {
         "name": "NVarCharField",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(50)",
           "schemaName": null
         },
         "dbdefault": {
@@ -1140,7 +1140,7 @@
       {
         "name": "NVarCharMaxField",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(MAX)",
           "schemaName": null
         },
         "dbdefault": {
@@ -1156,7 +1156,7 @@
       {
         "name": "TextField",
         "type": {
-          "type_name": "text(16)",
+          "type_name": "text",
           "schemaName": null
         },
         "dbdefault": {
@@ -1188,7 +1188,7 @@
       {
         "name": "VarcharMaxField",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(MAX)",
           "schemaName": null
         },
         "dbdefault": {
@@ -1248,7 +1248,7 @@
       {
         "name": "name",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1328,7 +1328,7 @@
       {
         "name": "name",
         "type": {
-          "type_name": "nvarchar",
+          "type_name": "nvarchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1385,7 +1385,7 @@
       {
         "name": "email",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1398,7 +1398,7 @@
       {
         "name": "first_name",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1411,7 +1411,7 @@
       {
         "name": "full_name",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1424,7 +1424,7 @@
       {
         "name": "full_name_lower",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1466,7 +1466,7 @@
       {
         "name": "last_name",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1479,7 +1479,7 @@
       {
         "name": "password_hash",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(255)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1505,7 +1505,7 @@
       {
         "name": "username",
         "type": {
-          "type_name": "varchar",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -49,7 +49,7 @@ const getValidatedClient = async (connection: string): Promise<sql.ConnectionPoo
 
 const convertQueryBoolean = (val: string | null): boolean => val === 'YES';
 
-const getFieldType = (data_type: string, default_type: DefaultType, character_maximum_length: number, numeric_precision: number, numeric_scale: number): string => {
+const getFieldType = (data_type: string, character_maximum_length: number, numeric_precision: number, numeric_scale: number): string => {
   if (MSSQL_DATE_TYPES.includes(data_type)) {
     return data_type;
   }
@@ -151,7 +151,7 @@ const generateField = (row: Record<string, any>): Field => {
   const dbdefault = column_default && default_type !== 'increment' ? getDbdefault(data_type, column_default, default_type) : null;
 
   const fieldType = {
-    type_name: getFieldType(data_type, default_type, character_maximum_length, numeric_precision, numeric_scale),
+    type_name: getFieldType(data_type, character_maximum_length, numeric_precision, numeric_scale),
     schemaName: null,
   };
 

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -16,6 +16,7 @@ import {
   TableConstraintsDictionary,
 } from './types';
 
+// https://learn.microsoft.com/en-us/sql/t-sql/data-types/date-and-time-types?view=sql-server-ver15
 const MSSQL_DATE_TYPES = [
   'date',
   'datetime',

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -56,9 +56,14 @@ const getFieldType = (data_type: string, default_type: DefaultType, character_ma
   if (data_type === 'bit') {
     return data_type;
   }
-  if (numeric_precision && numeric_scale && default_type === 'number') {
-    return `${data_type}(${numeric_precision},${numeric_scale})`;
+
+  // if precision != 0 => numeric-based column and its precision is defined
+  if (numeric_precision) {
+    return numeric_scale
+      ? `${data_type}(${numeric_precision},${numeric_scale})`
+      : `${data_type}(${numeric_precision})`;
   }
+
   if (character_maximum_length && character_maximum_length > 0 && default_type === 'string') {
     return `${data_type}(${character_maximum_length})`;
   }

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -85,6 +85,7 @@ const getFieldType = (data_type: string, character_maximum_length: number, numer
   // character_maximum_length is the lenght in bytes
   // nchar and nvarchar store Unicode characters, each character needs 2 bytes
   // so we have to divide it by 2 to get the correct maximum lenght in character.
+  // ref: https://learn.microsoft.com/en-us/sql/t-sql/data-types/nchar-and-nvarchar-transact-sql?view=sql-server-ver15
   if (character_maximum_length > 0) {
     const maximum_length_in_character = (data_type === 'nchar' || data_type === 'nvarchar')
       ? character_maximum_length / 2

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -54,14 +54,13 @@ const getFieldType = (data_type: string, character_maximum_length: number, numer
     return data_type;
   }
 
-  // timestamp is a synonym of rowversion
-  // microsoft recommends that we should not use timestamp, so we will convert it back to rowversion
+  // timestamp is a synonym of rowversion and we cannot specify the precision for it
   // https://learn.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver15
   if (data_type === 'timestamp') {
-    return 'rowversion';
+    return data_type;
   }
 
-  // process numeric -based type
+  // process numeric-based type
   if (data_type === 'bit') {
     return data_type;
   }


### PR DESCRIPTION
## Summary
- Fetch numeric precision and scale for numeric-based column
- Fetch character max length for string-based column

## Issue
https://github.com/holistics/dbml/issues/644

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [x] Code Review