### PR TITLE
Fix missing FROM-clause entry for table "t"

### DIFF
--- a/packages/dbml-connector/src/connectors/postgresConnector.ts
+++ b/packages/dbml-connector/src/connectors/postgresConnector.ts
@@ -152,7 +152,7 @@ const generateTablesAndFields = async (client: Client, schemas: string[]): Promi
           -- see https://www.postgresql.org/docs/14/catalog-pg-class.html#:~:text=%3D%20temporary%20table-,relkind,-char
           pc.relkind = 'r'
           AND pn.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
-          ${buildSchemaQuery('t.table_schema', schemas)}
+          ${buildSchemaQuery('pn.nspname', schemas)}
       )
     SELECT
       t.table_schema,


### PR DESCRIPTION
This was likely a copy-paste mistake since the table `information_schema.tables t`
does exist in the next query but is missing from the current one.

This was causing:
```
error: missing FROM-clause entry for table "t"
    at /usr/local/lib/node_modules/@dbml/cli/node_modules/pg/lib/client.js:535:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async generateTablesAndFields (/usr/local/lib/node_modules/@dbml/cli/node_modules/@dbml/connector/dist/connectors/postgresConnector.js:159:35)
    at async Promise.all (index 0)
    at async fetchSchemaJson (/usr/local/lib/node_modules/@dbml/cli/node_modules/@dbml/connector/dist/connectors/postgresConnector.js:420:17)
    at async connectionHandler (/usr/local/lib/node_modules/@dbml/cli/lib/cli/connector.js:24:24)
```
    
when running

`db2dbml postgres 'postgresql://dbml_user:dbml_pass@localhost:5432/dbname?schemas=public'`

with the `schemas` parameter.