### PR TITLE
fix: Fixed DbmlExporter and other type Exporters to export DEFAULT co…

### DIFF
--- a/packages/dbml-core/src/export/DbmlExporter.js
+++ b/packages/dbml-core/src/export/DbmlExporter.js
@@ -89,6 +89,7 @@ class DbmlExporter {
             break;
 
           default:
+            value += `\`${field.dbdefault.value}\``;
             break;
         }
         constraints.push(value);


### PR DESCRIPTION
…nsistently

When using dbmlExporter, if field.dbdefault.type is not set, a value of "DEFAULT  <null value>" will appear. However, other Exporters will directly use field.dbdefault.type. I think it needs to be consistent.

## Summary
* Short summary of the task, what have been done etc
* Please include screenshots whenever possible (important).

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review