### PR TITLE
Connector - Keep table ordinal position

### DIFF
--- a/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
@@ -12,69 +12,122 @@ Enum "dbo"."chk_gender" {
   "Male"
 }
 
-Table "dbo"."Authors" {
-  "AuthorID" int(10) [pk, not null]
-  "AuthorName" nvarchar(100) [unique]
-  "BirthYear" int(10) [unique]
-  "NationalityID" int(10) [pk, not null]
+Table "dbo"."users" {
+  "user_id" int(10) [pk, not null, increment]
+  "username" varchar(50) [unique, not null]
+  "email" varchar(100) [unique, not null]
+  "password_hash" varchar(255) [not null]
+  "first_name" varchar(50)
+  "last_name" varchar(50)
+  "full_name" varchar(100)
+  "full_name_lower" varchar(100)
+  "date_of_birth" date
+  "created_at" datetime2 [default: `getdate()`]
+  "last_login" datetime2
+  "is_active" bit [default: 1]
+
+  Indexes {
+    email [type: nonclustered, name: "idx_users_email"]
+    full_name [type: nonclustered, name: "idx_users_full_name"]
+    (is_active, full_name_lower) [type: nonclustered, name: "idx_users_is_active_full_name"]
+  }
 }
 
-Table "dbo"."Books" {
-  "AuthorID" int(10) [pk, not null]
-  "BookID" int(10) [pk, not null]
-  "ISBN" nvarchar(20) [unique]
-  "NationalityID" int(10)
-  "Title" nvarchar(200)
+Table "dbo"."products" {
+  "product_id" int(10) [pk, not null, increment]
+  "name" varchar(100) [not null]
+  "description" text
+  "price" decimal(10,2) [not null]
+  "stock_quantity" int(10) [not null, default: 0]
+  "category" varchar(50)
+  "created_at" datetime2 [default: `getdate()`]
+  "updated_at" datetime2 [default: `getdate()`]
+  "is_available" bit [default: 1]
+
+  Indexes {
+    category [type: nonclustered, name: "idx_products_category"]
+  }
 }
 
-Table "dbo"."DatetimeTypes" {
-  "DATECol" date [default: `getdate()`]
-  "DATETIME2Col" datetime2 [default: `sysdatetime()`]
-  "DATETIMECol" datetime [default: `getdate()`]
-  "DATETIMEOFFSETCol" datetimeoffset [default: `sysdatetimeoffset()`]
-  "ID" int(10) [pk, not null, increment]
-  "ROWVERSIONCol" timestamp [not null]
-  "SMALLDATETIMECol" smalldatetime [default: `getdate()`]
-  "TIMECol" time [default: `CONVERT([time],getdate())`]
+Table "dbo"."orders" {
+  "order_id" int(10) [pk, not null, increment]
+  "user_id" int(10) [not null]
+  "order_date" datetime2 [default: `getdate()`]
+  "total_amount" decimal(12,2) [not null]
+  "status" dbo.chk_status [default: 'pending']
+  "shipping_address" text [not null]
+  "billing_address" text [not null]
+
+  Indexes {
+    (user_id, order_date) [type: nonclustered, name: "idx_orders_user_date"]
+  }
 }
 
-Table "dbo"."gender_reference" {
-  "value" nvarchar(10) [pk, not null]
+Table "dbo"."order_items" {
+  "order_item_id" int(10) [pk, not null, increment]
+  "order_id" int(10) [unique, not null]
+  "product_id" int(10) [unique, not null]
+  "quantity" int(10) [not null]
+  "unit_price" decimal(10,2) [not null]
+
+  Indexes {
+    (order_id, product_id) [type: nonclustered, name: "idx_order_items_order_product"]
+  }
+}
+
+Table "dbo"."StringTypes" {
+  "Id" int(10) [pk, not null, increment]
+  "CharField" char(10) [default: 'N/A']
+  "VarcharField" varchar(50) [default: '{"default_key": "default_value"}']
+  "VarcharMaxField" varchar(MAX) [default: 'N/A']
+  "TextField" text [default: 'N/A']
+  "NCharField" nchar(10) [default: `N'N/A'`]
+  "NVarCharField" nvarchar(50) [default: `N'N/A'`]
+  "NVarCharMaxField" nvarchar(MAX) [default: `N'N/A'`]
+  "NTextField" ntext [default: `N'N/A'`]
 }
 
 Table "dbo"."NumberTypes" {
-  "BIGINTCol" bigint(19) [default: 0]
-  "BITCol" bit [default: 0]
-  "DECIMALCol" decimal(10,2) [default: 0.00]
-  "FLOATCol" float(53) [default: 0.0]
   "ID" int(10) [pk, not null, increment]
-  "INTCol" int(10) [default: 0]
-  "NUMERICCol" numeric(10,2) [default: 0.00]
-  "REALCol" real(24) [default: 0.0]
-  "SMALLINTCol" smallint(5) [default: 0]
   "TINYINTCol" tinyint(3) [default: 0]
+  "SMALLINTCol" smallint(5) [default: 0]
+  "INTCol" int(10) [default: 0]
+  "BIGINTCol" bigint(19) [default: 0]
+  "DECIMALCol" decimal(10,2) [default: 0.00]
+  "NUMERICCol" numeric(10,2) [default: 0.00]
+  "FLOATCol" float(53) [default: 0.0]
+  "REALCol" real(24) [default: 0.0]
+  "BITCol" bit [default: 0]
 }
 
 Table "dbo"."NumberTypesNoDefault" {
-  "BIGINTCol" bigint(19)
-  "BITCol" bit
-  "DECIMALCol" decimal(10,2)
-  "FLOATCol" float(53)
   "ID" int(10) [pk, not null, increment]
-  "INTCol" int(10)
-  "NUMERICCol" numeric(10,2)
-  "REALCol" real(24)
-  "SMALLINTCol" smallint(5)
   "TINYINTCol" tinyint(3)
+  "SMALLINTCol" smallint(5)
+  "INTCol" int(10)
+  "BIGINTCol" bigint(19)
+  "DECIMALCol" decimal(10,2)
+  "NUMERICCol" numeric(10,2)
+  "FLOATCol" float(53)
+  "REALCol" real(24)
+  "BITCol" bit
+}
+
+Table "dbo"."DatetimeTypes" {
+  "ID" int(10) [pk, not null, increment]
+  "DATECol" date [default: `getdate()`]
+  "TIMECol" time [default: `CONVERT([time],getdate())`]
+  "DATETIMECol" datetime [default: `getdate()`]
+  "DATETIME2Col" datetime2 [default: `sysdatetime()`]
+  "SMALLDATETIMECol" smalldatetime [default: `getdate()`]
+  "ROWVERSIONCol" timestamp [not null]
+  "DATETIMEOFFSETCol" datetimeoffset [default: `sysdatetimeoffset()`]
+  "DATETIME2Col_2" datetime2 [default: `sysdatetime()`]
+  "DATETIMEOFFSETCol_2" datetimeoffset [default: `sysdatetimeoffset()`]
 }
 
 Table "dbo"."ObjectTypes" {
-  "BinaryField" binary(50) [default: `0x00`]
   "Id" int(10) [pk, not null, increment]
-  "ImageField" image [default: `0x00`]
-  "JsonField" nvarchar(MAX) [default: `N'{"defaultKey": "defaultValue", "status": "active", "count": 0}'`]
-  "VarBinaryField" varbinary(50) [default: `0x00`]
-  "VarBinaryMaxField" varbinary(MAX) [default: `0x00`]
   "XmlField" xml [default: '''<Books>
     <Book>
       <Title>The Great Gatsby</Title>
@@ -97,99 +150,48 @@ Table "dbo"."ObjectTypes" {
       <Subgenre>Political Fiction</Subgenre>
     </Book>
   </Books>''']
+  "JsonField" nvarchar(MAX) [default: `N'{"defaultKey": "defaultValue", "status": "active", "count": 0}'`]
+  "BinaryField" binary(50) [default: `0x00`]
+  "VarBinaryField" varbinary(50) [default: `0x00`]
+  "VarBinaryMaxField" varbinary(MAX) [default: `0x00`]
+  "ImageField" image [default: `0x00`]
 }
 
-Table "dbo"."order_items" {
-  "order_id" int(10) [unique, not null]
-  "order_item_id" int(10) [pk, not null, increment]
-  "product_id" int(10) [unique, not null]
-  "quantity" int(10) [not null]
-  "unit_price" decimal(10,2) [not null]
-
-  Indexes {
-    (order_id, product_id) [type: nonclustered, name: "idx_order_items_order_product"]
-  }
-}
-
-Table "dbo"."orders" {
-  "billing_address" text [not null]
-  "order_date" datetime2 [default: `getdate()`]
-  "order_id" int(10) [pk, not null, increment]
-  "shipping_address" text [not null]
-  "status" dbo.chk_status [default: 'pending']
-  "total_amount" decimal(12,2) [not null]
-  "user_id" int(10) [not null]
-
-  Indexes {
-    (user_id, order_date) [type: nonclustered, name: "idx_orders_user_date"]
-  }
-}
-
-Table "dbo"."products" {
-  "category" varchar(50)
-  "created_at" datetime2 [default: `getdate()`]
-  "description" text
-  "is_available" bit [default: 1]
-  "name" varchar(100) [not null]
-  "price" decimal(10,2) [not null]
-  "product_id" int(10) [pk, not null, increment]
-  "stock_quantity" int(10) [not null, default: 0]
-  "updated_at" datetime2 [default: `getdate()`]
-
-  Indexes {
-    category [type: nonclustered, name: "idx_products_category"]
-  }
-}
-
-Table "dbo"."StringTypes" {
-  "CharField" char(10) [default: 'N/A']
-  "Id" int(10) [pk, not null, increment]
-  "NCharField" nchar(10) [default: `N'N/A'`]
-  "NTextField" ntext [default: `N'N/A'`]
-  "NVarCharField" nvarchar(50) [default: `N'N/A'`]
-  "NVarCharMaxField" nvarchar(MAX) [default: `N'N/A'`]
-  "TextField" text [default: 'N/A']
-  "VarcharField" varchar(50) [default: '{"default_key": "default_value"}']
-  "VarcharMaxField" varchar(MAX) [default: 'N/A']
-}
-
-Table "dbo"."table_with_comments" {
-  "created_at" datetime2 [default: `getdate()`, note: 'Timestamp when the item was created.']
-  "description" text [note: '''Item\'s description''']
-  "id" int(10) [pk, not null, increment, note: 'Unique identifier for each item.']
-  "name" varchar(100) [note: 'Name of the item.']
-  Note: 'This table stores information about various items.'
+Table "dbo"."gender_reference" {
+  "value" nvarchar(10) [pk, not null]
 }
 
 Table "dbo"."user_define_data_types" {
-  "age_end" int(10)
-  "age_start" int(10)
-  "gender" dbo.chk_gender
-  "height" float(53)
   "id" int(10) [pk, not null, increment]
   "name" nvarchar(50)
+  "gender" dbo.chk_gender
+  "age_start" int(10)
+  "age_end" int(10)
+  "height" float(53)
   "weight" float(53)
 }
 
-Table "dbo"."users" {
-  "created_at" datetime2 [default: `getdate()`]
-  "date_of_birth" date
-  "email" varchar(100) [unique, not null]
-  "first_name" varchar(50)
-  "full_name" varchar(100)
-  "full_name_lower" varchar(100)
-  "is_active" bit [default: 1]
-  "last_login" datetime2
-  "last_name" varchar(50)
-  "password_hash" varchar(255) [not null]
-  "user_id" int(10) [pk, not null, increment]
-  "username" varchar(50) [unique, not null]
+Table "dbo"."table_with_comments" {
+  "id" int(10) [pk, not null, increment, note: 'Unique identifier for each item.']
+  "name" varchar(100) [note: 'Name of the item.']
+  "description" text [note: '''Item\'s description''']
+  "created_at" datetime2 [default: `getdate()`, note: 'Timestamp when the item was created.']
+  Note: 'This table stores information about various items.'
+}
 
-  Indexes {
-    email [type: nonclustered, name: "idx_users_email"]
-    full_name [type: nonclustered, name: "idx_users_full_name"]
-    (is_active, full_name_lower) [type: nonclustered, name: "idx_users_is_active_full_name"]
-  }
+Table "dbo"."Authors" {
+  "AuthorID" int(10) [pk, not null]
+  "NationalityID" int(10) [pk, not null]
+  "AuthorName" nvarchar(100) [unique]
+  "BirthYear" int(10) [unique]
+}
+
+Table "dbo"."Books" {
+  "BookID" int(10) [pk, not null]
+  "AuthorID" int(10) [pk, not null]
+  "NationalityID" int(10)
+  "ISBN" nvarchar(20) [unique]
+  "Title" nvarchar(200)
 }
 
 Ref "FK_AuthorNationality":"dbo"."Authors".("AuthorID", "NationalityID") < "dbo"."Books".("AuthorID", "NationalityID")

--- a/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/mssql/expect-out-files/schema.dbml
@@ -122,8 +122,6 @@ Table "dbo"."DatetimeTypes" {
   "SMALLDATETIMECol" smalldatetime [default: `getdate()`]
   "ROWVERSIONCol" timestamp [not null]
   "DATETIMEOFFSETCol" datetimeoffset [default: `sysdatetimeoffset()`]
-  "DATETIME2Col_2" datetime2 [default: `sysdatetime()`]
-  "DATETIMEOFFSETCol_2" datetimeoffset [default: `sysdatetimeoffset()`]
 }
 
 Table "dbo"."ObjectTypes" {

--- a/packages/dbml-cli/__test__/db2dbml/postgres/expect-out-files/schema.dbml
+++ b/packages/dbml-cli/__test__/db2dbml/postgres/expect-out-files/schema.dbml
@@ -34,6 +34,82 @@ Enum "gender_type" {
   "Other"
 }
 
+Table "users" {
+  "user_id" int4 [pk, not null, increment]
+  "username" varchar(50) [unique, not null]
+  "email" varchar(100) [unique, not null]
+  "password_hash" varchar(255) [not null]
+  "first_name" varchar(50)
+  "last_name" varchar(50)
+  "full_name" varchar(100)
+  "date_of_birth" date
+  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`]
+  "last_login" timestamptz
+  "is_active" bool [default: true]
+
+  Indexes {
+    full_name [type: btree, name: "User Name"]
+    email [type: btree, name: "idx_users_email"]
+    (is_active, `lower((full_name)::text)`) [type: btree, name: "users_is_active_lower_idx"]
+  }
+}
+
+Table "products" {
+  "product_id" int4 [pk, not null, increment]
+  "name" varchar(100) [not null]
+  "description" text
+  "price" numeric(10,2) [not null]
+  "stock_quantity" int4 [not null, default: 0]
+  "category" varchar(50)
+  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`]
+  "updated_at" timestamptz [default: `CURRENT_TIMESTAMP`]
+  "is_available" bool [default: true]
+
+  Indexes {
+    category [type: btree, name: "idx_products_category"]
+  }
+}
+
+Table "orders" {
+  "order_id" int4 [pk, not null, increment]
+  "user_id" int4 [not null]
+  "order_date" timestamptz [default: `CURRENT_TIMESTAMP`]
+  "total_amount" numeric(12,2) [not null]
+  "status" varchar(20) [default: 'pending']
+  "shipping_address" text [not null]
+  "billing_address" text [not null]
+
+  Indexes {
+    (user_id, order_date) [type: btree, name: "idx_orders_user_date"]
+  }
+}
+
+Table "order_items" {
+  "order_item_id" int4 [pk, not null, increment]
+  "order_id" int4 [not null]
+  "product_id" int4 [not null]
+  "quantity" int4 [not null]
+  "unit_price" numeric(10,2) [not null]
+
+  Indexes {
+    (order_id, product_id) [type: btree, name: "uq_order_product"]
+    (order_id, product_id) [type: btree, name: "idx_order_items_order_product"]
+  }
+}
+
+Table "all_string_types" {
+  "text_col" text [default: 'default_text']
+  "varchar_col" varchar(100) [default: 'default_varchar']
+  "char_col" bpchar(10) [default: 'default_char']
+  "character_varying_col" varchar(50) [default: 'default_character_varying']
+  "character_col" bpchar(5) [default: 'default_character']
+  "name_col" name [default: 'default_name']
+  "bpchar_col" bpchar(15) [default: 'default_bpchar']
+  "text_array_col" "text[]" [default: `ARRAY['default_text1',  'default_text2']`]
+  "json_col" json [default: `{"default_key": "default_value"}`]
+  "jsonb_col" jsonb [default: `{"default_key": "default_value"}`]
+}
+
 Table "all_default_values" {
   "id" int4 [pk, not null, increment]
   "boolean_col" bool [default: true]
@@ -49,17 +125,21 @@ Table "all_default_values" {
   "timestamp_minus_15_minutes" timestamp [default: `(CURRENT_TIMESTAMP - '00:15:00'::interval)`]
 }
 
-Table "all_string_types" {
-  "text_col" text [default: 'default_text']
-  "varchar_col" varchar(100) [default: 'default_varchar']
-  "char_col" bpchar(10) [default: 'default_char']
-  "character_varying_col" varchar(50) [default: 'default_character_varying']
-  "character_col" bpchar(5) [default: 'default_character']
-  "name_col" name [default: 'default_name']
-  "bpchar_col" bpchar(15) [default: 'default_bpchar']
-  "text_array_col" "text[]" [default: `ARRAY['default_text1',  'default_text2']`]
-  "json_col" json [default: `{"default_key": "default_value"}`]
-  "jsonb_col" jsonb [default: `{"default_key": "default_value"}`]
+Table "user_define_data_types" {
+  "id" int4 [pk, not null, increment]
+  "name" varchar(50)
+  "gender" gender_type
+  "age" int4range
+  "height" float8
+  "weight" float8
+}
+
+Table "table_with_comments" {
+  "id" int4 [pk, not null, increment, note: 'Unique identifier for each item.']
+  "name" varchar(100) [note: '''Item\'s name.''']
+  "description" text [note: '''Item\'s description''']
+  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`, note: 'Timestamp when the item was created.']
+  Note: '''This table stores information about various items. Such as: \'id\', \'name\', \'description\''''
 }
 
 Table "authors" {
@@ -81,49 +161,6 @@ Table "books" {
   "title" varchar(200)
 }
 
-Table "order_items" {
-  "order_item_id" int4 [pk, not null, increment]
-  "order_id" int4 [not null]
-  "product_id" int4 [not null]
-  "quantity" int4 [not null]
-  "unit_price" numeric(10,2) [not null]
-
-  Indexes {
-    (order_id, product_id) [type: btree, name: "uq_order_product"]
-    (order_id, product_id) [type: btree, name: "idx_order_items_order_product"]
-  }
-}
-
-Table "orders" {
-  "order_id" int4 [pk, not null, increment]
-  "user_id" int4 [not null]
-  "order_date" timestamptz [default: `CURRENT_TIMESTAMP`]
-  "total_amount" numeric(12,2) [not null]
-  "status" varchar(20) [default: 'pending']
-  "shipping_address" text [not null]
-  "billing_address" text [not null]
-
-  Indexes {
-    (user_id, order_date) [type: btree, name: "idx_orders_user_date"]
-  }
-}
-
-Table "products" {
-  "product_id" int4 [pk, not null, increment]
-  "name" varchar(100) [not null]
-  "description" text
-  "price" numeric(10,2) [not null]
-  "stock_quantity" int4 [not null, default: 0]
-  "category" varchar(50)
-  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`]
-  "updated_at" timestamptz [default: `CURRENT_TIMESTAMP`]
-  "is_available" bool [default: true]
-
-  Indexes {
-    category [type: btree, name: "idx_products_category"]
-  }
-}
-
 Table "table1" {
   "id" int4 [pk, not null, increment]
   "status" enum_type1
@@ -132,43 +169,6 @@ Table "table1" {
 Table "table2" {
   "id" int4 [pk, not null, increment]
   "status" enum_type2
-}
-
-Table "table_with_comments" {
-  "id" int4 [pk, not null, increment, note: 'Unique identifier for each item.']
-  "name" varchar(100) [note: '''Item\'s name.''']
-  "description" text [note: '''Item\'s description''']
-  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`, note: 'Timestamp when the item was created.']
-  Note: '''This table stores information about various items. Such as: \'id\', \'name\', \'description\''''
-}
-
-Table "user_define_data_types" {
-  "id" int4 [pk, not null, increment]
-  "name" varchar(50)
-  "gender" gender_type
-  "age" int4range
-  "height" float8
-  "weight" float8
-}
-
-Table "users" {
-  "user_id" int4 [pk, not null, increment]
-  "username" varchar(50) [unique, not null]
-  "email" varchar(100) [unique, not null]
-  "password_hash" varchar(255) [not null]
-  "first_name" varchar(50)
-  "last_name" varchar(50)
-  "full_name" varchar(100)
-  "date_of_birth" date
-  "created_at" timestamptz [default: `CURRENT_TIMESTAMP`]
-  "last_login" timestamptz
-  "is_active" bool [default: true]
-
-  Indexes {
-    full_name [type: btree, name: "User Name"]
-    email [type: btree, name: "idx_users_email"]
-    (is_active, `lower((full_name)::text)`) [type: btree, name: "users_is_active_lower_idx"]
-  }
 }
 
 Ref "fk_authornationality":"authors".("authorid", "nationalityid") < "books".("authorid", "nationalityid") [delete: cascade]

--- a/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
@@ -1117,38 +1117,6 @@
         "note": {
           "value": ""
         }
-      },
-      {
-        "name": "DATETIME2Col_2",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "sysdatetime()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "DATETIMEOFFSETCol_2",
-        "type": {
-          "type_name": "datetimeoffset",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "sysdatetimeoffset()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
       }
     ],
     "dbo.ObjectTypes": [

--- a/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/mssql/expect-out-files/schema.json
@@ -1,28 +1,35 @@
 {
   "tables": [
     {
-      "name": "Authors",
+      "name": "users",
       "schemaName": "dbo",
       "note": {
         "value": ""
       }
     },
     {
-      "name": "Books",
+      "name": "products",
       "schemaName": "dbo",
       "note": {
         "value": ""
       }
     },
     {
-      "name": "DatetimeTypes",
+      "name": "orders",
       "schemaName": "dbo",
       "note": {
         "value": ""
       }
     },
     {
-      "name": "gender_reference",
+      "name": "order_items",
+      "schemaName": "dbo",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "StringTypes",
       "schemaName": "dbo",
       "note": {
         "value": ""
@@ -43,6 +50,13 @@
       }
     },
     {
+      "name": "DatetimeTypes",
+      "schemaName": "dbo",
+      "note": {
+        "value": ""
+      }
+    },
+    {
       "name": "ObjectTypes",
       "schemaName": "dbo",
       "note": {
@@ -50,28 +64,14 @@
       }
     },
     {
-      "name": "order_items",
+      "name": "gender_reference",
       "schemaName": "dbo",
       "note": {
         "value": ""
       }
     },
     {
-      "name": "orders",
-      "schemaName": "dbo",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "products",
-      "schemaName": "dbo",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "StringTypes",
+      "name": "user_define_data_types",
       "schemaName": "dbo",
       "note": {
         "value": ""
@@ -85,14 +85,14 @@
       }
     },
     {
-      "name": "user_define_data_types",
+      "name": "Authors",
       "schemaName": "dbo",
       "note": {
         "value": ""
       }
     },
     {
-      "name": "users",
+      "name": "Books",
       "schemaName": "dbo",
       "note": {
         "value": ""
@@ -100,11 +100,24 @@
     }
   ],
   "fields": {
-    "dbo.Authors": [
+    "dbo.users": [
       {
-        "name": "AuthorID",
+        "name": "user_id",
         "type": {
           "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "username",
+        "type": {
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -115,50 +128,9 @@
         }
       },
       {
-        "name": "AuthorName",
+        "name": "email",
         "type": {
-          "type_name": "nvarchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "BirthYear",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "NationalityID",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.Books": [
-      {
-        "name": "AuthorID",
-        "type": {
-          "type_name": "int(10)",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -169,9 +141,9 @@
         }
       },
       {
-        "name": "BookID",
+        "name": "password_hash",
         "type": {
-          "type_name": "int(10)",
+          "type_name": "varchar(255)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -182,9 +154,9 @@
         }
       },
       {
-        "name": "ISBN",
+        "name": "first_name",
         "type": {
-          "type_name": "nvarchar(20)",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -195,9 +167,9 @@
         }
       },
       {
-        "name": "NationalityID",
+        "name": "last_name",
         "type": {
-          "type_name": "int(10)",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -208,9 +180,9 @@
         }
       },
       {
-        "name": "Title",
+        "name": "full_name",
         "type": {
-          "type_name": "nvarchar(200)",
+          "type_name": "varchar(100)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -219,19 +191,27 @@
         "note": {
           "value": ""
         }
-      }
-    ],
-    "dbo.DatetimeTypes": [
+      },
       {
-        "name": "DATECol",
+        "name": "full_name_lower",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "date_of_birth",
         "type": {
           "type_name": "date",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "expression",
-          "value": "getdate()"
-        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
@@ -239,14 +219,14 @@
         }
       },
       {
-        "name": "DATETIME2Col",
+        "name": "created_at",
         "type": {
           "type_name": "datetime2",
           "schemaName": null
         },
         "dbdefault": {
           "type": "expression",
-          "value": "sysdatetime()"
+          "value": "getdate()"
         },
         "not_null": false,
         "increment": false,
@@ -255,9 +235,121 @@
         }
       },
       {
-        "name": "DATETIMECol",
+        "name": "last_login",
         "type": {
-          "type_name": "datetime",
+          "type_name": "datetime2",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "is_active",
+        "type": {
+          "type_name": "bit",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "1"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.products": [
+      {
+        "name": "product_id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "name",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "description",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "price",
+        "type": {
+          "type_name": "decimal(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "stock_quantity",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "category",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "created_at",
+        "type": {
+          "type_name": "datetime2",
           "schemaName": null
         },
         "dbdefault": {
@@ -271,51 +363,9 @@
         }
       },
       {
-        "name": "DATETIMEOFFSETCol",
+        "name": "updated_at",
         "type": {
-          "type_name": "datetimeoffset",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "sysdatetimeoffset()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "ID",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "ROWVERSIONCol",
-        "type": {
-          "type_name": "timestamp",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "SMALLDATETIMECol",
-        "type": {
-          "type_name": "smalldatetime",
+          "type_name": "datetime2",
           "schemaName": null
         },
         "dbdefault": {
@@ -329,188 +379,14 @@
         }
       },
       {
-        "name": "TIMECol",
-        "type": {
-          "type_name": "time",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CONVERT([time],getdate())"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.gender_reference": [
-      {
-        "name": "value",
-        "type": {
-          "type_name": "nvarchar(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.NumberTypes": [
-      {
-        "name": "BIGINTCol",
-        "type": {
-          "type_name": "bigint(19)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "BITCol",
+        "name": "is_available",
         "type": {
           "type_name": "bit",
           "schemaName": null
         },
         "dbdefault": {
           "type": "number",
-          "value": "0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "DECIMALCol",
-        "type": {
-          "type_name": "decimal(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0.00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "FLOATCol",
-        "type": {
-          "type_name": "float(53)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0.0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "ID",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "INTCol",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "NUMERICCol",
-        "type": {
-          "type_name": "numeric(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0.00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "REALCol",
-        "type": {
-          "type_name": "real(24)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0.0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "SMALLINTCol",
-        "type": {
-          "type_name": "smallint(5)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "TINYINTCol",
-        "type": {
-          "type_name": "tinyint(3)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
+          "value": "1"
         },
         "not_null": false,
         "increment": false,
@@ -519,250 +395,7 @@
         }
       }
     ],
-    "dbo.NumberTypesNoDefault": [
-      {
-        "name": "BIGINTCol",
-        "type": {
-          "type_name": "bigint(19)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "BITCol",
-        "type": {
-          "type_name": "bit",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "DECIMALCol",
-        "type": {
-          "type_name": "decimal(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "FLOATCol",
-        "type": {
-          "type_name": "float(53)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "ID",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "INTCol",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "NUMERICCol",
-        "type": {
-          "type_name": "numeric(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "REALCol",
-        "type": {
-          "type_name": "real(24)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "SMALLINTCol",
-        "type": {
-          "type_name": "smallint(5)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "TINYINTCol",
-        "type": {
-          "type_name": "tinyint(3)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.ObjectTypes": [
-      {
-        "name": "BinaryField",
-        "type": {
-          "type_name": "binary(50)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "0x00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "Id",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "ImageField",
-        "type": {
-          "type_name": "image",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "0x00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "JsonField",
-        "type": {
-          "type_name": "nvarchar(MAX)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "N'{\"defaultKey\": \"defaultValue\", \"status\": \"active\", \"count\": 0}'"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "VarBinaryField",
-        "type": {
-          "type_name": "varbinary(50)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "0x00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "VarBinaryMaxField",
-        "type": {
-          "type_name": "varbinary(MAX)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "0x00"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "XmlField",
-        "type": {
-          "type_name": "xml",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "<Books>\r\n    <Book>\r\n      <Title>The Great Gatsby</Title>\r\n      <Author>F. Scott Fitzgerald</Author>\r\n      <Year>1925</Year>\r\n      <Price>10.99</Price>\r\n      <Publisher>Scribner</Publisher>\r\n      <Location>New York</Location>\r\n      <Genre>Fiction</Genre>\r\n      <Subgenre>Classic</Subgenre>\r\n    </Book>\r\n    <Book>\r\n      <Title>1984</Title>\r\n      <Author>George Orwell</Author>\r\n      <Year>1949</Year>\r\n      <Price>8.99</Price>\r\n      <Publisher>Secker & Warburg</Publisher>\r\n      <Location>London</Location>\r\n      <Genre>Dystopian</Genre>\r\n      <Subgenre>Political Fiction</Subgenre>\r\n    </Book>\r\n  </Books>"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.order_items": [
+    "dbo.orders": [
       {
         "name": "order_id",
         "type": {
@@ -771,11 +404,97 @@
         },
         "dbdefault": null,
         "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "user_id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
         "increment": false,
         "note": {
           "value": ""
         }
       },
+      {
+        "name": "order_date",
+        "type": {
+          "type_name": "datetime2",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "getdate()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "total_amount",
+        "type": {
+          "type_name": "decimal(12,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "chk_status",
+          "schemaName": "dbo"
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "pending"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "shipping_address",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "billing_address",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.order_items": [
       {
         "name": "order_item_id",
         "type": {
@@ -785,6 +504,19 @@
         "dbdefault": null,
         "not_null": true,
         "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "order_id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
         "note": {
           "value": ""
         }
@@ -829,237 +561,20 @@
         }
       }
     ],
-    "dbo.orders": [
-      {
-        "name": "billing_address",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "order_date",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "getdate()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "order_id",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "shipping_address",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "status",
-        "type": {
-          "type_name": "chk_status",
-          "schemaName": "dbo"
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "pending"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "total_amount",
-        "type": {
-          "type_name": "decimal(12,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "user_id",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "dbo.products": [
-      {
-        "name": "category",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "created_at",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "getdate()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "description",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "is_available",
-        "type": {
-          "type_name": "bit",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "1"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "name",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "price",
-        "type": {
-          "type_name": "decimal(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "product_id",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "stock_quantity",
-        "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
-        },
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "updated_at",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "getdate()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
     "dbo.StringTypes": [
+      {
+        "name": "Id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
       {
         "name": "CharField",
         "type": {
@@ -1077,27 +592,14 @@
         }
       },
       {
-        "name": "Id",
+        "name": "VarcharField",
         "type": {
-          "type_name": "int(10)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "NCharField",
-        "type": {
-          "type_name": "nchar(10)",
+          "type_name": "varchar(50)",
           "schemaName": null
         },
         "dbdefault": {
-          "type": "expression",
-          "value": "N'N/A'"
+          "type": "string",
+          "value": "{\"default_key\": \"default_value\"}"
         },
         "not_null": false,
         "increment": false,
@@ -1106,9 +608,41 @@
         }
       },
       {
-        "name": "NTextField",
+        "name": "VarcharMaxField",
         "type": {
-          "type_name": "ntext",
+          "type_name": "varchar(MAX)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "N/A"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "TextField",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "N/A"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "NCharField",
+        "type": {
+          "type_name": "nchar(10)",
           "schemaName": null
         },
         "dbdefault": {
@@ -1154,46 +688,14 @@
         }
       },
       {
-        "name": "TextField",
+        "name": "NTextField",
         "type": {
-          "type_name": "text",
+          "type_name": "ntext",
           "schemaName": null
         },
         "dbdefault": {
-          "type": "string",
-          "value": "N/A"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "VarcharField",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "{\"default_key\": \"default_value\"}"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "VarcharMaxField",
-        "type": {
-          "type_name": "varchar(MAX)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "N/A"
+          "type": "expression",
+          "value": "N'N/A'"
         },
         "not_null": false,
         "increment": false,
@@ -1202,38 +704,9 @@
         }
       }
     ],
-    "dbo.table_with_comments": [
+    "dbo.NumberTypes": [
       {
-        "name": "created_at",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "getdate()"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": "Timestamp when the item was created."
-        }
-      },
-      {
-        "name": "description",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": "Item's description"
-        }
-      },
-      {
-        "name": "id",
+        "name": "ID",
         "type": {
           "type_name": "int(10)",
           "schemaName": null
@@ -1242,26 +715,196 @@
         "not_null": true,
         "increment": true,
         "note": {
-          "value": "Unique identifier for each item."
+          "value": ""
         }
       },
       {
-        "name": "name",
+        "name": "TINYINTCol",
         "type": {
-          "type_name": "varchar(100)",
+          "type_name": "tinyint(3)",
           "schemaName": null
         },
-        "dbdefault": null,
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
         "not_null": false,
         "increment": false,
         "note": {
-          "value": "Name of the item."
+          "value": ""
+        }
+      },
+      {
+        "name": "SMALLINTCol",
+        "type": {
+          "type_name": "smallint(5)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "INTCol",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BIGINTCol",
+        "type": {
+          "type_name": "bigint(19)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DECIMALCol",
+        "type": {
+          "type_name": "decimal(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0.00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "NUMERICCol",
+        "type": {
+          "type_name": "numeric(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0.00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "FLOATCol",
+        "type": {
+          "type_name": "float(53)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0.0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "REALCol",
+        "type": {
+          "type_name": "real(24)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0.0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BITCol",
+        "type": {
+          "type_name": "bit",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
         }
       }
     ],
-    "dbo.user_define_data_types": [
+    "dbo.NumberTypesNoDefault": [
       {
-        "name": "age_end",
+        "name": "ID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "TINYINTCol",
+        "type": {
+          "type_name": "tinyint(3)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "SMALLINTCol",
+        "type": {
+          "type_name": "smallint(5)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "INTCol",
         "type": {
           "type_name": "int(10)",
           "schemaName": null
@@ -1274,9 +917,9 @@
         }
       },
       {
-        "name": "age_start",
+        "name": "BIGINTCol",
         "type": {
-          "type_name": "int(10)",
+          "type_name": "bigint(19)",
           "schemaName": null
         },
         "dbdefault": null,
@@ -1287,10 +930,10 @@
         }
       },
       {
-        "name": "gender",
+        "name": "DECIMALCol",
         "type": {
-          "type_name": "chk_gender",
-          "schemaName": "dbo"
+          "type_name": "decimal(10,2)",
+          "schemaName": null
         },
         "dbdefault": null,
         "not_null": false,
@@ -1300,7 +943,20 @@
         }
       },
       {
-        "name": "height",
+        "name": "NUMERICCol",
+        "type": {
+          "type_name": "numeric(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "FLOATCol",
         "type": {
           "type_name": "float(53)",
           "schemaName": null
@@ -1312,6 +968,316 @@
           "value": ""
         }
       },
+      {
+        "name": "REALCol",
+        "type": {
+          "type_name": "real(24)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BITCol",
+        "type": {
+          "type_name": "bit",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.DatetimeTypes": [
+      {
+        "name": "ID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATECol",
+        "type": {
+          "type_name": "date",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "getdate()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "TIMECol",
+        "type": {
+          "type_name": "time",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "CONVERT([time],getdate())"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATETIMECol",
+        "type": {
+          "type_name": "datetime",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "getdate()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATETIME2Col",
+        "type": {
+          "type_name": "datetime2",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "sysdatetime()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "SMALLDATETIMECol",
+        "type": {
+          "type_name": "smalldatetime",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "getdate()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "ROWVERSIONCol",
+        "type": {
+          "type_name": "timestamp",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATETIMEOFFSETCol",
+        "type": {
+          "type_name": "datetimeoffset",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "sysdatetimeoffset()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATETIME2Col_2",
+        "type": {
+          "type_name": "datetime2",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "sysdatetime()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "DATETIMEOFFSETCol_2",
+        "type": {
+          "type_name": "datetimeoffset",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "sysdatetimeoffset()"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.ObjectTypes": [
+      {
+        "name": "Id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "XmlField",
+        "type": {
+          "type_name": "xml",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "<Books>\r\n    <Book>\r\n      <Title>The Great Gatsby</Title>\r\n      <Author>F. Scott Fitzgerald</Author>\r\n      <Year>1925</Year>\r\n      <Price>10.99</Price>\r\n      <Publisher>Scribner</Publisher>\r\n      <Location>New York</Location>\r\n      <Genre>Fiction</Genre>\r\n      <Subgenre>Classic</Subgenre>\r\n    </Book>\r\n    <Book>\r\n      <Title>1984</Title>\r\n      <Author>George Orwell</Author>\r\n      <Year>1949</Year>\r\n      <Price>8.99</Price>\r\n      <Publisher>Secker & Warburg</Publisher>\r\n      <Location>London</Location>\r\n      <Genre>Dystopian</Genre>\r\n      <Subgenre>Political Fiction</Subgenre>\r\n    </Book>\r\n  </Books>"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "JsonField",
+        "type": {
+          "type_name": "nvarchar(MAX)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "N'{\"defaultKey\": \"defaultValue\", \"status\": \"active\", \"count\": 0}'"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BinaryField",
+        "type": {
+          "type_name": "binary(50)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "0x00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "VarBinaryField",
+        "type": {
+          "type_name": "varbinary(50)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "0x00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "VarBinaryMaxField",
+        "type": {
+          "type_name": "varbinary(MAX)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "0x00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "ImageField",
+        "type": {
+          "type_name": "image",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "0x00"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.gender_reference": [
+      {
+        "name": "value",
+        "type": {
+          "type_name": "nvarchar(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.user_define_data_types": [
       {
         "name": "id",
         "type": {
@@ -1339,6 +1305,58 @@
         }
       },
       {
+        "name": "gender",
+        "type": {
+          "type_name": "chk_gender",
+          "schemaName": "dbo"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "age_start",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "age_end",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "height",
+        "type": {
+          "type_name": "float(53)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
         "name": "weight",
         "type": {
           "type_name": "float(53)",
@@ -1352,7 +1370,46 @@
         }
       }
     ],
-    "dbo.users": [
+    "dbo.table_with_comments": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": "Unique identifier for each item."
+        }
+      },
+      {
+        "name": "name",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": "Name of the item."
+        }
+      },
+      {
+        "name": "description",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": "Item's description"
+        }
+      },
       {
         "name": "created_at",
         "type": {
@@ -1366,150 +1423,125 @@
         "not_null": false,
         "increment": false,
         "note": {
-          "value": ""
+          "value": "Timestamp when the item was created."
         }
-      },
+      }
+    ],
+    "dbo.Authors": [
       {
-        "name": "date_of_birth",
-        "type": {
-          "type_name": "date",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "email",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "first_name",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "full_name",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "full_name_lower",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "is_active",
-        "type": {
-          "type_name": "bit",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "1"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "last_login",
-        "type": {
-          "type_name": "datetime2",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "last_name",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "password_hash",
-        "type": {
-          "type_name": "varchar(255)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "user_id",
+        "name": "AuthorID",
         "type": {
           "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
         "not_null": true,
-        "increment": true,
+        "increment": false,
         "note": {
           "value": ""
         }
       },
       {
-        "name": "username",
+        "name": "NationalityID",
         "type": {
-          "type_name": "varchar(50)",
+          "type_name": "int(10)",
           "schemaName": null
         },
         "dbdefault": null,
         "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "AuthorName",
+        "type": {
+          "type_name": "nvarchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "BirthYear",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "dbo.Books": [
+      {
+        "name": "BookID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "AuthorID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "NationalityID",
+        "type": {
+          "type_name": "int(10)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "ISBN",
+        "type": {
+          "type_name": "nvarchar(20)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "Title",
+        "type": {
+          "type_name": "nvarchar(200)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
         "increment": false,
         "note": {
           "value": ""

--- a/packages/dbml-connector/__tests__/connectors/postgres/expect-out-files/schema.json
+++ b/packages/dbml-connector/__tests__/connectors/postgres/expect-out-files/schema.json
@@ -15,7 +15,28 @@
       }
     },
     {
-      "name": "all_default_values",
+      "name": "users",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "products",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "orders",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "order_items",
       "schemaName": "public",
       "note": {
         "value": ""
@@ -26,6 +47,27 @@
       "schemaName": "public",
       "note": {
         "value": ""
+      }
+    },
+    {
+      "name": "all_default_values",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "user_define_data_types",
+      "schemaName": "public",
+      "note": {
+        "value": ""
+      }
+    },
+    {
+      "name": "table_with_comments",
+      "schemaName": "public",
+      "note": {
+        "value": "This table stores information about various items. Such as: 'id', 'name', 'description'"
       }
     },
     {
@@ -43,27 +85,6 @@
       }
     },
     {
-      "name": "order_items",
-      "schemaName": "public",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "orders",
-      "schemaName": "public",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "products",
-      "schemaName": "public",
-      "note": {
-        "value": ""
-      }
-    },
-    {
       "name": "table1",
       "schemaName": "public",
       "note": {
@@ -72,27 +93,6 @@
     },
     {
       "name": "table2",
-      "schemaName": "public",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "table_with_comments",
-      "schemaName": "public",
-      "note": {
-        "value": "This table stores information about various items. Such as: 'id', 'name', 'description'"
-      }
-    },
-    {
-      "name": "user_define_data_types",
-      "schemaName": "public",
-      "note": {
-        "value": ""
-      }
-    },
-    {
-      "name": "users",
       "schemaName": "public",
       "note": {
         "value": ""
@@ -149,6 +149,616 @@
           "schemaName": "dbml_test"
         },
         "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.users": [
+      {
+        "name": "user_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "username",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "email",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "password_hash",
+        "type": {
+          "type_name": "varchar(255)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "first_name",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "last_name",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "full_name",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "date_of_birth",
+        "type": {
+          "type_name": "date",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "created_at",
+        "type": {
+          "type_name": "timestamptz",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "CURRENT_TIMESTAMP"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "last_login",
+        "type": {
+          "type_name": "timestamptz",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "is_active",
+        "type": {
+          "type_name": "bool",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "boolean",
+          "value": "true"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.products": [
+      {
+        "name": "product_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "name",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "description",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "price",
+        "type": {
+          "type_name": "numeric(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "stock_quantity",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "number",
+          "value": "0"
+        },
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "category",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "created_at",
+        "type": {
+          "type_name": "timestamptz",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "CURRENT_TIMESTAMP"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "updated_at",
+        "type": {
+          "type_name": "timestamptz",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "CURRENT_TIMESTAMP"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "is_available",
+        "type": {
+          "type_name": "bool",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "boolean",
+          "value": "true"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.orders": [
+      {
+        "name": "order_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "user_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "order_date",
+        "type": {
+          "type_name": "timestamptz",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "CURRENT_TIMESTAMP"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "total_amount",
+        "type": {
+          "type_name": "numeric(12,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "status",
+        "type": {
+          "type_name": "varchar(20)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "pending"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "shipping_address",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "billing_address",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.order_items": [
+      {
+        "name": "order_item_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "order_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "product_id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "quantity",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "unit_price",
+        "type": {
+          "type_name": "numeric(10,2)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      }
+    ],
+    "public.all_string_types": [
+      {
+        "name": "text_col",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_text"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "varchar_col",
+        "type": {
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_varchar"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "char_col",
+        "type": {
+          "type_name": "bpchar(10)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_char"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "character_varying_col",
+        "type": {
+          "type_name": "varchar(50)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_character_varying"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "character_col",
+        "type": {
+          "type_name": "bpchar(5)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_character"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "name_col",
+        "type": {
+          "type_name": "name",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_name"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "bpchar_col",
+        "type": {
+          "type_name": "bpchar(15)",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "string",
+          "value": "default_bpchar"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "text_array_col",
+        "type": {
+          "type_name": "text[]",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "ARRAY['default_text1',  'default_text2']"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "json_col",
+        "type": {
+          "type_name": "json",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "{\"default_key\": \"default_value\"}"
+        },
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "jsonb_col",
+        "type": {
+          "type_name": "jsonb",
+          "schemaName": null
+        },
+        "dbdefault": {
+          "type": "expression",
+          "value": "{\"default_key\": \"default_value\"}"
+        },
         "not_null": false,
         "increment": false,
         "note": {
@@ -347,65 +957,27 @@
         }
       }
     ],
-    "public.all_string_types": [
+    "public.user_define_data_types": [
       {
-        "name": "text_col",
+        "name": "id",
         "type": {
-          "type_name": "text",
+          "type_name": "int4",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_text"
-        },
-        "not_null": false,
-        "increment": false,
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
         "note": {
           "value": ""
         }
       },
       {
-        "name": "varchar_col",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_varchar"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "char_col",
-        "type": {
-          "type_name": "bpchar(10)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_char"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "character_varying_col",
+        "name": "name",
         "type": {
           "type_name": "varchar(50)",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_character_varying"
-        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
@@ -413,15 +985,25 @@
         }
       },
       {
-        "name": "character_col",
+        "name": "gender",
         "type": {
-          "type_name": "bpchar(5)",
+          "type_name": "gender_type",
+          "schemaName": "public"
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": ""
+        }
+      },
+      {
+        "name": "age",
+        "type": {
+          "type_name": "int4range",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_character"
-        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
@@ -429,15 +1011,12 @@
         }
       },
       {
-        "name": "name_col",
+        "name": "height",
         "type": {
-          "type_name": "name",
+          "type_name": "float8",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_name"
-        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
@@ -445,67 +1024,73 @@
         }
       },
       {
-        "name": "bpchar_col",
+        "name": "weight",
         "type": {
-          "type_name": "bpchar(15)",
+          "type_name": "float8",
           "schemaName": null
         },
-        "dbdefault": {
-          "type": "string",
-          "value": "default_bpchar"
-        },
+        "dbdefault": null,
         "not_null": false,
         "increment": false,
         "note": {
           "value": ""
         }
+      }
+    ],
+    "public.table_with_comments": [
+      {
+        "name": "id",
+        "type": {
+          "type_name": "int4",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": true,
+        "increment": true,
+        "note": {
+          "value": "Unique identifier for each item."
+        }
       },
       {
-        "name": "text_array_col",
+        "name": "name",
         "type": {
-          "type_name": "text[]",
+          "type_name": "varchar(100)",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": "Item's name."
+        }
+      },
+      {
+        "name": "description",
+        "type": {
+          "type_name": "text",
+          "schemaName": null
+        },
+        "dbdefault": null,
+        "not_null": false,
+        "increment": false,
+        "note": {
+          "value": "Item's description"
+        }
+      },
+      {
+        "name": "created_at",
+        "type": {
+          "type_name": "timestamptz",
           "schemaName": null
         },
         "dbdefault": {
           "type": "expression",
-          "value": "ARRAY['default_text1',  'default_text2']"
+          "value": "CURRENT_TIMESTAMP"
         },
         "not_null": false,
         "increment": false,
         "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "json_col",
-        "type": {
-          "type_name": "json",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "{\"default_key\": \"default_value\"}"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "jsonb_col",
-        "type": {
-          "type_name": "jsonb",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "{\"default_key\": \"default_value\"}"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
+          "value": "Timestamp when the item was created."
         }
       }
     ],
@@ -630,303 +1215,6 @@
         }
       }
     ],
-    "public.order_items": [
-      {
-        "name": "order_item_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "order_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "product_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "quantity",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "unit_price",
-        "type": {
-          "type_name": "numeric(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "public.orders": [
-      {
-        "name": "order_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "user_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "order_date",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CURRENT_TIMESTAMP"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "total_amount",
-        "type": {
-          "type_name": "numeric(12,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "status",
-        "type": {
-          "type_name": "varchar(20)",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "string",
-          "value": "pending"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "shipping_address",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "billing_address",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "public.products": [
-      {
-        "name": "product_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "name",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "description",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "price",
-        "type": {
-          "type_name": "numeric(10,2)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "stock_quantity",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "number",
-          "value": "0"
-        },
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "category",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "created_at",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CURRENT_TIMESTAMP"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "updated_at",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CURRENT_TIMESTAMP"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "is_available",
-        "type": {
-          "type_name": "bool",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "boolean",
-          "value": "true"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
     "public.table1": [
       {
         "name": "id",
@@ -976,294 +1264,6 @@
           "schemaName": "public"
         },
         "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "public.table_with_comments": [
-      {
-        "name": "id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": "Unique identifier for each item."
-        }
-      },
-      {
-        "name": "name",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": "Item's name."
-        }
-      },
-      {
-        "name": "description",
-        "type": {
-          "type_name": "text",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": "Item's description"
-        }
-      },
-      {
-        "name": "created_at",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CURRENT_TIMESTAMP"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": "Timestamp when the item was created."
-        }
-      }
-    ],
-    "public.user_define_data_types": [
-      {
-        "name": "id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "name",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "gender",
-        "type": {
-          "type_name": "gender_type",
-          "schemaName": "public"
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "age",
-        "type": {
-          "type_name": "int4range",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "height",
-        "type": {
-          "type_name": "float8",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "weight",
-        "type": {
-          "type_name": "float8",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      }
-    ],
-    "public.users": [
-      {
-        "name": "user_id",
-        "type": {
-          "type_name": "int4",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": true,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "username",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "email",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "password_hash",
-        "type": {
-          "type_name": "varchar(255)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": true,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "first_name",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "last_name",
-        "type": {
-          "type_name": "varchar(50)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "full_name",
-        "type": {
-          "type_name": "varchar(100)",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "date_of_birth",
-        "type": {
-          "type_name": "date",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "created_at",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "expression",
-          "value": "CURRENT_TIMESTAMP"
-        },
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "last_login",
-        "type": {
-          "type_name": "timestamptz",
-          "schemaName": null
-        },
-        "dbdefault": null,
-        "not_null": false,
-        "increment": false,
-        "note": {
-          "value": ""
-        }
-      },
-      {
-        "name": "is_active",
-        "type": {
-          "type_name": "bool",
-          "schemaName": null
-        },
-        "dbdefault": {
-          "type": "boolean",
-          "value": "true"
-        },
         "not_null": false,
         "increment": false,
         "note": {

--- a/packages/dbml-connector/src/connectors/bigqueryConnector.ts
+++ b/packages/dbml-connector/src/connectors/bigqueryConnector.ts
@@ -137,15 +137,10 @@ async function generateTablesAndFields(
       t.table_schema = c.table_schema
       and t.table_name = c.table_name
     where t.table_type = 'BASE TABLE'
-    order by t.table_name, c.ordinal_position;
+    order by t.create_time, c.ordinal_position;
   `;
 
-  const [queryResult] = await client.query({
-    query,
-    params: {
-      // stringRegex: STRING_REGEX,
-    },
-  });
+  const [queryResult] = await client.query({ query });
 
   const tableMap: Record<string, Table> = {};
   const fieldMap: FieldsDictionary = {};

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -178,7 +178,9 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
       SELECT
         s.name AS table_schema,
         t.name AS table_name,
+        t.create_date as table_create_date,
         c.name AS column_name,
+        c.column_id as column_id,
         ty.name AS data_type,
         c.max_length AS character_maximum_length,
         c.precision AS numeric_precision,
@@ -265,8 +267,8 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
       ${buildSchemaQuery('table_schema', schemas)}
     ORDER BY
       table_schema,
-      table_name,
-      column_name;
+      table_create_date,
+      column_id;
   `;
 
   const tablesAndFieldsResult = await client.query(tablesAndFieldsSql);

--- a/packages/dbml-connector/src/connectors/snowflakeConnector.ts
+++ b/packages/dbml-connector/src/connectors/snowflakeConnector.ts
@@ -212,7 +212,7 @@ const generateTablesAndFields = async (conn: Connection, schemas: string[]): Pro
         ${schemaSql}
     ORDER BY
         c.table_schema,
-        c.table_name,
+        t.created,
         c.ordinal_position;
   `;
 


### PR DESCRIPTION
## Summary
Fix issue: The generated table from connectors cannot keep the ordinal position according to the SQL creation script.
 
## Issue

## Lasting Changes (Technical)

- PostgreSQL: fixed function `generateTablesAndFields`
    - Added CTE to get the table ordinal position using object id from[`pg_class` table](https://www.postgresql.org/docs/14/catalog-pg-class.html)
    - Replaced `order by t.table_name` by `order by t.table_ordinal_position`
- MSSQL: fixed function `generateTablesFieldsAndEnums`
    - Added `select t.create_date as table_create_date` and order by this field
    - Added `select c.column_id as column_id` and order by this field
- MySQL: _cannot fix since there is no appropriate information_
- BigQuery: replaced `order by t.table_name` by `order by t.create_time` in `generateTablesAndFields` function
- Snowflake: replaced `order by t.table_name` by `order by t.created` in `generateTablesAndFields` function

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [X] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [x] Code Review