### PR TITLE
Update type definition for Parser.js

### DIFF
--- a/packages/dbml-core/types/index.d.ts
+++ b/packages/dbml-core/types/index.d.ts
@@ -2,5 +2,5 @@ import ModelExporter from './export/ModelExporter';
 import Parser from './parse/Parser';
 import importer from './import';
 import exporter from './export';
-export { importer, exporter, ModelExporter, Parser, };
-export { CompilerDiagnostic, CompilerError as CompilerDiagnostics, EditorPosition, ErrorCode, WarningLevel, } from './parse/error'
+export { importer, exporter, ModelExporter, Parser };
+export { CompilerDiagnostic, CompilerError as CompilerDiagnostics, EditorPosition, ErrorCode, WarningLevel, } from './parse/error';

--- a/packages/dbml-core/types/parse/Parser.d.ts
+++ b/packages/dbml-core/types/parse/Parser.d.ts
@@ -1,20 +1,33 @@
 import { Compiler } from '@dbml/parse';
 import Database, { RawDatabase } from '../model_structure/database';
+
+declare type ParseFormat = 'json'
+    | 'mysql' | 'mysqlLegacy'
+    | 'postgres' | 'postgresLegacy'
+    | 'dbml' | 'dbmlv2'
+    | 'mssql'
+    | 'schemarb'
+    | 'snowflake';
+
 declare class Parser {
+    public DBMLCompiler: Compiler;
     constructor(dbmlCompiler?: Compiler);
     static parseJSONToDatabase(rawDatabase: RawDatabase): Database;
     static parseMySQLToJSON(str: string): RawDatabase;
+    static parseMySQLToJSONv2(str: string): RawDatabase;
     static parsePostgresToJSON(str: string): RawDatabase;
     static parsePostgresToJSONv2(str: string): RawDatabase;
     static parseDBMLToJSON(str: string): RawDatabase;
+    static parseDBMLToJSONv2(str: string, dbmlCompiler: Compiler): RawDatabase;
     static parseSchemaRbToJSON(str: string): RawDatabase;
     static parseMSSQLToJSON(str: string): RawDatabase;
+    static parseSnowflakeToJSON(str: string): RawDatabase;
     /**
      * Should use parse() instance method instead of this static method whenever possible
      */
-    static parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
+    static parse(str: string, format: ParseFormat): Database;
     static parse(str: RawDatabase, format: 'json'): Database;
-    parse(str: string, format: 'mysql' | 'postgres' | 'dbml' | 'dbmlv2' | 'schemarb' | 'mssql' | 'json'): Database;
+    parse(str: string, format: ParseFormat): Database;
     parse(str: RawDatabase, format: 'json'): Database;
 }
 export default Parser;


### PR DESCRIPTION
## Summary
Update type definition for Parser.js:
- Add missing `parseMySQLToJSONv2`, `parseDBMLToJSONv2` and `parseSnowflakeToJSON` methods
- Add type for `ParseFormat`
- Add the missing `DBMLCompiler` field

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [x] Code Review