### PR TITLE
Fix: Unset not_null if null or not_null setting is not specified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-latest
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: dbml.123.123

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-CU30-ubuntu-20.04
+        image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: dbml.123.123

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mssql:
-        image: mcr.microsoft.com/mssql/server:2022-latest
+        image: mcr.microsoft.com/mssql/server:2019-CU30-ubuntu-20.04
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: dbml.123.123

--- a/packages/dbml-core/__tests__/normalized_model/schema_def.out.json
+++ b/packages/dbml-core/__tests__/normalized_model/schema_def.out.json
@@ -433,7 +433,6 @@
       },
       "unique": false,
       "pk": true,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [
@@ -529,7 +528,6 @@
       },
       "unique": false,
       "pk": true,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [
@@ -626,7 +624,6 @@
       },
       "unique": false,
       "pk": true,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [],
@@ -658,7 +655,6 @@
       },
       "unique": false,
       "pk": true,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [],
@@ -675,7 +671,6 @@
       },
       "unique": false,
       "pk": false,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [
@@ -694,7 +689,6 @@
       },
       "unique": false,
       "pk": true,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [],
@@ -711,7 +705,6 @@
       },
       "unique": false,
       "pk": false,
-      "not_null": false,
       "note": null,
       "increment": false,
       "endpointIds": [

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -148,9 +148,11 @@ export class TableInterpreter implements ElementInterpreter {
       column.pk = !!settingMap['pk']?.length || !!settingMap['primary key']?.length;
       column.increment = !!settingMap['increment']?.length;
       column.unique = !!settingMap['unique']?.length;
-
-      const hasNullSetting = !!settingMap['null']?.length || !!settingMap['not null']?.length;
-      column.not_null = hasNullSetting ? !!settingMap['not null']?.length : undefined;
+      column.not_null = !!settingMap['not null']?.length
+        ? true
+        : !!settingMap['null']?.length
+          ? false
+          : undefined;
       column.dbdefault = processDefaultValue(settingMap['default']?.at(0)?.value);
       const noteNode = settingMap['note']?.at(0);
       column.note = noteNode && {

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -26,7 +26,7 @@ export class TableInterpreter implements ElementInterpreter {
   interpret(): CompileError[] {
     this.table.token = getTokenPosition(this.declarationNode);
     this.env.tables.set(this.declarationNode, this.table as Table);
-  
+
     const errors = [
       ...this.interpretName(this.declarationNode.name!),
       ...this.interpretAlias(this.declarationNode.alias),
@@ -54,7 +54,7 @@ export class TableInterpreter implements ElementInterpreter {
 
   private interpretName(nameNode: SyntaxNode): CompileError[] {
     const { name, schemaName } = extractElementName(nameNode);
-    
+
     if (schemaName.length > 1) {
       this.table.name = name;
       this.table.schemaName = schemaName.join('.');
@@ -92,7 +92,7 @@ export class TableInterpreter implements ElementInterpreter {
     const settingMap = aggregateSettingList(settings).getValue();
 
     this.table.headerColor = settingMap['headercolor']?.length ? extractColor(settingMap['headercolor']?.at(0)?.value as any) : undefined;
-    
+
     const [noteNode] = settingMap['note'] || [];
     this.table.note = noteNode && {
       value: extractQuotedStringToken(noteNode?.value).map(normalizeNoteContent).unwrap(),
@@ -104,7 +104,7 @@ export class TableInterpreter implements ElementInterpreter {
 
   private interpretBody(body: BlockExpressionNode): CompileError[] {
     const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
-    return [...this.interpretFields(fields as FunctionApplicationNode[]), ...this.interpretSubElements(subs as ElementDeclarationNode[])];   
+    return [...this.interpretFields(fields as FunctionApplicationNode[]), ...this.interpretSubElements(subs as ElementDeclarationNode[])];
   }
 
   private interpretSubElements(subs: ElementDeclarationNode[]): CompileError[] {
@@ -132,7 +132,7 @@ export class TableInterpreter implements ElementInterpreter {
     const errors: CompileError[] = [];
 
     const column: Partial<Column> = {};
-    
+
     column.name = extractVarNameFromPrimaryVariable(field.callee as any).unwrap();
 
     const typeReport = processColumnType(field.args[0]);
@@ -141,14 +141,16 @@ export class TableInterpreter implements ElementInterpreter {
 
     column.token = getTokenPosition(field);
     column.inline_refs = [];
-    
+
     const settings = field.args.slice(1);
     if (_.last(settings) instanceof ListExpressionNode) {
       const settingMap = aggregateSettingList(settings.pop() as ListExpressionNode).getValue();
       column.pk = !!settingMap['pk']?.length || !!settingMap['primary key']?.length;
       column.increment = !!settingMap['increment']?.length;
       column.unique = !!settingMap['unique']?.length;
-      column.not_null = !!settingMap['not null']?.length && true;
+
+      const hasNullSetting = !!settingMap['null']?.length || !!settingMap['not null']?.length;
+      column.not_null = hasNullSetting ? !!settingMap['not null']?.length : undefined;
       column.dbdefault = processDefaultValue(settingMap['default']?.at(0)?.value);
       const noteNode = settingMap['note']?.at(0);
       column.note = noteNode && {
@@ -165,7 +167,7 @@ export class TableInterpreter implements ElementInterpreter {
 
         const op = (ref.value as PrefixExpressionNode).op!;
         const fragments = destructureComplexVariable((ref.value as PrefixExpressionNode).expression).unwrap();
-        
+
         let inlineRef: InlineRef | undefined;
         if (fragments.length === 1) {
           const [column] = fragments;
@@ -243,7 +245,7 @@ export class TableInterpreter implements ElementInterpreter {
           value: extractQuotedStringToken(noteNode.value).unwrap(),
           token: getTokenPosition(noteNode),
         };
-        index.type = extractVariableFromExpression(settingMap['type']?.at(0)?.value).unwrap_or(undefined); 
+        index.type = extractVariableFromExpression(settingMap['type']?.at(0)?.value).unwrap_or(undefined);
       }
 
       args.flatMap((arg) => {
@@ -260,7 +262,7 @@ export class TableInterpreter implements ElementInterpreter {
         }
         fragments.push(arg);
         return fragments;
-      }).forEach((arg) => { 
+      }).forEach((arg) => {
         const { functional, nonFunctional } = destructureIndexNode(arg).unwrap();
         index.columns!.push(
           ...functional.map((s) => ({
@@ -275,10 +277,10 @@ export class TableInterpreter implements ElementInterpreter {
           })),
         );
       });
-       
+
       return index as Index;
     }));
-    
+
     return [];
   }
 
@@ -297,7 +299,7 @@ export class TableInterpreter implements ElementInterpreter {
       name: null,
       schemaName: null,
       token: inlineRef.token,
-      endpoints: [ 
+      endpoints: [
         {
           ...inlineRef,
           relation: multiplicities[1],
@@ -370,7 +372,7 @@ function processDefaultValue(valueNode?: SyntaxNode):
   if (!valueNode) {
     return undefined;
   }
-  
+
   if (isExpressionAQuotedString(valueNode)) {
     return {
       value: extractQuotedStringToken(valueNode).unwrap(),
@@ -388,7 +390,7 @@ function processDefaultValue(valueNode?: SyntaxNode):
   if (isExpressionAnIdentifierNode(valueNode)) {
     const value = valueNode.expression.variable.value.toLowerCase();
     return {
-      value, 
+      value,
       type: 'boolean',
     };
   }
@@ -400,7 +402,7 @@ function processDefaultValue(valueNode?: SyntaxNode):
   ) {
     const number = Number.parseFloat(valueNode.expression.expression.literal.value);
     return {
-      value: valueNode.op?.value === '-' ? 0 - number : number, 
+      value: valueNode.op?.value === '-' ? 0 - number : number,
       type: 'number',
     };
   }

--- a/packages/dbml-parse/tests/interpreter/output/comment.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/comment.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "user_id",
@@ -79,7 +78,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "Status of an order",
             "token": {
@@ -119,7 +117,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "When order created",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/default_tables.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/default_tables.out.json
@@ -29,7 +29,6 @@
           "pk": true,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "type": "number",
             "value": 123
@@ -83,7 +82,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "Completed",
             "type": "string"
@@ -112,7 +110,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "now()",
             "type": "expression"
@@ -249,8 +246,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -275,7 +271,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "null",
             "type": "boolean"
@@ -333,7 +328,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": -123.12,
             "type": "number"
@@ -362,7 +356,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "true",
             "type": "boolean"
@@ -391,7 +384,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "current_date + interval 1 year",
             "type": "expression"

--- a/packages/dbml-parse/tests/interpreter/output/enum_tables.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/enum_tables.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "status",
@@ -54,7 +53,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "This is a column note",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/general_schema.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/general_schema.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": true,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "user_id",
@@ -192,7 +191,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "type": "number",
             "value": 1
@@ -240,8 +238,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -360,7 +357,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "now()",
             "type": "expression"
@@ -495,8 +491,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "full_name",
@@ -543,8 +538,7 @@
           "inline_refs": [],
           "pk": false,
           "increment": false,
-          "unique": true,
-          "not_null": false
+          "unique": true
         },
         {
           "name": "gender",
@@ -680,8 +674,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "merchant_name",
@@ -817,8 +810,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",

--- a/packages/dbml-parse/tests/interpreter/output/index_tables.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/index_tables.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "full_name",
@@ -76,8 +75,7 @@
           "inline_refs": [],
           "pk": false,
           "increment": false,
-          "unique": true,
-          "not_null": false
+          "unique": true
         },
         {
           "name": "gender",

--- a/packages/dbml-parse/tests/interpreter/output/multi_notes.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/multi_notes.out.json
@@ -29,7 +29,6 @@
           "pk": true,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "primary key field",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/multiline_string.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/multiline_string.out.json
@@ -29,7 +29,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "# Objective\n  * Support writing long string that can 'span' over multiple lines\n  * Support writing markdown for DBML Note\n\n# Syntax\n\n",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/note_normalize.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/note_normalize.out.json
@@ -132,8 +132,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "username",
@@ -261,8 +260,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "title",
@@ -310,7 +308,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "# Heading 1\n    code block\n# Heading 2\n  * 1\n  * 2\n  ",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/note_normalize_with_top_empty_lines.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/note_normalize_with_top_empty_lines.out.json
@@ -132,8 +132,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "username",
@@ -261,8 +260,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "title",
@@ -310,7 +308,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "note": {
             "value": "# Heading 1\n    code block\n# Heading 2\n  * 1\n  * 2\n  ",
             "token": {

--- a/packages/dbml-parse/tests/interpreter/output/old_undocumented_syntax.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/old_undocumented_syntax.out.json
@@ -133,7 +133,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "null",
             "type": "boolean"
@@ -241,7 +240,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "CURRENT_TIMESTAMP",
             "type": "expression"
@@ -289,8 +287,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -315,7 +312,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "hello",
             "type": "string"

--- a/packages/dbml-parse/tests/interpreter/output/primary_key.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/primary_key.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         }
       ],
       "token": {

--- a/packages/dbml-parse/tests/interpreter/output/project.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/project.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": true,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "user_id",
@@ -192,7 +191,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "type": "number",
             "value": 1
@@ -240,8 +238,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -360,7 +357,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "now()",
             "type": "expression"
@@ -495,8 +491,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "full_name",
@@ -543,8 +538,7 @@
           "inline_refs": [],
           "pk": false,
           "increment": false,
-          "unique": true,
-          "not_null": false
+          "unique": true
         },
         {
           "name": "gender",
@@ -680,8 +674,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "merchant_name",
@@ -817,8 +810,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",

--- a/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": true,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "user_id",
@@ -214,7 +213,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "type": "number",
             "value": 1
@@ -332,7 +330,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "now()",
             "type": "expression"
@@ -431,8 +428,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": true,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -479,8 +475,7 @@
           "inline_refs": [],
           "pk": false,
           "increment": false,
-          "unique": true,
-          "not_null": false
+          "unique": true
         },
         {
           "name": "date_of_birth",
@@ -528,7 +523,6 @@
           "pk": false,
           "increment": false,
           "unique": false,
-          "not_null": false,
           "dbdefault": {
             "value": "now()",
             "type": "expression"
@@ -601,8 +595,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",

--- a/packages/dbml-parse/tests/interpreter/output/sticky_notes.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/sticky_notes.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "username",

--- a/packages/dbml-parse/tests/interpreter/output/table_group.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/table_group.out.json
@@ -253,8 +253,7 @@
           ],
           "pk": false,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         }
       ],
       "token": {

--- a/packages/dbml-parse/tests/interpreter/output/table_group_element.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/table_group_element.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         }
       ],
       "token": {
@@ -73,8 +72,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         }
       ],
       "token": {

--- a/packages/dbml-parse/tests/interpreter/output/table_group_settings.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/table_group_settings.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         }
       ],
       "token": {

--- a/packages/dbml-parse/tests/interpreter/output/table_settings.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/table_settings.out.json
@@ -28,8 +28,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -97,8 +96,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -182,8 +180,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "name",
@@ -291,8 +288,7 @@
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false,
-          "not_null": false
+          "unique": false
         },
         {
           "name": "user_id",


### PR DESCRIPTION
## Summary
Fix: Unset not_null if null or not_null setting is not specified

## Issue
(issue link here)

## Lasting Changes (Technical)
- Set `not_null` to `undefined` if neither `null` nor `not null` configuration is specified
- `not_null` will only have a boolean value if there is `null` or `not null` in the field setting

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review