### PR TITLE
DBX-5750: Fix an issue where tab characters are not recognized as white-space characters

### DIFF
--- a/packages/dbml-parse/src/lib/lexer/utils.ts
+++ b/packages/dbml-parse/src/lib/lexer/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last } from 'lodash';
 import { SyntaxToken, SyntaxTokenKind } from './tokens';
 
 export function hasTrailingNewLines(token: SyntaxToken): boolean {
@@ -13,13 +13,13 @@ export function isAtStartOfLine(previous: SyntaxToken, token: SyntaxToken): bool
 }
 
 export function hasTrailingSpaces(token: SyntaxToken): boolean {
-  return token.trailingTrivia.find(({ kind }) => kind === SyntaxTokenKind.SPACE) !== undefined;
+  return token.trailingTrivia.find(({ kind }) => [SyntaxTokenKind.SPACE, SyntaxTokenKind.TAB].includes(kind)) !== undefined;
 }
 
 export function getTokenFullEnd(token: SyntaxToken): number {
   return token.trailingTrivia.length === 0 ?
     token.end :
-    getTokenFullEnd(_.last(token.trailingTrivia)!);
+    getTokenFullEnd(last(token.trailingTrivia)!);
 }
 
 export function getTokenFullStart(token: SyntaxToken): number {

--- a/packages/dbml-parse/tests/parser/input/function_application.in.dbml
+++ b/packages/dbml-parse/tests/parser/input/function_application.in.dbml
@@ -1,4 +1,4 @@
 Test FunctionApplication {
-    id integer [primary key]
+    id	integer [primary key]
     name char (255) [unique]
 }

--- a/packages/dbml-parse/tests/parser/output/function_application.out.json
+++ b/packages/dbml-parse/tests/parser/output/function_application.out.json
@@ -9,13 +9,13 @@
     },
     "fullStart": 0,
     "endPos": {
-      "offset": 89,
-      "line": 3,
-      "column": 1
+      "offset": 91,
+      "line": 4,
+      "column": 0
     },
-    "fullEnd": 89,
+    "fullEnd": 91,
     "start": 0,
-    "end": 89,
+    "end": 91,
     "body": [
       {
         "id": 23,
@@ -31,7 +31,7 @@
           "line": 3,
           "column": 1
         },
-        "fullEnd": 89,
+        "fullEnd": 91,
         "start": 0,
         "end": 89,
         "type": {
@@ -170,7 +170,7 @@
             "line": 3,
             "column": 1
           },
-          "fullEnd": 89,
+          "fullEnd": 91,
           "start": 25,
           "end": 89,
           "blockOpenBrace": {
@@ -369,7 +369,7 @@
                     ],
                     "trailingTrivia": [
                       {
-                        "kind": "<space>",
+                        "kind": "<tab>",
                         "startPos": {
                           "offset": 34,
                           "line": 1,
@@ -380,7 +380,7 @@
                           "line": 1,
                           "column": 7
                         },
-                        "value": " ",
+                        "value": "\t",
                         "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
@@ -1249,7 +1249,29 @@
             },
             "value": "}",
             "leadingTrivia": [],
-            "trailingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 90,
+                  "line": 3,
+                  "column": 2
+                },
+                "endPos": {
+                  "offset": 91,
+                  "line": 4,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 90,
+                "end": 91
+              }
+            ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
@@ -1262,14 +1284,14 @@
     "eof": {
       "kind": "<eof>",
       "startPos": {
-        "offset": 89,
-        "line": 3,
-        "column": 1
+        "offset": 91,
+        "line": 4,
+        "column": 0
       },
       "endPos": {
-        "offset": 89,
-        "line": 3,
-        "column": 1
+        "offset": 91,
+        "line": 4,
+        "column": 0
       },
       "value": "",
       "leadingTrivia": [],
@@ -1277,8 +1299,8 @@
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 89,
-      "end": 89
+      "start": 91,
+      "end": 91
     }
   },
   "errors": []


### PR DESCRIPTION
## Summary
* Fix an issue where tab characters are not recognized as white-space characters (the character after `"id"` in the image is `\t`)
![image](https://github.com/user-attachments/assets/f294d157-b25c-44c2-8e0a-c524b970e342)

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review