### PR TITLE
fix: Incorrect Ref color settings position

### DIFF
--- a/dbml-homepage/docs/docs.md
+++ b/dbml-homepage/docs/docs.md
@@ -321,7 +321,13 @@ Ref: blogging.posts.user_id > core.users.id
 ### Relationship settings
 
 ```text
+// short form
 Ref: products.merchant_id > merchants.id [delete: cascade, update: no action, color: #79AD51]
+
+// long form
+Ref {
+  products.merchant_id > merchants.id [delete: cascade, update: no action, color: #79AD51]
+}
 ```
 
 - `delete / update: cascade | restrict | set null | set default | no action`

--- a/packages/dbml-core/__tests__/normalized_model/schema_def.in.dbml
+++ b/packages/dbml-core/__tests__/normalized_model/schema_def.in.dbml
@@ -83,9 +83,9 @@ Table c {
 }
 
 // Short form
-Ref short_ref [color: #aabbcc]: b.id < c.id
+Ref short_ref: b.id < c.id [color: #aabbcc]
 
 // Long form
-Ref long_ref [color: #123456] {
-  c.id < b.c_id
+Ref long_ref {
+  c.id < b.c_id [color: #123456]
 }

--- a/packages/dbml-parse/src/lib/analyzer/binder/types.ts
+++ b/packages/dbml-parse/src/lib/analyzer/binder/types.ts
@@ -33,5 +33,5 @@ export interface ArgumentBinderRule {
 }
 
 export interface SettingListBinderRule {
-  [index: string]: BinderRule,
+  [index: string]: BinderRule;
 }

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -56,30 +56,11 @@ export default class RefValidator implements ElementValidator {
   }
 
   private validateSettingList(settingList?: ListExpressionNode): CompileError[] {
-    if (!settingList) return [];
-
-    const aggReport = aggregateSettingList(settingList);
-    const errors = aggReport.getErrors();
-    const settingMap = aggReport.getValue();
-
-    for (const name in settingMap) {
-      const attrs = settingMap[name];
-      switch (name) {
-        case 'color':
-          if (attrs.length > 1) {
-            errors.push(...attrs.map((attr) => new CompileError(CompileErrorCode.DUPLICATE_REF_SETTING, '\'color\' can only appear once', attr)))
-          }
-          attrs.forEach((attr) => {
-            if (!isValidColor(attr.value)) {
-              errors.push(new CompileError(CompileErrorCode.INVALID_TABLE_SETTING, '\'color\' must be a color literal', attr.value || attr.name!));
-            }
-          });
-          break;
-        default:
-          errors.push(...attrs.map((attr) => new CompileError(CompileErrorCode.INVALID_TABLE_SETTING, `Unknown \'${name}\' setting`, attr)))
-      }
+    if (settingList) {
+      return [new CompileError(CompileErrorCode.UNEXPECTED_SETTINGS, 'A Ref shouldn\'t have a setting list', settingList)]
     }
-    return errors;
+
+    return [];
   }
 
   validateBody(body?: FunctionApplicationNode | BlockExpressionNode): CompileError[] {
@@ -115,7 +96,8 @@ export default class RefValidator implements ElementValidator {
 
       const args = [...field.args];
       if (_.last(args) instanceof ListExpressionNode) {
-        this.validateFieldSettings(_.last(args) as ListExpressionNode);
+        const errs = this.validateFieldSettings(_.last(args) as ListExpressionNode);
+        errors.push(...errs);
         args.pop();
       } else if (args[0] instanceof ListExpressionNode) {
         errors.push(...this.validateFieldSettings(args[0]));
@@ -145,6 +127,16 @@ export default class RefValidator implements ElementValidator {
           attrs.forEach((attr) => {
             if (!isValidPolicy(attr.value)) {
               errors.push(new CompileError(CompileErrorCode.INVALID_REF_SETTING_VALUE, `\'${name}\' can only have values "cascade", "no action", "set null", "set default" or "restrict"`, attr));
+            }
+          });
+          break;
+        case 'color':
+          if (attrs.length > 1) {
+            errors.push(...attrs.map((attr) => new CompileError(CompileErrorCode.DUPLICATE_REF_SETTING, '\'color\' can only appear once', attr)))
+          }
+          attrs.forEach((attr) => {
+            if (!isValidColor(attr.value)) {
+              errors.push(new CompileError(CompileErrorCode.INVALID_REF_SETTING_VALUE, '\'color\' must be a color literal', attr!));
             }
           });
           break;

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/ref.ts
@@ -25,7 +25,6 @@ export class RefInterpreter implements ElementInterpreter {
     this.env.ref.set(this.declarationNode, this.ref as Ref);
     const errors = [
       ...this.interpretName(this.declarationNode.name!),
-      ...this.interpretSettingList(this.declarationNode.attributeList),
       ...this.interpretBody(this.declarationNode.body!)];
     return errors;
   }
@@ -41,14 +40,6 @@ export class RefInterpreter implements ElementInterpreter {
     this.ref.schemaName = fragments.join('.') || null;
 
     return errors;
-  }
-
-  private interpretSettingList(settings?: ListExpressionNode): CompileError[] {
-    const settingMap = aggregateSettingList(settings).getValue();
-
-    this.ref.color = settingMap['color']?.length ? extractColor(settingMap['color']?.at(0)?.value as any) : undefined;
-    
-    return [];
   }
 
   private interpretBody(body: FunctionApplicationNode | BlockExpressionNode): CompileError[] {
@@ -80,14 +71,18 @@ export class RefInterpreter implements ElementInterpreter {
 
     if (field.args[0]) {
       const settingMap = aggregateSettingList(field.args[0] as ListExpressionNode).getValue();
+
       const deleteSetting = settingMap['delete']?.at(0)?.value;
       this.ref.onDelete = deleteSetting instanceof IdentiferStreamNode
         ? extractStringFromIdentifierStream(deleteSetting).unwrap_or(undefined) 
         : extractVariableFromExpression(deleteSetting).unwrap_or(undefined) as string;
+
       const updateSetting = settingMap['update']?.at(0)?.value;
       this.ref.onUpdate = updateSetting instanceof IdentiferStreamNode
         ? extractStringFromIdentifierStream(updateSetting).unwrap_or(undefined)
         : extractVariableFromExpression(updateSetting).unwrap_or(undefined) as string;
+
+      this.ref.color = settingMap['color']?.length ? extractColor(settingMap['color']?.at(0)?.value as any) : undefined;
     }
     
     const multiplicities = getMultiplicities(op);

--- a/packages/dbml-parse/tests/binder/input/ref_name_and_color_setting.in.dbml
+++ b/packages/dbml-parse/tests/binder/input/ref_name_and_color_setting.in.dbml
@@ -9,9 +9,9 @@ Table c {
 }
 
 // Short form
-Ref short_ref [color: #aabbcc]: b.id < c.id
+Ref short_ref: b.id < c.id [color: #aabbcc]
 
 // Long form
-Ref long_ref [color: #123456] {
-  c.id < b.c_id
+Ref long_ref {
+  c.id < b.c_id [color: #123456]
 }

--- a/packages/dbml-parse/tests/binder/output/ref_name_and_color_setting.out.json
+++ b/packages/dbml-parse/tests/binder/output/ref_name_and_color_setting.out.json
@@ -1805,7 +1805,7 @@
             "line": 11,
             "column": 13
           },
-          "fullEnd": 117,
+          "fullEnd": 116,
           "start": 107,
           "end": 116,
           "expression": {
@@ -1822,7 +1822,7 @@
               "line": 11,
               "column": 13
             },
-            "fullEnd": 117,
+            "fullEnd": 116,
             "start": 107,
             "end": 116,
             "variable": {
@@ -1839,29 +1839,7 @@
               },
               "value": "short_ref",
               "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 116,
-                    "line": 11,
-                    "column": 13
-                  },
-                  "endPos": {
-                    "offset": 117,
-                    "line": 11,
-                    "column": 14
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 116,
-                  "end": 117
-                }
-              ],
+              "trailingTrivia": [],
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
@@ -1870,48 +1848,129 @@
             }
           }
         },
-        "attributeList": {
-          "id": 39,
-          "kind": "<list-expression>",
+        "bodyColon": {
+          "kind": "<colon>",
           "startPos": {
+            "offset": 116,
+            "line": 11,
+            "column": 13
+          },
+          "endPos": {
             "offset": 117,
             "line": 11,
             "column": 14
           },
-          "fullStart": 117,
-          "endPos": {
-            "offset": 133,
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 117,
+                "line": 11,
+                "column": 14
+              },
+              "endPos": {
+                "offset": 118,
+                "line": 11,
+                "column": 15
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 117,
+              "end": 118
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 116,
+          "end": 117
+        },
+        "body": {
+          "id": 51,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 118,
             "line": 11,
-            "column": 30
+            "column": 15
           },
-          "fullEnd": 133,
-          "start": 117,
-          "end": 133,
-          "listOpenBracket": {
-            "kind": "<lbracket>",
+          "fullStart": 118,
+          "endPos": {
+            "offset": 146,
+            "line": 11,
+            "column": 43
+          },
+          "fullEnd": 147,
+          "start": 118,
+          "end": 146,
+          "callee": {
+            "id": 45,
+            "kind": "<infix-expression>",
             "startPos": {
-              "offset": 117,
-              "line": 11,
-              "column": 14
-            },
-            "endPos": {
               "offset": 118,
               "line": 11,
               "column": 15
             },
-            "value": "[",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 117,
-            "end": 118
-          },
-          "elementList": [
-            {
-              "id": 38,
-              "kind": "<attribute>",
+            "fullStart": 118,
+            "endPos": {
+              "offset": 129,
+              "line": 11,
+              "column": 26
+            },
+            "fullEnd": 130,
+            "start": 118,
+            "end": 129,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 123,
+                "line": 11,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 124,
+                "line": 11,
+                "column": 21
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 124,
+                    "line": 11,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 125,
+                    "line": 11,
+                    "column": 22
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 124,
+                  "end": 125
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 123,
+              "end": 124
+            },
+            "leftExpression": {
+              "id": 39,
+              "kind": "<infix-expression>",
               "startPos": {
                 "offset": 118,
                 "line": 11,
@@ -1919,16 +1978,37 @@
               },
               "fullStart": 118,
               "endPos": {
-                "offset": 132,
+                "offset": 122,
                 "line": 11,
-                "column": 29
+                "column": 19
               },
-              "fullEnd": 132,
+              "fullEnd": 123,
               "start": 118,
-              "end": 132,
-              "name": {
-                "id": 35,
-                "kind": "<identifer-stream>",
+              "end": 122,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 119,
+                  "line": 11,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 120,
+                  "line": 11,
+                  "column": 17
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 119,
+                "end": 120
+              },
+              "leftExpression": {
+                "id": 36,
+                "kind": "<primary-expression>",
                 "startPos": {
                   "offset": 118,
                   "line": 11,
@@ -1936,15 +2016,31 @@
                 },
                 "fullStart": 118,
                 "endPos": {
-                  "offset": 123,
+                  "offset": 119,
                   "line": 11,
-                  "column": 20
+                  "column": 16
                 },
-                "fullEnd": 123,
+                "fullEnd": 119,
                 "start": 118,
-                "end": 123,
-                "identifiers": [
-                  {
+                "end": 119,
+                "expression": {
+                  "id": 35,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 118,
+                    "line": 11,
+                    "column": 15
+                  },
+                  "fullStart": 118,
+                  "endPos": {
+                    "offset": 119,
+                    "line": 11,
+                    "column": 16
+                  },
+                  "fullEnd": 119,
+                  "start": 118,
+                  "end": 119,
+                  "variable": {
                     "kind": "<identifier>",
                     "startPos": {
                       "offset": 118,
@@ -1952,23 +2048,143 @@
                       "column": 15
                     },
                     "endPos": {
-                      "offset": 123,
+                      "offset": 119,
                       "line": 11,
-                      "column": 20
+                      "column": 16
                     },
-                    "value": "color",
+                    "value": "b",
                     "leadingTrivia": [],
                     "trailingTrivia": [],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
                     "start": 118,
-                    "end": 123
+                    "end": 119
                   }
-                ]
+                },
+                "referee": 1
               },
-              "value": {
-                "id": 37,
+              "rightExpression": {
+                "id": 38,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 120,
+                  "line": 11,
+                  "column": 17
+                },
+                "fullStart": 120,
+                "endPos": {
+                  "offset": 122,
+                  "line": 11,
+                  "column": 19
+                },
+                "fullEnd": 123,
+                "start": 120,
+                "end": 122,
+                "expression": {
+                  "id": 37,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 120,
+                    "line": 11,
+                    "column": 17
+                  },
+                  "fullStart": 120,
+                  "endPos": {
+                    "offset": 122,
+                    "line": 11,
+                    "column": 19
+                  },
+                  "fullEnd": 123,
+                  "start": 120,
+                  "end": 122,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 120,
+                      "line": 11,
+                      "column": 17
+                    },
+                    "endPos": {
+                      "offset": 122,
+                      "line": 11,
+                      "column": 19
+                    },
+                    "value": "id",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 122,
+                          "line": 11,
+                          "column": 19
+                        },
+                        "endPos": {
+                          "offset": 123,
+                          "line": 11,
+                          "column": 20
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 122,
+                        "end": 123
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 120,
+                    "end": 122
+                  }
+                },
+                "referee": 2
+              }
+            },
+            "rightExpression": {
+              "id": 44,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 125,
+                "line": 11,
+                "column": 22
+              },
+              "fullStart": 125,
+              "endPos": {
+                "offset": 129,
+                "line": 11,
+                "column": 26
+              },
+              "fullEnd": 130,
+              "start": 125,
+              "end": 129,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 126,
+                  "line": 11,
+                  "column": 23
+                },
+                "endPos": {
+                  "offset": 127,
+                  "line": 11,
+                  "column": 24
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 126,
+                "end": 127
+              },
+              "leftExpression": {
+                "id": 41,
                 "kind": "<primary-expression>",
                 "startPos": {
                   "offset": 125,
@@ -1977,16 +2193,16 @@
                 },
                 "fullStart": 125,
                 "endPos": {
-                  "offset": 132,
+                  "offset": 126,
                   "line": 11,
-                  "column": 29
+                  "column": 23
                 },
-                "fullEnd": 132,
+                "fullEnd": 126,
                 "start": 125,
-                "end": 132,
+                "end": 126,
                 "expression": {
-                  "id": 36,
-                  "kind": "<literal>",
+                  "id": 40,
+                  "kind": "<variable>",
                   "startPos": {
                     "offset": 125,
                     "line": 11,
@@ -1994,484 +2210,24 @@
                   },
                   "fullStart": 125,
                   "endPos": {
-                    "offset": 132,
+                    "offset": 126,
                     "line": 11,
-                    "column": 29
+                    "column": 23
                   },
-                  "fullEnd": 132,
+                  "fullEnd": 126,
                   "start": 125,
-                  "end": 132,
-                  "literal": {
-                    "kind": "<color>",
+                  "end": 126,
+                  "variable": {
+                    "kind": "<identifier>",
                     "startPos": {
                       "offset": 125,
                       "line": 11,
                       "column": 22
                     },
                     "endPos": {
-                      "offset": 132,
+                      "offset": 126,
                       "line": 11,
-                      "column": 29
-                    },
-                    "value": "#aabbcc",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 125,
-                    "end": 132
-                  }
-                }
-              },
-              "colon": {
-                "kind": "<colon>",
-                "startPos": {
-                  "offset": 123,
-                  "line": 11,
-                  "column": 20
-                },
-                "endPos": {
-                  "offset": 124,
-                  "line": 11,
-                  "column": 21
-                },
-                "value": ":",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 124,
-                      "line": 11,
-                      "column": 21
-                    },
-                    "endPos": {
-                      "offset": 125,
-                      "line": 11,
-                      "column": 22
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 124,
-                    "end": 125
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 123,
-                "end": 124
-              }
-            }
-          ],
-          "commaList": [],
-          "listCloseBracket": {
-            "kind": "<rbracket>",
-            "startPos": {
-              "offset": 132,
-              "line": 11,
-              "column": 29
-            },
-            "endPos": {
-              "offset": 133,
-              "line": 11,
-              "column": 30
-            },
-            "value": "]",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 132,
-            "end": 133
-          }
-        },
-        "bodyColon": {
-          "kind": "<colon>",
-          "startPos": {
-            "offset": 133,
-            "line": 11,
-            "column": 30
-          },
-          "endPos": {
-            "offset": 134,
-            "line": 11,
-            "column": 31
-          },
-          "value": ":",
-          "leadingTrivia": [],
-          "trailingTrivia": [
-            {
-              "kind": "<space>",
-              "startPos": {
-                "offset": 134,
-                "line": 11,
-                "column": 31
-              },
-              "endPos": {
-                "offset": 135,
-                "line": 11,
-                "column": 32
-              },
-              "value": " ",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 134,
-              "end": 135
-            }
-          ],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 133,
-          "end": 134
-        },
-        "body": {
-          "id": 51,
-          "kind": "<function-application>",
-          "startPos": {
-            "offset": 135,
-            "line": 11,
-            "column": 32
-          },
-          "fullStart": 135,
-          "endPos": {
-            "offset": 146,
-            "line": 11,
-            "column": 43
-          },
-          "fullEnd": 147,
-          "start": 135,
-          "end": 146,
-          "callee": {
-            "id": 50,
-            "kind": "<infix-expression>",
-            "startPos": {
-              "offset": 135,
-              "line": 11,
-              "column": 32
-            },
-            "fullStart": 135,
-            "endPos": {
-              "offset": 146,
-              "line": 11,
-              "column": 43
-            },
-            "fullEnd": 147,
-            "start": 135,
-            "end": 146,
-            "op": {
-              "kind": "<op>",
-              "startPos": {
-                "offset": 140,
-                "line": 11,
-                "column": 37
-              },
-              "endPos": {
-                "offset": 141,
-                "line": 11,
-                "column": 38
-              },
-              "value": "<",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 141,
-                    "line": 11,
-                    "column": 38
-                  },
-                  "endPos": {
-                    "offset": 142,
-                    "line": 11,
-                    "column": 39
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 141,
-                  "end": 142
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 140,
-              "end": 141
-            },
-            "leftExpression": {
-              "id": 44,
-              "kind": "<infix-expression>",
-              "startPos": {
-                "offset": 135,
-                "line": 11,
-                "column": 32
-              },
-              "fullStart": 135,
-              "endPos": {
-                "offset": 139,
-                "line": 11,
-                "column": 36
-              },
-              "fullEnd": 140,
-              "start": 135,
-              "end": 139,
-              "op": {
-                "kind": "<op>",
-                "startPos": {
-                  "offset": 136,
-                  "line": 11,
-                  "column": 33
-                },
-                "endPos": {
-                  "offset": 137,
-                  "line": 11,
-                  "column": 34
-                },
-                "value": ".",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 136,
-                "end": 137
-              },
-              "leftExpression": {
-                "id": 41,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 135,
-                  "line": 11,
-                  "column": 32
-                },
-                "fullStart": 135,
-                "endPos": {
-                  "offset": 136,
-                  "line": 11,
-                  "column": 33
-                },
-                "fullEnd": 136,
-                "start": 135,
-                "end": 136,
-                "expression": {
-                  "id": 40,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 135,
-                    "line": 11,
-                    "column": 32
-                  },
-                  "fullStart": 135,
-                  "endPos": {
-                    "offset": 136,
-                    "line": 11,
-                    "column": 33
-                  },
-                  "fullEnd": 136,
-                  "start": 135,
-                  "end": 136,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 135,
-                      "line": 11,
-                      "column": 32
-                    },
-                    "endPos": {
-                      "offset": 136,
-                      "line": 11,
-                      "column": 33
-                    },
-                    "value": "b",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 135,
-                    "end": 136
-                  }
-                },
-                "referee": 1
-              },
-              "rightExpression": {
-                "id": 43,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 137,
-                  "line": 11,
-                  "column": 34
-                },
-                "fullStart": 137,
-                "endPos": {
-                  "offset": 139,
-                  "line": 11,
-                  "column": 36
-                },
-                "fullEnd": 140,
-                "start": 137,
-                "end": 139,
-                "expression": {
-                  "id": 42,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 137,
-                    "line": 11,
-                    "column": 34
-                  },
-                  "fullStart": 137,
-                  "endPos": {
-                    "offset": 139,
-                    "line": 11,
-                    "column": 36
-                  },
-                  "fullEnd": 140,
-                  "start": 137,
-                  "end": 139,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 137,
-                      "line": 11,
-                      "column": 34
-                    },
-                    "endPos": {
-                      "offset": 139,
-                      "line": 11,
-                      "column": 36
-                    },
-                    "value": "id",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 139,
-                          "line": 11,
-                          "column": 36
-                        },
-                        "endPos": {
-                          "offset": 140,
-                          "line": 11,
-                          "column": 37
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 139,
-                        "end": 140
-                      }
-                    ],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 137,
-                    "end": 139
-                  }
-                },
-                "referee": 2
-              }
-            },
-            "rightExpression": {
-              "id": 49,
-              "kind": "<infix-expression>",
-              "startPos": {
-                "offset": 142,
-                "line": 11,
-                "column": 39
-              },
-              "fullStart": 142,
-              "endPos": {
-                "offset": 146,
-                "line": 11,
-                "column": 43
-              },
-              "fullEnd": 147,
-              "start": 142,
-              "end": 146,
-              "op": {
-                "kind": "<op>",
-                "startPos": {
-                  "offset": 143,
-                  "line": 11,
-                  "column": 40
-                },
-                "endPos": {
-                  "offset": 144,
-                  "line": 11,
-                  "column": 41
-                },
-                "value": ".",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 143,
-                "end": 144
-              },
-              "leftExpression": {
-                "id": 46,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 142,
-                  "line": 11,
-                  "column": 39
-                },
-                "fullStart": 142,
-                "endPos": {
-                  "offset": 143,
-                  "line": 11,
-                  "column": 40
-                },
-                "fullEnd": 143,
-                "start": 142,
-                "end": 143,
-                "expression": {
-                  "id": 45,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 142,
-                    "line": 11,
-                    "column": 39
-                  },
-                  "fullStart": 142,
-                  "endPos": {
-                    "offset": 143,
-                    "line": 11,
-                    "column": 40
-                  },
-                  "fullEnd": 143,
-                  "start": 142,
-                  "end": 143,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 142,
-                      "line": 11,
-                      "column": 39
-                    },
-                    "endPos": {
-                      "offset": 143,
-                      "line": 11,
-                      "column": 40
+                      "column": 23
                     },
                     "value": "c",
                     "leadingTrivia": [],
@@ -2479,95 +2235,340 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 142,
-                    "end": 143
+                    "start": 125,
+                    "end": 126
                   }
                 },
                 "referee": 4
               },
               "rightExpression": {
-                "id": 48,
+                "id": 43,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 144,
+                  "offset": 127,
                   "line": 11,
-                  "column": 41
+                  "column": 24
                 },
-                "fullStart": 144,
+                "fullStart": 127,
                 "endPos": {
-                  "offset": 146,
+                  "offset": 129,
                   "line": 11,
-                  "column": 43
+                  "column": 26
                 },
-                "fullEnd": 147,
-                "start": 144,
-                "end": 146,
+                "fullEnd": 130,
+                "start": 127,
+                "end": 129,
                 "expression": {
-                  "id": 47,
+                  "id": 42,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 144,
+                    "offset": 127,
                     "line": 11,
-                    "column": 41
+                    "column": 24
                   },
-                  "fullStart": 144,
+                  "fullStart": 127,
                   "endPos": {
-                    "offset": 146,
+                    "offset": 129,
                     "line": 11,
-                    "column": 43
+                    "column": 26
                   },
-                  "fullEnd": 147,
-                  "start": 144,
-                  "end": 146,
+                  "fullEnd": 130,
+                  "start": 127,
+                  "end": 129,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 144,
+                      "offset": 127,
                       "line": 11,
-                      "column": 41
+                      "column": 24
                     },
                     "endPos": {
-                      "offset": 146,
+                      "offset": 129,
                       "line": 11,
-                      "column": 43
+                      "column": 26
                     },
                     "value": "id",
                     "leadingTrivia": [],
                     "trailingTrivia": [
                       {
-                        "kind": "<newline>",
+                        "kind": "<space>",
                         "startPos": {
-                          "offset": 146,
+                          "offset": 129,
                           "line": 11,
-                          "column": 43
+                          "column": 26
                         },
                         "endPos": {
-                          "offset": 147,
-                          "line": 12,
-                          "column": 0
+                          "offset": 130,
+                          "line": 11,
+                          "column": 27
                         },
-                        "value": "\n",
+                        "value": " ",
                         "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 146,
-                        "end": 147
+                        "start": 129,
+                        "end": 130
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 144,
-                    "end": 146
+                    "start": 127,
+                    "end": 129
                   }
                 },
                 "referee": 5
               }
             }
           },
-          "args": []
+          "args": [
+            {
+              "id": 50,
+              "kind": "<list-expression>",
+              "startPos": {
+                "offset": 130,
+                "line": 11,
+                "column": 27
+              },
+              "fullStart": 130,
+              "endPos": {
+                "offset": 146,
+                "line": 11,
+                "column": 43
+              },
+              "fullEnd": 147,
+              "start": 130,
+              "end": 146,
+              "listOpenBracket": {
+                "kind": "<lbracket>",
+                "startPos": {
+                  "offset": 130,
+                  "line": 11,
+                  "column": 27
+                },
+                "endPos": {
+                  "offset": 131,
+                  "line": 11,
+                  "column": 28
+                },
+                "value": "[",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 130,
+                "end": 131
+              },
+              "elementList": [
+                {
+                  "id": 49,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 131,
+                    "line": 11,
+                    "column": 28
+                  },
+                  "fullStart": 131,
+                  "endPos": {
+                    "offset": 145,
+                    "line": 11,
+                    "column": 42
+                  },
+                  "fullEnd": 145,
+                  "start": 131,
+                  "end": 145,
+                  "name": {
+                    "id": 46,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 131,
+                      "line": 11,
+                      "column": 28
+                    },
+                    "fullStart": 131,
+                    "endPos": {
+                      "offset": 136,
+                      "line": 11,
+                      "column": 33
+                    },
+                    "fullEnd": 136,
+                    "start": 131,
+                    "end": 136,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 131,
+                          "line": 11,
+                          "column": 28
+                        },
+                        "endPos": {
+                          "offset": 136,
+                          "line": 11,
+                          "column": 33
+                        },
+                        "value": "color",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 131,
+                        "end": 136
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 48,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 138,
+                      "line": 11,
+                      "column": 35
+                    },
+                    "fullStart": 138,
+                    "endPos": {
+                      "offset": 145,
+                      "line": 11,
+                      "column": 42
+                    },
+                    "fullEnd": 145,
+                    "start": 138,
+                    "end": 145,
+                    "expression": {
+                      "id": 47,
+                      "kind": "<literal>",
+                      "startPos": {
+                        "offset": 138,
+                        "line": 11,
+                        "column": 35
+                      },
+                      "fullStart": 138,
+                      "endPos": {
+                        "offset": 145,
+                        "line": 11,
+                        "column": 42
+                      },
+                      "fullEnd": 145,
+                      "start": 138,
+                      "end": 145,
+                      "literal": {
+                        "kind": "<color>",
+                        "startPos": {
+                          "offset": 138,
+                          "line": 11,
+                          "column": 35
+                        },
+                        "endPos": {
+                          "offset": 145,
+                          "line": 11,
+                          "column": 42
+                        },
+                        "value": "#aabbcc",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 138,
+                        "end": 145
+                      }
+                    }
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 136,
+                      "line": 11,
+                      "column": 33
+                    },
+                    "endPos": {
+                      "offset": 137,
+                      "line": 11,
+                      "column": 34
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 137,
+                          "line": 11,
+                          "column": 34
+                        },
+                        "endPos": {
+                          "offset": 138,
+                          "line": 11,
+                          "column": 35
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 137,
+                        "end": 138
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 136,
+                    "end": 137
+                  }
+                }
+              ],
+              "commaList": [],
+              "listCloseBracket": {
+                "kind": "<rbracket>",
+                "startPos": {
+                  "offset": 145,
+                  "line": 11,
+                  "column": 42
+                },
+                "endPos": {
+                  "offset": 146,
+                  "line": 11,
+                  "column": 43
+                },
+                "value": "]",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 146,
+                      "line": 11,
+                      "column": 43
+                    },
+                    "endPos": {
+                      "offset": 147,
+                      "line": 12,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 146,
+                    "end": 147
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 145,
+                "end": 146
+              }
+            }
+          ]
         },
         "parent": 74
       },
@@ -2774,9 +2775,9 @@
             }
           }
         },
-        "attributeList": {
-          "id": 59,
-          "kind": "<list-expression>",
+        "body": {
+          "id": 72,
+          "kind": "<block-expression>",
           "startPos": {
             "offset": 174,
             "line": 14,
@@ -2784,15 +2785,15 @@
           },
           "fullStart": 174,
           "endPos": {
-            "offset": 190,
-            "line": 14,
-            "column": 29
+            "offset": 210,
+            "line": 16,
+            "column": 1
           },
-          "fullEnd": 191,
+          "fullEnd": 210,
           "start": 174,
-          "end": 190,
-          "listOpenBracket": {
-            "kind": "<lbracket>",
+          "end": 210,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
             "startPos": {
               "offset": 174,
               "line": 14,
@@ -2803,262 +2804,18 @@
               "line": 14,
               "column": 14
             },
-            "value": "[",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 174,
-            "end": 175
-          },
-          "elementList": [
-            {
-              "id": 58,
-              "kind": "<attribute>",
-              "startPos": {
-                "offset": 175,
-                "line": 14,
-                "column": 14
-              },
-              "fullStart": 175,
-              "endPos": {
-                "offset": 189,
-                "line": 14,
-                "column": 28
-              },
-              "fullEnd": 189,
-              "start": 175,
-              "end": 189,
-              "name": {
-                "id": 55,
-                "kind": "<identifer-stream>",
-                "startPos": {
-                  "offset": 175,
-                  "line": 14,
-                  "column": 14
-                },
-                "fullStart": 175,
-                "endPos": {
-                  "offset": 180,
-                  "line": 14,
-                  "column": 19
-                },
-                "fullEnd": 180,
-                "start": 175,
-                "end": 180,
-                "identifiers": [
-                  {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 175,
-                      "line": 14,
-                      "column": 14
-                    },
-                    "endPos": {
-                      "offset": 180,
-                      "line": 14,
-                      "column": 19
-                    },
-                    "value": "color",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 175,
-                    "end": 180
-                  }
-                ]
-              },
-              "value": {
-                "id": 57,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 182,
-                  "line": 14,
-                  "column": 21
-                },
-                "fullStart": 182,
-                "endPos": {
-                  "offset": 189,
-                  "line": 14,
-                  "column": 28
-                },
-                "fullEnd": 189,
-                "start": 182,
-                "end": 189,
-                "expression": {
-                  "id": 56,
-                  "kind": "<literal>",
-                  "startPos": {
-                    "offset": 182,
-                    "line": 14,
-                    "column": 21
-                  },
-                  "fullStart": 182,
-                  "endPos": {
-                    "offset": 189,
-                    "line": 14,
-                    "column": 28
-                  },
-                  "fullEnd": 189,
-                  "start": 182,
-                  "end": 189,
-                  "literal": {
-                    "kind": "<color>",
-                    "startPos": {
-                      "offset": 182,
-                      "line": 14,
-                      "column": 21
-                    },
-                    "endPos": {
-                      "offset": 189,
-                      "line": 14,
-                      "column": 28
-                    },
-                    "value": "#123456",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 182,
-                    "end": 189
-                  }
-                }
-              },
-              "colon": {
-                "kind": "<colon>",
-                "startPos": {
-                  "offset": 180,
-                  "line": 14,
-                  "column": 19
-                },
-                "endPos": {
-                  "offset": 181,
-                  "line": 14,
-                  "column": 20
-                },
-                "value": ":",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 181,
-                      "line": 14,
-                      "column": 20
-                    },
-                    "endPos": {
-                      "offset": 182,
-                      "line": 14,
-                      "column": 21
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 181,
-                    "end": 182
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 180,
-                "end": 181
-              }
-            }
-          ],
-          "commaList": [],
-          "listCloseBracket": {
-            "kind": "<rbracket>",
-            "startPos": {
-              "offset": 189,
-              "line": 14,
-              "column": 28
-            },
-            "endPos": {
-              "offset": 190,
-              "line": 14,
-              "column": 29
-            },
-            "value": "]",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 190,
-                  "line": 14,
-                  "column": 29
-                },
-                "endPos": {
-                  "offset": 191,
-                  "line": 14,
-                  "column": 30
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 190,
-                "end": 191
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 189,
-            "end": 190
-          }
-        },
-        "body": {
-          "id": 72,
-          "kind": "<block-expression>",
-          "startPos": {
-            "offset": 191,
-            "line": 14,
-            "column": 30
-          },
-          "fullStart": 191,
-          "endPos": {
-            "offset": 210,
-            "line": 16,
-            "column": 1
-          },
-          "fullEnd": 210,
-          "start": 191,
-          "end": 210,
-          "blockOpenBrace": {
-            "kind": "<lbrace>",
-            "startPos": {
-              "offset": 191,
-              "line": 14,
-              "column": 30
-            },
-            "endPos": {
-              "offset": 192,
-              "line": 14,
-              "column": 31
-            },
             "value": "{",
             "leadingTrivia": [],
             "trailingTrivia": [
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 192,
+                  "offset": 175,
                   "line": 14,
-                  "column": 31
+                  "column": 14
                 },
                 "endPos": {
-                  "offset": 193,
+                  "offset": 176,
                   "line": 15,
                   "column": 0
                 },
@@ -3068,60 +2825,60 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 192,
-                "end": 193
+                "start": 175,
+                "end": 176
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 191,
-            "end": 192
+            "start": 174,
+            "end": 175
           },
           "body": [
             {
               "id": 71,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 195,
+                "offset": 178,
                 "line": 15,
                 "column": 2
               },
-              "fullStart": 193,
+              "fullStart": 176,
               "endPos": {
                 "offset": 208,
                 "line": 15,
-                "column": 15
+                "column": 32
               },
               "fullEnd": 209,
-              "start": 195,
+              "start": 178,
               "end": 208,
               "callee": {
-                "id": 70,
+                "id": 65,
                 "kind": "<infix-expression>",
                 "startPos": {
-                  "offset": 195,
+                  "offset": 178,
                   "line": 15,
                   "column": 2
                 },
-                "fullStart": 193,
+                "fullStart": 176,
                 "endPos": {
-                  "offset": 208,
+                  "offset": 191,
                   "line": 15,
                   "column": 15
                 },
-                "fullEnd": 209,
-                "start": 195,
-                "end": 208,
+                "fullEnd": 192,
+                "start": 178,
+                "end": 191,
                 "op": {
                   "kind": "<op>",
                   "startPos": {
-                    "offset": 200,
+                    "offset": 183,
                     "line": 15,
                     "column": 7
                   },
                   "endPos": {
-                    "offset": 201,
+                    "offset": 184,
                     "line": 15,
                     "column": 8
                   },
@@ -3131,12 +2888,12 @@
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 201,
+                        "offset": 184,
                         "line": 15,
                         "column": 8
                       },
                       "endPos": {
-                        "offset": 202,
+                        "offset": 185,
                         "line": 15,
                         "column": 9
                       },
@@ -3146,42 +2903,42 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 201,
-                      "end": 202
+                      "start": 184,
+                      "end": 185
                     }
                   ],
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 200,
-                  "end": 201
+                  "start": 183,
+                  "end": 184
                 },
                 "leftExpression": {
-                  "id": 64,
+                  "id": 59,
                   "kind": "<infix-expression>",
                   "startPos": {
-                    "offset": 195,
+                    "offset": 178,
                     "line": 15,
                     "column": 2
                   },
-                  "fullStart": 193,
+                  "fullStart": 176,
                   "endPos": {
-                    "offset": 199,
+                    "offset": 182,
                     "line": 15,
                     "column": 6
                   },
-                  "fullEnd": 200,
-                  "start": 195,
-                  "end": 199,
+                  "fullEnd": 183,
+                  "start": 178,
+                  "end": 182,
                   "op": {
                     "kind": "<op>",
                     "startPos": {
-                      "offset": 196,
+                      "offset": 179,
                       "line": 15,
                       "column": 3
                     },
                     "endPos": {
-                      "offset": 197,
+                      "offset": 180,
                       "line": 15,
                       "column": 4
                     },
@@ -3191,52 +2948,52 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 196,
-                    "end": 197
+                    "start": 179,
+                    "end": 180
                   },
                   "leftExpression": {
-                    "id": 61,
+                    "id": 56,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 195,
+                      "offset": 178,
                       "line": 15,
                       "column": 2
                     },
-                    "fullStart": 193,
+                    "fullStart": 176,
                     "endPos": {
-                      "offset": 196,
+                      "offset": 179,
                       "line": 15,
                       "column": 3
                     },
-                    "fullEnd": 196,
-                    "start": 195,
-                    "end": 196,
+                    "fullEnd": 179,
+                    "start": 178,
+                    "end": 179,
                     "expression": {
-                      "id": 60,
+                      "id": 55,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 195,
+                        "offset": 178,
                         "line": 15,
                         "column": 2
                       },
-                      "fullStart": 193,
+                      "fullStart": 176,
                       "endPos": {
-                        "offset": 196,
+                        "offset": 179,
                         "line": 15,
                         "column": 3
                       },
-                      "fullEnd": 196,
-                      "start": 195,
-                      "end": 196,
+                      "fullEnd": 179,
+                      "start": 178,
+                      "end": 179,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 195,
+                          "offset": 178,
                           "line": 15,
                           "column": 2
                         },
                         "endPos": {
-                          "offset": 196,
+                          "offset": 179,
                           "line": 15,
                           "column": 3
                         },
@@ -3245,12 +3002,12 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 193,
+                              "offset": 176,
                               "line": 15,
                               "column": 0
                             },
                             "endPos": {
-                              "offset": 194,
+                              "offset": 177,
                               "line": 15,
                               "column": 1
                             },
@@ -3260,18 +3017,18 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 193,
-                            "end": 194
+                            "start": 176,
+                            "end": 177
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 194,
+                              "offset": 177,
                               "line": 15,
                               "column": 1
                             },
                             "endPos": {
-                              "offset": 195,
+                              "offset": 178,
                               "line": 15,
                               "column": 2
                             },
@@ -3281,63 +3038,63 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 194,
-                            "end": 195
+                            "start": 177,
+                            "end": 178
                           }
                         ],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 195,
-                        "end": 196
+                        "start": 178,
+                        "end": 179
                       }
                     },
                     "referee": 4
                   },
                   "rightExpression": {
-                    "id": 63,
+                    "id": 58,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 197,
+                      "offset": 180,
                       "line": 15,
                       "column": 4
                     },
-                    "fullStart": 197,
+                    "fullStart": 180,
                     "endPos": {
-                      "offset": 199,
+                      "offset": 182,
                       "line": 15,
                       "column": 6
                     },
-                    "fullEnd": 200,
-                    "start": 197,
-                    "end": 199,
+                    "fullEnd": 183,
+                    "start": 180,
+                    "end": 182,
                     "expression": {
-                      "id": 62,
+                      "id": 57,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 197,
+                        "offset": 180,
                         "line": 15,
                         "column": 4
                       },
-                      "fullStart": 197,
+                      "fullStart": 180,
                       "endPos": {
-                        "offset": 199,
+                        "offset": 182,
                         "line": 15,
                         "column": 6
                       },
-                      "fullEnd": 200,
-                      "start": 197,
-                      "end": 199,
+                      "fullEnd": 183,
+                      "start": 180,
+                      "end": 182,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 197,
+                          "offset": 180,
                           "line": 15,
                           "column": 4
                         },
                         "endPos": {
-                          "offset": 199,
+                          "offset": 182,
                           "line": 15,
                           "column": 6
                         },
@@ -3347,14 +3104,394 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 199,
+                              "offset": 182,
                               "line": 15,
                               "column": 6
                             },
                             "endPos": {
-                              "offset": 200,
+                              "offset": 183,
                               "line": 15,
                               "column": 7
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 182,
+                            "end": 183
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 180,
+                        "end": 182
+                      }
+                    },
+                    "referee": 5
+                  }
+                },
+                "rightExpression": {
+                  "id": 64,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 185,
+                    "line": 15,
+                    "column": 9
+                  },
+                  "fullStart": 185,
+                  "endPos": {
+                    "offset": 191,
+                    "line": 15,
+                    "column": 15
+                  },
+                  "fullEnd": 192,
+                  "start": 185,
+                  "end": 191,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 186,
+                      "line": 15,
+                      "column": 10
+                    },
+                    "endPos": {
+                      "offset": 187,
+                      "line": 15,
+                      "column": 11
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 186,
+                    "end": 187
+                  },
+                  "leftExpression": {
+                    "id": 61,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 185,
+                      "line": 15,
+                      "column": 9
+                    },
+                    "fullStart": 185,
+                    "endPos": {
+                      "offset": 186,
+                      "line": 15,
+                      "column": 10
+                    },
+                    "fullEnd": 186,
+                    "start": 185,
+                    "end": 186,
+                    "expression": {
+                      "id": 60,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 185,
+                        "line": 15,
+                        "column": 9
+                      },
+                      "fullStart": 185,
+                      "endPos": {
+                        "offset": 186,
+                        "line": 15,
+                        "column": 10
+                      },
+                      "fullEnd": 186,
+                      "start": 185,
+                      "end": 186,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 185,
+                          "line": 15,
+                          "column": 9
+                        },
+                        "endPos": {
+                          "offset": 186,
+                          "line": 15,
+                          "column": 10
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 185,
+                        "end": 186
+                      }
+                    },
+                    "referee": 1
+                  },
+                  "rightExpression": {
+                    "id": 63,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 187,
+                      "line": 15,
+                      "column": 11
+                    },
+                    "fullStart": 187,
+                    "endPos": {
+                      "offset": 191,
+                      "line": 15,
+                      "column": 15
+                    },
+                    "fullEnd": 192,
+                    "start": 187,
+                    "end": 191,
+                    "expression": {
+                      "id": 62,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 187,
+                        "line": 15,
+                        "column": 11
+                      },
+                      "fullStart": 187,
+                      "endPos": {
+                        "offset": 191,
+                        "line": 15,
+                        "column": 15
+                      },
+                      "fullEnd": 192,
+                      "start": 187,
+                      "end": 191,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 187,
+                          "line": 15,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 191,
+                          "line": 15,
+                          "column": 15
+                        },
+                        "value": "c_id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 191,
+                              "line": 15,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 192,
+                              "line": 15,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 191,
+                            "end": 192
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 187,
+                        "end": 191
+                      }
+                    },
+                    "referee": 3
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 70,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 192,
+                    "line": 15,
+                    "column": 16
+                  },
+                  "fullStart": 192,
+                  "endPos": {
+                    "offset": 208,
+                    "line": 15,
+                    "column": 32
+                  },
+                  "fullEnd": 209,
+                  "start": 192,
+                  "end": 208,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 192,
+                      "line": 15,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 193,
+                      "line": 15,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 192,
+                    "end": 193
+                  },
+                  "elementList": [
+                    {
+                      "id": 69,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 193,
+                        "line": 15,
+                        "column": 17
+                      },
+                      "fullStart": 193,
+                      "endPos": {
+                        "offset": 207,
+                        "line": 15,
+                        "column": 31
+                      },
+                      "fullEnd": 207,
+                      "start": 193,
+                      "end": 207,
+                      "name": {
+                        "id": 66,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 193,
+                          "line": 15,
+                          "column": 17
+                        },
+                        "fullStart": 193,
+                        "endPos": {
+                          "offset": 198,
+                          "line": 15,
+                          "column": 22
+                        },
+                        "fullEnd": 198,
+                        "start": 193,
+                        "end": 198,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 193,
+                              "line": 15,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 198,
+                              "line": 15,
+                              "column": 22
+                            },
+                            "value": "color",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 193,
+                            "end": 198
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 68,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 200,
+                          "line": 15,
+                          "column": 24
+                        },
+                        "fullStart": 200,
+                        "endPos": {
+                          "offset": 207,
+                          "line": 15,
+                          "column": 31
+                        },
+                        "fullEnd": 207,
+                        "start": 200,
+                        "end": 207,
+                        "expression": {
+                          "id": 67,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 200,
+                            "line": 15,
+                            "column": 24
+                          },
+                          "fullStart": 200,
+                          "endPos": {
+                            "offset": 207,
+                            "line": 15,
+                            "column": 31
+                          },
+                          "fullEnd": 207,
+                          "start": 200,
+                          "end": 207,
+                          "literal": {
+                            "kind": "<color>",
+                            "startPos": {
+                              "offset": 200,
+                              "line": 15,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 207,
+                              "line": 15,
+                              "column": 31
+                            },
+                            "value": "#123456",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 200,
+                            "end": 207
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 198,
+                          "line": 15,
+                          "column": 22
+                        },
+                        "endPos": {
+                          "offset": 199,
+                          "line": 15,
+                          "column": 23
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 199,
+                              "line": 15,
+                              "column": 23
+                            },
+                            "endPos": {
+                              "offset": 200,
+                              "line": 15,
+                              "column": 24
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -3369,192 +3506,57 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 197,
+                        "start": 198,
                         "end": 199
                       }
-                    },
-                    "referee": 5
-                  }
-                },
-                "rightExpression": {
-                  "id": 69,
-                  "kind": "<infix-expression>",
-                  "startPos": {
-                    "offset": 202,
-                    "line": 15,
-                    "column": 9
-                  },
-                  "fullStart": 202,
-                  "endPos": {
-                    "offset": 208,
-                    "line": 15,
-                    "column": 15
-                  },
-                  "fullEnd": 209,
-                  "start": 202,
-                  "end": 208,
-                  "op": {
-                    "kind": "<op>",
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
                     "startPos": {
-                      "offset": 203,
+                      "offset": 207,
                       "line": 15,
-                      "column": 10
+                      "column": 31
                     },
                     "endPos": {
-                      "offset": 204,
+                      "offset": 208,
                       "line": 15,
-                      "column": 11
+                      "column": 32
                     },
-                    "value": ".",
+                    "value": "]",
                     "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 203,
-                    "end": 204
-                  },
-                  "leftExpression": {
-                    "id": 66,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 202,
-                      "line": 15,
-                      "column": 9
-                    },
-                    "fullStart": 202,
-                    "endPos": {
-                      "offset": 203,
-                      "line": 15,
-                      "column": 10
-                    },
-                    "fullEnd": 203,
-                    "start": 202,
-                    "end": 203,
-                    "expression": {
-                      "id": 65,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 202,
-                        "line": 15,
-                        "column": 9
-                      },
-                      "fullStart": 202,
-                      "endPos": {
-                        "offset": 203,
-                        "line": 15,
-                        "column": 10
-                      },
-                      "fullEnd": 203,
-                      "start": 202,
-                      "end": 203,
-                      "variable": {
-                        "kind": "<identifier>",
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
                         "startPos": {
-                          "offset": 202,
+                          "offset": 208,
                           "line": 15,
-                          "column": 9
+                          "column": 32
                         },
                         "endPos": {
-                          "offset": 203,
-                          "line": 15,
-                          "column": 10
+                          "offset": 209,
+                          "line": 16,
+                          "column": 0
                         },
-                        "value": "b",
+                        "value": "\n",
                         "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 202,
-                        "end": 203
+                        "start": 208,
+                        "end": 209
                       }
-                    },
-                    "referee": 1
-                  },
-                  "rightExpression": {
-                    "id": 68,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 204,
-                      "line": 15,
-                      "column": 11
-                    },
-                    "fullStart": 204,
-                    "endPos": {
-                      "offset": 208,
-                      "line": 15,
-                      "column": 15
-                    },
-                    "fullEnd": 209,
-                    "start": 204,
-                    "end": 208,
-                    "expression": {
-                      "id": 67,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 204,
-                        "line": 15,
-                        "column": 11
-                      },
-                      "fullStart": 204,
-                      "endPos": {
-                        "offset": 208,
-                        "line": 15,
-                        "column": 15
-                      },
-                      "fullEnd": 209,
-                      "start": 204,
-                      "end": 208,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 204,
-                          "line": 15,
-                          "column": 11
-                        },
-                        "endPos": {
-                          "offset": 208,
-                          "line": 15,
-                          "column": 15
-                        },
-                        "value": "c_id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
-                          {
-                            "kind": "<newline>",
-                            "startPos": {
-                              "offset": 208,
-                              "line": 15,
-                              "column": 15
-                            },
-                            "endPos": {
-                              "offset": 209,
-                              "line": 16,
-                              "column": 0
-                            },
-                            "value": "\n",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 208,
-                            "end": 209
-                          }
-                        ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 204,
-                        "end": 208
-                      }
-                    },
-                    "referee": 3
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 207,
+                    "end": 208
                   }
                 }
-              },
-              "args": []
+              ]
             }
           ],
           "blockCloseBrace": {
@@ -3608,50 +3610,50 @@
         "Table:b": {
           "references": [
             {
-              "id": 41,
+              "id": 36,
               "kind": "<primary-expression>",
               "startPos": {
-                "offset": 135,
+                "offset": 118,
                 "line": 11,
-                "column": 32
+                "column": 15
               },
-              "fullStart": 135,
+              "fullStart": 118,
               "endPos": {
-                "offset": 136,
+                "offset": 119,
                 "line": 11,
-                "column": 33
+                "column": 16
               },
-              "fullEnd": 136,
-              "start": 135,
-              "end": 136,
+              "fullEnd": 119,
+              "start": 118,
+              "end": 119,
               "expression": {
-                "id": 40,
+                "id": 35,
                 "kind": "<variable>",
                 "startPos": {
-                  "offset": 135,
+                  "offset": 118,
                   "line": 11,
-                  "column": 32
+                  "column": 15
                 },
-                "fullStart": 135,
+                "fullStart": 118,
                 "endPos": {
-                  "offset": 136,
+                  "offset": 119,
                   "line": 11,
-                  "column": 33
+                  "column": 16
                 },
-                "fullEnd": 136,
-                "start": 135,
-                "end": 136,
+                "fullEnd": 119,
+                "start": 118,
+                "end": 119,
                 "variable": {
                   "kind": "<identifier>",
                   "startPos": {
-                    "offset": 135,
+                    "offset": 118,
                     "line": 11,
-                    "column": 32
+                    "column": 15
                   },
                   "endPos": {
-                    "offset": 136,
+                    "offset": 119,
                     "line": 11,
-                    "column": 33
+                    "column": 16
                   },
                   "value": "b",
                   "leadingTrivia": [],
@@ -3659,55 +3661,55 @@
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 135,
-                  "end": 136
+                  "start": 118,
+                  "end": 119
                 }
               },
               "referee": 1
             },
             {
-              "id": 66,
+              "id": 61,
               "kind": "<primary-expression>",
               "startPos": {
-                "offset": 202,
+                "offset": 185,
                 "line": 15,
                 "column": 9
               },
-              "fullStart": 202,
+              "fullStart": 185,
               "endPos": {
-                "offset": 203,
+                "offset": 186,
                 "line": 15,
                 "column": 10
               },
-              "fullEnd": 203,
-              "start": 202,
-              "end": 203,
+              "fullEnd": 186,
+              "start": 185,
+              "end": 186,
               "expression": {
-                "id": 65,
+                "id": 60,
                 "kind": "<variable>",
                 "startPos": {
-                  "offset": 202,
+                  "offset": 185,
                   "line": 15,
                   "column": 9
                 },
-                "fullStart": 202,
+                "fullStart": 185,
                 "endPos": {
-                  "offset": 203,
+                  "offset": 186,
                   "line": 15,
                   "column": 10
                 },
-                "fullEnd": 203,
-                "start": 202,
-                "end": 203,
+                "fullEnd": 186,
+                "start": 185,
+                "end": 186,
                 "variable": {
                   "kind": "<identifier>",
                   "startPos": {
-                    "offset": 202,
+                    "offset": 185,
                     "line": 15,
                     "column": 9
                   },
                   "endPos": {
-                    "offset": 203,
+                    "offset": 186,
                     "line": 15,
                     "column": 10
                   },
@@ -3717,8 +3719,8 @@
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 202,
-                  "end": 203
+                  "start": 185,
+                  "end": 186
                 }
               },
               "referee": 1
@@ -3729,50 +3731,50 @@
             "Column:id": {
               "references": [
                 {
-                  "id": 43,
+                  "id": 38,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 137,
+                    "offset": 120,
                     "line": 11,
-                    "column": 34
+                    "column": 17
                   },
-                  "fullStart": 137,
+                  "fullStart": 120,
                   "endPos": {
-                    "offset": 139,
+                    "offset": 122,
                     "line": 11,
-                    "column": 36
+                    "column": 19
                   },
-                  "fullEnd": 140,
-                  "start": 137,
-                  "end": 139,
+                  "fullEnd": 123,
+                  "start": 120,
+                  "end": 122,
                   "expression": {
-                    "id": 42,
+                    "id": 37,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 137,
+                      "offset": 120,
                       "line": 11,
-                      "column": 34
+                      "column": 17
                     },
-                    "fullStart": 137,
+                    "fullStart": 120,
                     "endPos": {
-                      "offset": 139,
+                      "offset": 122,
                       "line": 11,
-                      "column": 36
+                      "column": 19
                     },
-                    "fullEnd": 140,
-                    "start": 137,
-                    "end": 139,
+                    "fullEnd": 123,
+                    "start": 120,
+                    "end": 122,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 137,
+                        "offset": 120,
                         "line": 11,
-                        "column": 34
+                        "column": 17
                       },
                       "endPos": {
-                        "offset": 139,
+                        "offset": 122,
                         "line": 11,
-                        "column": 36
+                        "column": 19
                       },
                       "value": "id",
                       "leadingTrivia": [],
@@ -3780,14 +3782,14 @@
                         {
                           "kind": "<space>",
                           "startPos": {
-                            "offset": 139,
+                            "offset": 122,
                             "line": 11,
-                            "column": 36
+                            "column": 19
                           },
                           "endPos": {
-                            "offset": 140,
+                            "offset": 123,
                             "line": 11,
-                            "column": 37
+                            "column": 20
                           },
                           "value": " ",
                           "leadingTrivia": [],
@@ -3795,15 +3797,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 139,
-                          "end": 140
+                          "start": 122,
+                          "end": 123
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 137,
-                      "end": 139
+                      "start": 120,
+                      "end": 122
                     }
                   },
                   "referee": 2
@@ -3815,48 +3817,48 @@
             "Column:c_id": {
               "references": [
                 {
-                  "id": 68,
+                  "id": 63,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 204,
+                    "offset": 187,
                     "line": 15,
                     "column": 11
                   },
-                  "fullStart": 204,
+                  "fullStart": 187,
                   "endPos": {
-                    "offset": 208,
+                    "offset": 191,
                     "line": 15,
                     "column": 15
                   },
-                  "fullEnd": 209,
-                  "start": 204,
-                  "end": 208,
+                  "fullEnd": 192,
+                  "start": 187,
+                  "end": 191,
                   "expression": {
-                    "id": 67,
+                    "id": 62,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 204,
+                      "offset": 187,
                       "line": 15,
                       "column": 11
                     },
-                    "fullStart": 204,
+                    "fullStart": 187,
                     "endPos": {
-                      "offset": 208,
+                      "offset": 191,
                       "line": 15,
                       "column": 15
                     },
-                    "fullEnd": 209,
-                    "start": 204,
-                    "end": 208,
+                    "fullEnd": 192,
+                    "start": 187,
+                    "end": 191,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 204,
+                        "offset": 187,
                         "line": 15,
                         "column": 11
                       },
                       "endPos": {
-                        "offset": 208,
+                        "offset": 191,
                         "line": 15,
                         "column": 15
                       },
@@ -3864,32 +3866,32 @@
                       "leadingTrivia": [],
                       "trailingTrivia": [
                         {
-                          "kind": "<newline>",
+                          "kind": "<space>",
                           "startPos": {
-                            "offset": 208,
+                            "offset": 191,
                             "line": 15,
                             "column": 15
                           },
                           "endPos": {
-                            "offset": 209,
-                            "line": 16,
-                            "column": 0
+                            "offset": 192,
+                            "line": 15,
+                            "column": 16
                           },
-                          "value": "\n",
+                          "value": " ",
                           "leadingTrivia": [],
                           "trailingTrivia": [],
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 208,
-                          "end": 209
+                          "start": 191,
+                          "end": 192
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 204,
-                      "end": 208
+                      "start": 187,
+                      "end": 191
                     }
                   },
                   "referee": 3
@@ -3904,50 +3906,50 @@
         "Table:c": {
           "references": [
             {
-              "id": 46,
+              "id": 41,
               "kind": "<primary-expression>",
               "startPos": {
-                "offset": 142,
+                "offset": 125,
                 "line": 11,
-                "column": 39
+                "column": 22
               },
-              "fullStart": 142,
+              "fullStart": 125,
               "endPos": {
-                "offset": 143,
+                "offset": 126,
                 "line": 11,
-                "column": 40
+                "column": 23
               },
-              "fullEnd": 143,
-              "start": 142,
-              "end": 143,
+              "fullEnd": 126,
+              "start": 125,
+              "end": 126,
               "expression": {
-                "id": 45,
+                "id": 40,
                 "kind": "<variable>",
                 "startPos": {
-                  "offset": 142,
+                  "offset": 125,
                   "line": 11,
-                  "column": 39
+                  "column": 22
                 },
-                "fullStart": 142,
+                "fullStart": 125,
                 "endPos": {
-                  "offset": 143,
+                  "offset": 126,
                   "line": 11,
-                  "column": 40
+                  "column": 23
                 },
-                "fullEnd": 143,
-                "start": 142,
-                "end": 143,
+                "fullEnd": 126,
+                "start": 125,
+                "end": 126,
                 "variable": {
                   "kind": "<identifier>",
                   "startPos": {
-                    "offset": 142,
+                    "offset": 125,
                     "line": 11,
-                    "column": 39
+                    "column": 22
                   },
                   "endPos": {
-                    "offset": 143,
+                    "offset": 126,
                     "line": 11,
-                    "column": 40
+                    "column": 23
                   },
                   "value": "c",
                   "leadingTrivia": [],
@@ -3955,55 +3957,55 @@
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 142,
-                  "end": 143
+                  "start": 125,
+                  "end": 126
                 }
               },
               "referee": 4
             },
             {
-              "id": 61,
+              "id": 56,
               "kind": "<primary-expression>",
               "startPos": {
-                "offset": 195,
+                "offset": 178,
                 "line": 15,
                 "column": 2
               },
-              "fullStart": 193,
+              "fullStart": 176,
               "endPos": {
-                "offset": 196,
+                "offset": 179,
                 "line": 15,
                 "column": 3
               },
-              "fullEnd": 196,
-              "start": 195,
-              "end": 196,
+              "fullEnd": 179,
+              "start": 178,
+              "end": 179,
               "expression": {
-                "id": 60,
+                "id": 55,
                 "kind": "<variable>",
                 "startPos": {
-                  "offset": 195,
+                  "offset": 178,
                   "line": 15,
                   "column": 2
                 },
-                "fullStart": 193,
+                "fullStart": 176,
                 "endPos": {
-                  "offset": 196,
+                  "offset": 179,
                   "line": 15,
                   "column": 3
                 },
-                "fullEnd": 196,
-                "start": 195,
-                "end": 196,
+                "fullEnd": 179,
+                "start": 178,
+                "end": 179,
                 "variable": {
                   "kind": "<identifier>",
                   "startPos": {
-                    "offset": 195,
+                    "offset": 178,
                     "line": 15,
                     "column": 2
                   },
                   "endPos": {
-                    "offset": 196,
+                    "offset": 179,
                     "line": 15,
                     "column": 3
                   },
@@ -4012,12 +4014,12 @@
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 193,
+                        "offset": 176,
                         "line": 15,
                         "column": 0
                       },
                       "endPos": {
-                        "offset": 194,
+                        "offset": 177,
                         "line": 15,
                         "column": 1
                       },
@@ -4027,18 +4029,18 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 193,
-                      "end": 194
+                      "start": 176,
+                      "end": 177
                     },
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 194,
+                        "offset": 177,
                         "line": 15,
                         "column": 1
                       },
                       "endPos": {
-                        "offset": 195,
+                        "offset": 178,
                         "line": 15,
                         "column": 2
                       },
@@ -4048,16 +4050,16 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 194,
-                      "end": 195
+                      "start": 177,
+                      "end": 178
                     }
                   ],
                   "trailingTrivia": [],
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 195,
-                  "end": 196
+                  "start": 178,
+                  "end": 179
                 }
               },
               "referee": 4
@@ -4068,128 +4070,128 @@
             "Column:id": {
               "references": [
                 {
-                  "id": 48,
+                  "id": 43,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 144,
+                    "offset": 127,
                     "line": 11,
-                    "column": 41
+                    "column": 24
                   },
-                  "fullStart": 144,
+                  "fullStart": 127,
                   "endPos": {
-                    "offset": 146,
+                    "offset": 129,
                     "line": 11,
-                    "column": 43
+                    "column": 26
                   },
-                  "fullEnd": 147,
-                  "start": 144,
-                  "end": 146,
+                  "fullEnd": 130,
+                  "start": 127,
+                  "end": 129,
                   "expression": {
-                    "id": 47,
+                    "id": 42,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 144,
+                      "offset": 127,
                       "line": 11,
-                      "column": 41
+                      "column": 24
                     },
-                    "fullStart": 144,
+                    "fullStart": 127,
                     "endPos": {
-                      "offset": 146,
+                      "offset": 129,
                       "line": 11,
-                      "column": 43
+                      "column": 26
                     },
-                    "fullEnd": 147,
-                    "start": 144,
-                    "end": 146,
+                    "fullEnd": 130,
+                    "start": 127,
+                    "end": 129,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 144,
+                        "offset": 127,
                         "line": 11,
-                        "column": 41
+                        "column": 24
                       },
                       "endPos": {
-                        "offset": 146,
+                        "offset": 129,
                         "line": 11,
-                        "column": 43
+                        "column": 26
                       },
                       "value": "id",
                       "leadingTrivia": [],
                       "trailingTrivia": [
                         {
-                          "kind": "<newline>",
+                          "kind": "<space>",
                           "startPos": {
-                            "offset": 146,
+                            "offset": 129,
                             "line": 11,
-                            "column": 43
+                            "column": 26
                           },
                           "endPos": {
-                            "offset": 147,
-                            "line": 12,
-                            "column": 0
+                            "offset": 130,
+                            "line": 11,
+                            "column": 27
                           },
-                          "value": "\n",
+                          "value": " ",
                           "leadingTrivia": [],
                           "trailingTrivia": [],
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 146,
-                          "end": 147
+                          "start": 129,
+                          "end": 130
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 144,
-                      "end": 146
+                      "start": 127,
+                      "end": 129
                     }
                   },
                   "referee": 5
                 },
                 {
-                  "id": 63,
+                  "id": 58,
                   "kind": "<primary-expression>",
                   "startPos": {
-                    "offset": 197,
+                    "offset": 180,
                     "line": 15,
                     "column": 4
                   },
-                  "fullStart": 197,
+                  "fullStart": 180,
                   "endPos": {
-                    "offset": 199,
+                    "offset": 182,
                     "line": 15,
                     "column": 6
                   },
-                  "fullEnd": 200,
-                  "start": 197,
-                  "end": 199,
+                  "fullEnd": 183,
+                  "start": 180,
+                  "end": 182,
                   "expression": {
-                    "id": 62,
+                    "id": 57,
                     "kind": "<variable>",
                     "startPos": {
-                      "offset": 197,
+                      "offset": 180,
                       "line": 15,
                       "column": 4
                     },
-                    "fullStart": 197,
+                    "fullStart": 180,
                     "endPos": {
-                      "offset": 199,
+                      "offset": 182,
                       "line": 15,
                       "column": 6
                     },
-                    "fullEnd": 200,
-                    "start": 197,
-                    "end": 199,
+                    "fullEnd": 183,
+                    "start": 180,
+                    "end": 182,
                     "variable": {
                       "kind": "<identifier>",
                       "startPos": {
-                        "offset": 197,
+                        "offset": 180,
                         "line": 15,
                         "column": 4
                       },
                       "endPos": {
-                        "offset": 199,
+                        "offset": 182,
                         "line": 15,
                         "column": 6
                       },
@@ -4199,12 +4201,12 @@
                         {
                           "kind": "<space>",
                           "startPos": {
-                            "offset": 199,
+                            "offset": 182,
                             "line": 15,
                             "column": 6
                           },
                           "endPos": {
-                            "offset": 200,
+                            "offset": 183,
                             "line": 15,
                             "column": 7
                           },
@@ -4214,15 +4216,15 @@
                           "leadingInvalid": [],
                           "trailingInvalid": [],
                           "isInvalid": false,
-                          "start": 199,
-                          "end": 200
+                          "start": 182,
+                          "end": 183
                         }
                       ],
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 197,
-                      "end": 199
+                      "start": 180,
+                      "end": 182
                     }
                   },
                   "referee": 5

--- a/packages/dbml-parse/tests/interpreter/input/ref_name_and_color_setting.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/ref_name_and_color_setting.in.dbml
@@ -9,9 +9,9 @@ Table c {
 }
 
 // Short form
-Ref short_ref [color: #aabbcc]: b.id < c.id
+Ref short_ref: b.id < c.id [color: #aabbcc]
 
 // Long form
-Ref long_ref [color: #123456] {
-  c.id < b.c_id
+Ref long_ref {
+  c.id < b.c_id [color: #123456]
 }

--- a/packages/dbml-parse/tests/interpreter/output/ref_name_and_color_setting.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/ref_name_and_color_setting.out.json
@@ -163,14 +163,14 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 135,
+              "offset": 118,
               "line": 12,
-              "column": 33
+              "column": 16
             },
             "end": {
-              "offset": 139,
+              "offset": 122,
               "line": 12,
-              "column": 37
+              "column": 20
             }
           }
         },
@@ -183,14 +183,14 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 142,
+              "offset": 125,
               "line": 12,
-              "column": 40
+              "column": 23
             },
             "end": {
-              "offset": 146,
+              "offset": 129,
               "line": 12,
-              "column": 44
+              "column": 27
             }
           }
         }
@@ -222,12 +222,12 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 195,
+              "offset": 178,
               "line": 16,
               "column": 3
             },
             "end": {
-              "offset": 199,
+              "offset": 182,
               "line": 16,
               "column": 7
             }
@@ -242,12 +242,12 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 202,
+              "offset": 185,
               "line": 16,
               "column": 10
             },
             "end": {
-              "offset": 208,
+              "offset": 191,
               "line": 16,
               "column": 16
             }

--- a/packages/dbml-parse/tests/validator/input/ref_error_setting.in.dbml
+++ b/packages/dbml-parse/tests/validator/input/ref_error_setting.in.dbml
@@ -1,0 +1,45 @@
+Table b [headercolor: #aaaaaa] {
+  id int
+  c_id int
+  id2 int
+  id3 int
+  id4 int
+  id5 int
+  id6 int
+  id7 int
+}
+
+Table c {
+  id int
+  b_id int
+  id2 int
+  id3 int
+  id4 int
+  id5 int
+  id6 int
+  id7 int
+}
+
+// Short form
+Ref short_ref: b.id < c.id [color: #aabbcc, update: set null]
+
+// Long form
+Ref long_ref {
+  c.id < b.c_id [color: #123456, delete: cascade]
+}
+
+Ref error_ref2 [color: #123456] {
+  c.id2 < b.id2
+}
+
+Ref error_ref3 {
+  c.id3 < b.id3 [color: #not_a_color]
+}
+
+Ref error_ref4 {
+  c.id4 < b.id4 [hello: goodbye]
+}
+
+Ref error_shortref2 [color: #123456]: c.id5 < b.id5
+Ref error_shortref3: c.id6 < b.id6 [color: #not_a_color]
+Ref error_shortref4: c.id7 < b.id7 [hello: goodbye]

--- a/packages/dbml-parse/tests/validator/input/ref_name_and_color_setting.in copy.dbml
+++ b/packages/dbml-parse/tests/validator/input/ref_name_and_color_setting.in copy.dbml
@@ -9,9 +9,9 @@ Table c {
 }
 
 // Short form
-Ref short_ref [color: #aabbcc]: b.id < c.id
+Ref short_ref: b.id < c.id [color: #aabbcc]
 
 // Long form
-Ref long_ref [color: #123456] {
-  c.id < b.c_id
+Ref long_ref {
+  c.id < b.c_id [color: #123456]
 }

--- a/packages/dbml-parse/tests/validator/output/ref_error_setting.out.json
+++ b/packages/dbml-parse/tests/validator/output/ref_error_setting.out.json
@@ -9,13 +9,13 @@
     },
     "fullStart": 0,
     "endPos": {
-      "offset": 693,
-      "line": 46,
+      "offset": 692,
+      "line": 45,
       "column": 0
     },
-    "fullEnd": 693,
+    "fullEnd": 692,
     "start": 0,
-    "end": 693,
+    "end": 692,
     "body": [
       {
         "id": 48,
@@ -12190,45 +12190,23 @@
     "eof": {
       "kind": "<eof>",
       "startPos": {
-        "offset": 693,
-        "line": 46,
+        "offset": 692,
+        "line": 45,
         "column": 0
       },
       "endPos": {
-        "offset": 693,
-        "line": 46,
+        "offset": 692,
+        "line": 45,
         "column": 0
       },
       "value": "",
-      "leadingTrivia": [
-        {
-          "kind": "<newline>",
-          "startPos": {
-            "offset": 692,
-            "line": 45,
-            "column": 0
-          },
-          "endPos": {
-            "offset": 693,
-            "line": 46,
-            "column": 0
-          },
-          "value": "\n",
-          "leadingTrivia": [],
-          "trailingTrivia": [],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 692,
-          "end": 693
-        }
-      ],
+      "leadingTrivia": [],
       "trailingTrivia": [],
       "leadingInvalid": [],
       "trailingInvalid": [],
       "isInvalid": false,
-      "start": 693,
-      "end": 693
+      "start": 692,
+      "end": 692
     },
     "symbol": {
       "symbolTable": {

--- a/packages/dbml-parse/tests/validator/output/ref_error_setting.out.json
+++ b/packages/dbml-parse/tests/validator/output/ref_error_setting.out.json
@@ -1,0 +1,13480 @@
+{
+  "value": {
+    "id": 264,
+    "kind": "<program>",
+    "startPos": {
+      "offset": 0,
+      "line": 0,
+      "column": 0
+    },
+    "fullStart": 0,
+    "endPos": {
+      "offset": 693,
+      "line": 46,
+      "column": 0
+    },
+    "fullEnd": 693,
+    "start": 0,
+    "end": 693,
+    "body": [
+      {
+        "id": 48,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 0,
+          "line": 0,
+          "column": 0
+        },
+        "fullStart": 0,
+        "endPos": {
+          "offset": 114,
+          "line": 9,
+          "column": 1
+        },
+        "fullEnd": 115,
+        "start": 0,
+        "end": 114,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 0,
+            "line": 0,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 5,
+            "line": 0,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 5,
+                "line": 0,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 5,
+              "end": 6
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 0,
+          "end": 5
+        },
+        "name": {
+          "id": 1,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 6,
+            "line": 0,
+            "column": 6
+          },
+          "fullStart": 6,
+          "endPos": {
+            "offset": 7,
+            "line": 0,
+            "column": 7
+          },
+          "fullEnd": 8,
+          "start": 6,
+          "end": 7,
+          "expression": {
+            "id": 0,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 6,
+              "line": 0,
+              "column": 6
+            },
+            "fullStart": 6,
+            "endPos": {
+              "offset": 7,
+              "line": 0,
+              "column": 7
+            },
+            "fullEnd": 8,
+            "start": 6,
+            "end": 7,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 6,
+                "line": 0,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 7,
+                "line": 0,
+                "column": 7
+              },
+              "value": "b",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 7,
+                    "line": 0,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 8,
+                    "line": 0,
+                    "column": 8
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 7,
+                  "end": 8
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 6,
+              "end": 7
+            }
+          }
+        },
+        "attributeList": {
+          "id": 6,
+          "kind": "<list-expression>",
+          "startPos": {
+            "offset": 8,
+            "line": 0,
+            "column": 8
+          },
+          "fullStart": 8,
+          "endPos": {
+            "offset": 30,
+            "line": 0,
+            "column": 30
+          },
+          "fullEnd": 31,
+          "start": 8,
+          "end": 30,
+          "listOpenBracket": {
+            "kind": "<lbracket>",
+            "startPos": {
+              "offset": 8,
+              "line": 0,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 9,
+              "line": 0,
+              "column": 9
+            },
+            "value": "[",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 8,
+            "end": 9
+          },
+          "elementList": [
+            {
+              "id": 5,
+              "kind": "<attribute>",
+              "startPos": {
+                "offset": 9,
+                "line": 0,
+                "column": 9
+              },
+              "fullStart": 9,
+              "endPos": {
+                "offset": 29,
+                "line": 0,
+                "column": 29
+              },
+              "fullEnd": 29,
+              "start": 9,
+              "end": 29,
+              "name": {
+                "id": 2,
+                "kind": "<identifer-stream>",
+                "startPos": {
+                  "offset": 9,
+                  "line": 0,
+                  "column": 9
+                },
+                "fullStart": 9,
+                "endPos": {
+                  "offset": 20,
+                  "line": 0,
+                  "column": 20
+                },
+                "fullEnd": 20,
+                "start": 9,
+                "end": 20,
+                "identifiers": [
+                  {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 9,
+                      "line": 0,
+                      "column": 9
+                    },
+                    "endPos": {
+                      "offset": 20,
+                      "line": 0,
+                      "column": 20
+                    },
+                    "value": "headercolor",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 9,
+                    "end": 20
+                  }
+                ]
+              },
+              "value": {
+                "id": 4,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 22,
+                  "line": 0,
+                  "column": 22
+                },
+                "fullStart": 22,
+                "endPos": {
+                  "offset": 29,
+                  "line": 0,
+                  "column": 29
+                },
+                "fullEnd": 29,
+                "start": 22,
+                "end": 29,
+                "expression": {
+                  "id": 3,
+                  "kind": "<literal>",
+                  "startPos": {
+                    "offset": 22,
+                    "line": 0,
+                    "column": 22
+                  },
+                  "fullStart": 22,
+                  "endPos": {
+                    "offset": 29,
+                    "line": 0,
+                    "column": 29
+                  },
+                  "fullEnd": 29,
+                  "start": 22,
+                  "end": 29,
+                  "literal": {
+                    "kind": "<color>",
+                    "startPos": {
+                      "offset": 22,
+                      "line": 0,
+                      "column": 22
+                    },
+                    "endPos": {
+                      "offset": 29,
+                      "line": 0,
+                      "column": 29
+                    },
+                    "value": "#aaaaaa",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 22,
+                    "end": 29
+                  }
+                }
+              },
+              "colon": {
+                "kind": "<colon>",
+                "startPos": {
+                  "offset": 20,
+                  "line": 0,
+                  "column": 20
+                },
+                "endPos": {
+                  "offset": 21,
+                  "line": 0,
+                  "column": 21
+                },
+                "value": ":",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 21,
+                      "line": 0,
+                      "column": 21
+                    },
+                    "endPos": {
+                      "offset": 22,
+                      "line": 0,
+                      "column": 22
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 21,
+                    "end": 22
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 20,
+                "end": 21
+              }
+            }
+          ],
+          "commaList": [],
+          "listCloseBracket": {
+            "kind": "<rbracket>",
+            "startPos": {
+              "offset": 29,
+              "line": 0,
+              "column": 29
+            },
+            "endPos": {
+              "offset": 30,
+              "line": 0,
+              "column": 30
+            },
+            "value": "]",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 30,
+                  "line": 0,
+                  "column": 30
+                },
+                "endPos": {
+                  "offset": 31,
+                  "line": 0,
+                  "column": 31
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 30,
+                "end": 31
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 29,
+            "end": 30
+          }
+        },
+        "body": {
+          "id": 47,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 31,
+            "line": 0,
+            "column": 31
+          },
+          "fullStart": 31,
+          "endPos": {
+            "offset": 114,
+            "line": 9,
+            "column": 1
+          },
+          "fullEnd": 115,
+          "start": 31,
+          "end": 114,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 31,
+              "line": 0,
+              "column": 31
+            },
+            "endPos": {
+              "offset": 32,
+              "line": 0,
+              "column": 32
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 32,
+                  "line": 0,
+                  "column": 32
+                },
+                "endPos": {
+                  "offset": 33,
+                  "line": 1,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 32,
+                "end": 33
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 31,
+            "end": 32
+          },
+          "body": [
+            {
+              "id": 11,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 35,
+                "line": 1,
+                "column": 2
+              },
+              "fullStart": 33,
+              "endPos": {
+                "offset": 41,
+                "line": 1,
+                "column": 8
+              },
+              "fullEnd": 42,
+              "start": 35,
+              "end": 41,
+              "callee": {
+                "id": 8,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 35,
+                  "line": 1,
+                  "column": 2
+                },
+                "fullStart": 33,
+                "endPos": {
+                  "offset": 37,
+                  "line": 1,
+                  "column": 4
+                },
+                "fullEnd": 38,
+                "start": 35,
+                "end": 37,
+                "expression": {
+                  "id": 7,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 35,
+                    "line": 1,
+                    "column": 2
+                  },
+                  "fullStart": 33,
+                  "endPos": {
+                    "offset": 37,
+                    "line": 1,
+                    "column": 4
+                  },
+                  "fullEnd": 38,
+                  "start": 35,
+                  "end": 37,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 35,
+                      "line": 1,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 37,
+                      "line": 1,
+                      "column": 4
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 33,
+                          "line": 1,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 34,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 33,
+                        "end": 34
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 34,
+                          "line": 1,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 35,
+                          "line": 1,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 34,
+                        "end": 35
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 37,
+                          "line": 1,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 38,
+                          "line": 1,
+                          "column": 5
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 37,
+                        "end": 38
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 35,
+                    "end": 37
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 10,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 38,
+                    "line": 1,
+                    "column": 5
+                  },
+                  "fullStart": 38,
+                  "endPos": {
+                    "offset": 41,
+                    "line": 1,
+                    "column": 8
+                  },
+                  "fullEnd": 42,
+                  "start": 38,
+                  "end": 41,
+                  "expression": {
+                    "id": 9,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 38,
+                      "line": 1,
+                      "column": 5
+                    },
+                    "fullStart": 38,
+                    "endPos": {
+                      "offset": 41,
+                      "line": 1,
+                      "column": 8
+                    },
+                    "fullEnd": 42,
+                    "start": 38,
+                    "end": 41,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 38,
+                        "line": 1,
+                        "column": 5
+                      },
+                      "endPos": {
+                        "offset": 41,
+                        "line": 1,
+                        "column": 8
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 41,
+                            "line": 1,
+                            "column": 8
+                          },
+                          "endPos": {
+                            "offset": 42,
+                            "line": 2,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 41,
+                          "end": 42
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 38,
+                      "end": 41
+                    }
+                  }
+                }
+              ],
+              "symbol": 2
+            },
+            {
+              "id": 16,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 44,
+                "line": 2,
+                "column": 2
+              },
+              "fullStart": 42,
+              "endPos": {
+                "offset": 52,
+                "line": 2,
+                "column": 10
+              },
+              "fullEnd": 53,
+              "start": 44,
+              "end": 52,
+              "callee": {
+                "id": 13,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 44,
+                  "line": 2,
+                  "column": 2
+                },
+                "fullStart": 42,
+                "endPos": {
+                  "offset": 48,
+                  "line": 2,
+                  "column": 6
+                },
+                "fullEnd": 49,
+                "start": 44,
+                "end": 48,
+                "expression": {
+                  "id": 12,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 44,
+                    "line": 2,
+                    "column": 2
+                  },
+                  "fullStart": 42,
+                  "endPos": {
+                    "offset": 48,
+                    "line": 2,
+                    "column": 6
+                  },
+                  "fullEnd": 49,
+                  "start": 44,
+                  "end": 48,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 44,
+                      "line": 2,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 48,
+                      "line": 2,
+                      "column": 6
+                    },
+                    "value": "c_id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 42,
+                          "line": 2,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 43,
+                          "line": 2,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 42,
+                        "end": 43
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 43,
+                          "line": 2,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 44,
+                          "line": 2,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 43,
+                        "end": 44
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 48,
+                          "line": 2,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 49,
+                          "line": 2,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 48,
+                        "end": 49
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 44,
+                    "end": 48
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 15,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 49,
+                    "line": 2,
+                    "column": 7
+                  },
+                  "fullStart": 49,
+                  "endPos": {
+                    "offset": 52,
+                    "line": 2,
+                    "column": 10
+                  },
+                  "fullEnd": 53,
+                  "start": 49,
+                  "end": 52,
+                  "expression": {
+                    "id": 14,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 49,
+                      "line": 2,
+                      "column": 7
+                    },
+                    "fullStart": 49,
+                    "endPos": {
+                      "offset": 52,
+                      "line": 2,
+                      "column": 10
+                    },
+                    "fullEnd": 53,
+                    "start": 49,
+                    "end": 52,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 49,
+                        "line": 2,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 52,
+                        "line": 2,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 52,
+                            "line": 2,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 53,
+                            "line": 3,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 52,
+                          "end": 53
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 49,
+                      "end": 52
+                    }
+                  }
+                }
+              ],
+              "symbol": 3
+            },
+            {
+              "id": 21,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 55,
+                "line": 3,
+                "column": 2
+              },
+              "fullStart": 53,
+              "endPos": {
+                "offset": 62,
+                "line": 3,
+                "column": 9
+              },
+              "fullEnd": 63,
+              "start": 55,
+              "end": 62,
+              "callee": {
+                "id": 18,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 55,
+                  "line": 3,
+                  "column": 2
+                },
+                "fullStart": 53,
+                "endPos": {
+                  "offset": 58,
+                  "line": 3,
+                  "column": 5
+                },
+                "fullEnd": 59,
+                "start": 55,
+                "end": 58,
+                "expression": {
+                  "id": 17,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 55,
+                    "line": 3,
+                    "column": 2
+                  },
+                  "fullStart": 53,
+                  "endPos": {
+                    "offset": 58,
+                    "line": 3,
+                    "column": 5
+                  },
+                  "fullEnd": 59,
+                  "start": 55,
+                  "end": 58,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 55,
+                      "line": 3,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 58,
+                      "line": 3,
+                      "column": 5
+                    },
+                    "value": "id2",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 53,
+                          "line": 3,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 54,
+                          "line": 3,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 53,
+                        "end": 54
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 54,
+                          "line": 3,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 55,
+                          "line": 3,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 54,
+                        "end": 55
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 58,
+                          "line": 3,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 59,
+                          "line": 3,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 58,
+                        "end": 59
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 55,
+                    "end": 58
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 20,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 59,
+                    "line": 3,
+                    "column": 6
+                  },
+                  "fullStart": 59,
+                  "endPos": {
+                    "offset": 62,
+                    "line": 3,
+                    "column": 9
+                  },
+                  "fullEnd": 63,
+                  "start": 59,
+                  "end": 62,
+                  "expression": {
+                    "id": 19,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 59,
+                      "line": 3,
+                      "column": 6
+                    },
+                    "fullStart": 59,
+                    "endPos": {
+                      "offset": 62,
+                      "line": 3,
+                      "column": 9
+                    },
+                    "fullEnd": 63,
+                    "start": 59,
+                    "end": 62,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 59,
+                        "line": 3,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 62,
+                        "line": 3,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 62,
+                            "line": 3,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 63,
+                            "line": 4,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 62,
+                          "end": 63
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 59,
+                      "end": 62
+                    }
+                  }
+                }
+              ],
+              "symbol": 4
+            },
+            {
+              "id": 26,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 65,
+                "line": 4,
+                "column": 2
+              },
+              "fullStart": 63,
+              "endPos": {
+                "offset": 72,
+                "line": 4,
+                "column": 9
+              },
+              "fullEnd": 73,
+              "start": 65,
+              "end": 72,
+              "callee": {
+                "id": 23,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 65,
+                  "line": 4,
+                  "column": 2
+                },
+                "fullStart": 63,
+                "endPos": {
+                  "offset": 68,
+                  "line": 4,
+                  "column": 5
+                },
+                "fullEnd": 69,
+                "start": 65,
+                "end": 68,
+                "expression": {
+                  "id": 22,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 65,
+                    "line": 4,
+                    "column": 2
+                  },
+                  "fullStart": 63,
+                  "endPos": {
+                    "offset": 68,
+                    "line": 4,
+                    "column": 5
+                  },
+                  "fullEnd": 69,
+                  "start": 65,
+                  "end": 68,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 65,
+                      "line": 4,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 68,
+                      "line": 4,
+                      "column": 5
+                    },
+                    "value": "id3",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 63,
+                          "line": 4,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 64,
+                          "line": 4,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 63,
+                        "end": 64
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 64,
+                          "line": 4,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 65,
+                          "line": 4,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 64,
+                        "end": 65
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 68,
+                          "line": 4,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 69,
+                          "line": 4,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 68,
+                        "end": 69
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 65,
+                    "end": 68
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 25,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 69,
+                    "line": 4,
+                    "column": 6
+                  },
+                  "fullStart": 69,
+                  "endPos": {
+                    "offset": 72,
+                    "line": 4,
+                    "column": 9
+                  },
+                  "fullEnd": 73,
+                  "start": 69,
+                  "end": 72,
+                  "expression": {
+                    "id": 24,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 69,
+                      "line": 4,
+                      "column": 6
+                    },
+                    "fullStart": 69,
+                    "endPos": {
+                      "offset": 72,
+                      "line": 4,
+                      "column": 9
+                    },
+                    "fullEnd": 73,
+                    "start": 69,
+                    "end": 72,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 69,
+                        "line": 4,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 72,
+                        "line": 4,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 72,
+                            "line": 4,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 73,
+                            "line": 5,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 72,
+                          "end": 73
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 69,
+                      "end": 72
+                    }
+                  }
+                }
+              ],
+              "symbol": 5
+            },
+            {
+              "id": 31,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 75,
+                "line": 5,
+                "column": 2
+              },
+              "fullStart": 73,
+              "endPos": {
+                "offset": 82,
+                "line": 5,
+                "column": 9
+              },
+              "fullEnd": 83,
+              "start": 75,
+              "end": 82,
+              "callee": {
+                "id": 28,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 75,
+                  "line": 5,
+                  "column": 2
+                },
+                "fullStart": 73,
+                "endPos": {
+                  "offset": 78,
+                  "line": 5,
+                  "column": 5
+                },
+                "fullEnd": 79,
+                "start": 75,
+                "end": 78,
+                "expression": {
+                  "id": 27,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 75,
+                    "line": 5,
+                    "column": 2
+                  },
+                  "fullStart": 73,
+                  "endPos": {
+                    "offset": 78,
+                    "line": 5,
+                    "column": 5
+                  },
+                  "fullEnd": 79,
+                  "start": 75,
+                  "end": 78,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 75,
+                      "line": 5,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 78,
+                      "line": 5,
+                      "column": 5
+                    },
+                    "value": "id4",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 73,
+                          "line": 5,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 74,
+                          "line": 5,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 73,
+                        "end": 74
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 74,
+                          "line": 5,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 75,
+                          "line": 5,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 74,
+                        "end": 75
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 78,
+                          "line": 5,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 79,
+                          "line": 5,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 78,
+                        "end": 79
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 75,
+                    "end": 78
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 30,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 79,
+                    "line": 5,
+                    "column": 6
+                  },
+                  "fullStart": 79,
+                  "endPos": {
+                    "offset": 82,
+                    "line": 5,
+                    "column": 9
+                  },
+                  "fullEnd": 83,
+                  "start": 79,
+                  "end": 82,
+                  "expression": {
+                    "id": 29,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 79,
+                      "line": 5,
+                      "column": 6
+                    },
+                    "fullStart": 79,
+                    "endPos": {
+                      "offset": 82,
+                      "line": 5,
+                      "column": 9
+                    },
+                    "fullEnd": 83,
+                    "start": 79,
+                    "end": 82,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 79,
+                        "line": 5,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 82,
+                        "line": 5,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 82,
+                            "line": 5,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 83,
+                            "line": 6,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 82,
+                          "end": 83
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 79,
+                      "end": 82
+                    }
+                  }
+                }
+              ],
+              "symbol": 6
+            },
+            {
+              "id": 36,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 85,
+                "line": 6,
+                "column": 2
+              },
+              "fullStart": 83,
+              "endPos": {
+                "offset": 92,
+                "line": 6,
+                "column": 9
+              },
+              "fullEnd": 93,
+              "start": 85,
+              "end": 92,
+              "callee": {
+                "id": 33,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 85,
+                  "line": 6,
+                  "column": 2
+                },
+                "fullStart": 83,
+                "endPos": {
+                  "offset": 88,
+                  "line": 6,
+                  "column": 5
+                },
+                "fullEnd": 89,
+                "start": 85,
+                "end": 88,
+                "expression": {
+                  "id": 32,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 85,
+                    "line": 6,
+                    "column": 2
+                  },
+                  "fullStart": 83,
+                  "endPos": {
+                    "offset": 88,
+                    "line": 6,
+                    "column": 5
+                  },
+                  "fullEnd": 89,
+                  "start": 85,
+                  "end": 88,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 85,
+                      "line": 6,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 88,
+                      "line": 6,
+                      "column": 5
+                    },
+                    "value": "id5",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 83,
+                          "line": 6,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 84,
+                          "line": 6,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 83,
+                        "end": 84
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 84,
+                          "line": 6,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 85,
+                          "line": 6,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 84,
+                        "end": 85
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 88,
+                          "line": 6,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 89,
+                          "line": 6,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 88,
+                        "end": 89
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 85,
+                    "end": 88
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 35,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 89,
+                    "line": 6,
+                    "column": 6
+                  },
+                  "fullStart": 89,
+                  "endPos": {
+                    "offset": 92,
+                    "line": 6,
+                    "column": 9
+                  },
+                  "fullEnd": 93,
+                  "start": 89,
+                  "end": 92,
+                  "expression": {
+                    "id": 34,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 89,
+                      "line": 6,
+                      "column": 6
+                    },
+                    "fullStart": 89,
+                    "endPos": {
+                      "offset": 92,
+                      "line": 6,
+                      "column": 9
+                    },
+                    "fullEnd": 93,
+                    "start": 89,
+                    "end": 92,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 89,
+                        "line": 6,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 92,
+                        "line": 6,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 92,
+                            "line": 6,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 93,
+                            "line": 7,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 92,
+                          "end": 93
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 89,
+                      "end": 92
+                    }
+                  }
+                }
+              ],
+              "symbol": 7
+            },
+            {
+              "id": 41,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 95,
+                "line": 7,
+                "column": 2
+              },
+              "fullStart": 93,
+              "endPos": {
+                "offset": 102,
+                "line": 7,
+                "column": 9
+              },
+              "fullEnd": 103,
+              "start": 95,
+              "end": 102,
+              "callee": {
+                "id": 38,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 95,
+                  "line": 7,
+                  "column": 2
+                },
+                "fullStart": 93,
+                "endPos": {
+                  "offset": 98,
+                  "line": 7,
+                  "column": 5
+                },
+                "fullEnd": 99,
+                "start": 95,
+                "end": 98,
+                "expression": {
+                  "id": 37,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 95,
+                    "line": 7,
+                    "column": 2
+                  },
+                  "fullStart": 93,
+                  "endPos": {
+                    "offset": 98,
+                    "line": 7,
+                    "column": 5
+                  },
+                  "fullEnd": 99,
+                  "start": 95,
+                  "end": 98,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 95,
+                      "line": 7,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 98,
+                      "line": 7,
+                      "column": 5
+                    },
+                    "value": "id6",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 93,
+                          "line": 7,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 94,
+                          "line": 7,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 93,
+                        "end": 94
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 94,
+                          "line": 7,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 95,
+                          "line": 7,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 94,
+                        "end": 95
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 98,
+                          "line": 7,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 99,
+                          "line": 7,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 98,
+                        "end": 99
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 95,
+                    "end": 98
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 40,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 99,
+                    "line": 7,
+                    "column": 6
+                  },
+                  "fullStart": 99,
+                  "endPos": {
+                    "offset": 102,
+                    "line": 7,
+                    "column": 9
+                  },
+                  "fullEnd": 103,
+                  "start": 99,
+                  "end": 102,
+                  "expression": {
+                    "id": 39,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 99,
+                      "line": 7,
+                      "column": 6
+                    },
+                    "fullStart": 99,
+                    "endPos": {
+                      "offset": 102,
+                      "line": 7,
+                      "column": 9
+                    },
+                    "fullEnd": 103,
+                    "start": 99,
+                    "end": 102,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 99,
+                        "line": 7,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 102,
+                        "line": 7,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 102,
+                            "line": 7,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 103,
+                            "line": 8,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 102,
+                          "end": 103
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 99,
+                      "end": 102
+                    }
+                  }
+                }
+              ],
+              "symbol": 8
+            },
+            {
+              "id": 46,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 105,
+                "line": 8,
+                "column": 2
+              },
+              "fullStart": 103,
+              "endPos": {
+                "offset": 112,
+                "line": 8,
+                "column": 9
+              },
+              "fullEnd": 113,
+              "start": 105,
+              "end": 112,
+              "callee": {
+                "id": 43,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 105,
+                  "line": 8,
+                  "column": 2
+                },
+                "fullStart": 103,
+                "endPos": {
+                  "offset": 108,
+                  "line": 8,
+                  "column": 5
+                },
+                "fullEnd": 109,
+                "start": 105,
+                "end": 108,
+                "expression": {
+                  "id": 42,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 105,
+                    "line": 8,
+                    "column": 2
+                  },
+                  "fullStart": 103,
+                  "endPos": {
+                    "offset": 108,
+                    "line": 8,
+                    "column": 5
+                  },
+                  "fullEnd": 109,
+                  "start": 105,
+                  "end": 108,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 105,
+                      "line": 8,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 108,
+                      "line": 8,
+                      "column": 5
+                    },
+                    "value": "id7",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 103,
+                          "line": 8,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 104,
+                          "line": 8,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 103,
+                        "end": 104
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 104,
+                          "line": 8,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 105,
+                          "line": 8,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 104,
+                        "end": 105
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 108,
+                          "line": 8,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 109,
+                          "line": 8,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 108,
+                        "end": 109
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 105,
+                    "end": 108
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 45,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 109,
+                    "line": 8,
+                    "column": 6
+                  },
+                  "fullStart": 109,
+                  "endPos": {
+                    "offset": 112,
+                    "line": 8,
+                    "column": 9
+                  },
+                  "fullEnd": 113,
+                  "start": 109,
+                  "end": 112,
+                  "expression": {
+                    "id": 44,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 109,
+                      "line": 8,
+                      "column": 6
+                    },
+                    "fullStart": 109,
+                    "endPos": {
+                      "offset": 112,
+                      "line": 8,
+                      "column": 9
+                    },
+                    "fullEnd": 113,
+                    "start": 109,
+                    "end": 112,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 109,
+                        "line": 8,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 112,
+                        "line": 8,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 112,
+                            "line": 8,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 113,
+                            "line": 9,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 112,
+                          "end": 113
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 109,
+                      "end": 112
+                    }
+                  }
+                }
+              ],
+              "symbol": 9
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 113,
+              "line": 9,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 114,
+              "line": 9,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 114,
+                  "line": 9,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 115,
+                  "line": 10,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 114,
+                "end": 115
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 113,
+            "end": 114
+          }
+        },
+        "parent": 264,
+        "symbol": 1
+      },
+      {
+        "id": 92,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 116,
+          "line": 11,
+          "column": 0
+        },
+        "fullStart": 115,
+        "endPos": {
+          "offset": 207,
+          "line": 20,
+          "column": 1
+        },
+        "fullEnd": 208,
+        "start": 116,
+        "end": 207,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 116,
+            "line": 11,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 121,
+            "line": 11,
+            "column": 5
+          },
+          "value": "Table",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 115,
+                "line": 10,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 116,
+                "line": 11,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 115,
+              "end": 116
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 121,
+                "line": 11,
+                "column": 5
+              },
+              "endPos": {
+                "offset": 122,
+                "line": 11,
+                "column": 6
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 121,
+              "end": 122
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 116,
+          "end": 121
+        },
+        "name": {
+          "id": 50,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 122,
+            "line": 11,
+            "column": 6
+          },
+          "fullStart": 122,
+          "endPos": {
+            "offset": 123,
+            "line": 11,
+            "column": 7
+          },
+          "fullEnd": 124,
+          "start": 122,
+          "end": 123,
+          "expression": {
+            "id": 49,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 122,
+              "line": 11,
+              "column": 6
+            },
+            "fullStart": 122,
+            "endPos": {
+              "offset": 123,
+              "line": 11,
+              "column": 7
+            },
+            "fullEnd": 124,
+            "start": 122,
+            "end": 123,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 122,
+                "line": 11,
+                "column": 6
+              },
+              "endPos": {
+                "offset": 123,
+                "line": 11,
+                "column": 7
+              },
+              "value": "c",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 123,
+                    "line": 11,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 124,
+                    "line": 11,
+                    "column": 8
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 123,
+                  "end": 124
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 122,
+              "end": 123
+            }
+          }
+        },
+        "body": {
+          "id": 91,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 124,
+            "line": 11,
+            "column": 8
+          },
+          "fullStart": 124,
+          "endPos": {
+            "offset": 207,
+            "line": 20,
+            "column": 1
+          },
+          "fullEnd": 208,
+          "start": 124,
+          "end": 207,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 124,
+              "line": 11,
+              "column": 8
+            },
+            "endPos": {
+              "offset": 125,
+              "line": 11,
+              "column": 9
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 125,
+                  "line": 11,
+                  "column": 9
+                },
+                "endPos": {
+                  "offset": 126,
+                  "line": 12,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 125,
+                "end": 126
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 124,
+            "end": 125
+          },
+          "body": [
+            {
+              "id": 55,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 128,
+                "line": 12,
+                "column": 2
+              },
+              "fullStart": 126,
+              "endPos": {
+                "offset": 134,
+                "line": 12,
+                "column": 8
+              },
+              "fullEnd": 135,
+              "start": 128,
+              "end": 134,
+              "callee": {
+                "id": 52,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 128,
+                  "line": 12,
+                  "column": 2
+                },
+                "fullStart": 126,
+                "endPos": {
+                  "offset": 130,
+                  "line": 12,
+                  "column": 4
+                },
+                "fullEnd": 131,
+                "start": 128,
+                "end": 130,
+                "expression": {
+                  "id": 51,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 128,
+                    "line": 12,
+                    "column": 2
+                  },
+                  "fullStart": 126,
+                  "endPos": {
+                    "offset": 130,
+                    "line": 12,
+                    "column": 4
+                  },
+                  "fullEnd": 131,
+                  "start": 128,
+                  "end": 130,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 128,
+                      "line": 12,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 130,
+                      "line": 12,
+                      "column": 4
+                    },
+                    "value": "id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 126,
+                          "line": 12,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 127,
+                          "line": 12,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 126,
+                        "end": 127
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 127,
+                          "line": 12,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 128,
+                          "line": 12,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 127,
+                        "end": 128
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 130,
+                          "line": 12,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 131,
+                          "line": 12,
+                          "column": 5
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 130,
+                        "end": 131
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 128,
+                    "end": 130
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 54,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 131,
+                    "line": 12,
+                    "column": 5
+                  },
+                  "fullStart": 131,
+                  "endPos": {
+                    "offset": 134,
+                    "line": 12,
+                    "column": 8
+                  },
+                  "fullEnd": 135,
+                  "start": 131,
+                  "end": 134,
+                  "expression": {
+                    "id": 53,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 131,
+                      "line": 12,
+                      "column": 5
+                    },
+                    "fullStart": 131,
+                    "endPos": {
+                      "offset": 134,
+                      "line": 12,
+                      "column": 8
+                    },
+                    "fullEnd": 135,
+                    "start": 131,
+                    "end": 134,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 131,
+                        "line": 12,
+                        "column": 5
+                      },
+                      "endPos": {
+                        "offset": 134,
+                        "line": 12,
+                        "column": 8
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 134,
+                            "line": 12,
+                            "column": 8
+                          },
+                          "endPos": {
+                            "offset": 135,
+                            "line": 13,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 134,
+                          "end": 135
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 131,
+                      "end": 134
+                    }
+                  }
+                }
+              ],
+              "symbol": 11
+            },
+            {
+              "id": 60,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 137,
+                "line": 13,
+                "column": 2
+              },
+              "fullStart": 135,
+              "endPos": {
+                "offset": 145,
+                "line": 13,
+                "column": 10
+              },
+              "fullEnd": 146,
+              "start": 137,
+              "end": 145,
+              "callee": {
+                "id": 57,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 137,
+                  "line": 13,
+                  "column": 2
+                },
+                "fullStart": 135,
+                "endPos": {
+                  "offset": 141,
+                  "line": 13,
+                  "column": 6
+                },
+                "fullEnd": 142,
+                "start": 137,
+                "end": 141,
+                "expression": {
+                  "id": 56,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 137,
+                    "line": 13,
+                    "column": 2
+                  },
+                  "fullStart": 135,
+                  "endPos": {
+                    "offset": 141,
+                    "line": 13,
+                    "column": 6
+                  },
+                  "fullEnd": 142,
+                  "start": 137,
+                  "end": 141,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 137,
+                      "line": 13,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 141,
+                      "line": 13,
+                      "column": 6
+                    },
+                    "value": "b_id",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 135,
+                          "line": 13,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 136,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 135,
+                        "end": 136
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 136,
+                          "line": 13,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 137,
+                          "line": 13,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 136,
+                        "end": 137
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 141,
+                          "line": 13,
+                          "column": 6
+                        },
+                        "endPos": {
+                          "offset": 142,
+                          "line": 13,
+                          "column": 7
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 141,
+                        "end": 142
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 137,
+                    "end": 141
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 59,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 142,
+                    "line": 13,
+                    "column": 7
+                  },
+                  "fullStart": 142,
+                  "endPos": {
+                    "offset": 145,
+                    "line": 13,
+                    "column": 10
+                  },
+                  "fullEnd": 146,
+                  "start": 142,
+                  "end": 145,
+                  "expression": {
+                    "id": 58,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 142,
+                      "line": 13,
+                      "column": 7
+                    },
+                    "fullStart": 142,
+                    "endPos": {
+                      "offset": 145,
+                      "line": 13,
+                      "column": 10
+                    },
+                    "fullEnd": 146,
+                    "start": 142,
+                    "end": 145,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 142,
+                        "line": 13,
+                        "column": 7
+                      },
+                      "endPos": {
+                        "offset": 145,
+                        "line": 13,
+                        "column": 10
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 145,
+                            "line": 13,
+                            "column": 10
+                          },
+                          "endPos": {
+                            "offset": 146,
+                            "line": 14,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 145,
+                          "end": 146
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 142,
+                      "end": 145
+                    }
+                  }
+                }
+              ],
+              "symbol": 12
+            },
+            {
+              "id": 65,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 148,
+                "line": 14,
+                "column": 2
+              },
+              "fullStart": 146,
+              "endPos": {
+                "offset": 155,
+                "line": 14,
+                "column": 9
+              },
+              "fullEnd": 156,
+              "start": 148,
+              "end": 155,
+              "callee": {
+                "id": 62,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 148,
+                  "line": 14,
+                  "column": 2
+                },
+                "fullStart": 146,
+                "endPos": {
+                  "offset": 151,
+                  "line": 14,
+                  "column": 5
+                },
+                "fullEnd": 152,
+                "start": 148,
+                "end": 151,
+                "expression": {
+                  "id": 61,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 148,
+                    "line": 14,
+                    "column": 2
+                  },
+                  "fullStart": 146,
+                  "endPos": {
+                    "offset": 151,
+                    "line": 14,
+                    "column": 5
+                  },
+                  "fullEnd": 152,
+                  "start": 148,
+                  "end": 151,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 148,
+                      "line": 14,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 151,
+                      "line": 14,
+                      "column": 5
+                    },
+                    "value": "id2",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 146,
+                          "line": 14,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 147,
+                          "line": 14,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 146,
+                        "end": 147
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 147,
+                          "line": 14,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 148,
+                          "line": 14,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 147,
+                        "end": 148
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 151,
+                          "line": 14,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 152,
+                          "line": 14,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 151,
+                        "end": 152
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 148,
+                    "end": 151
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 64,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 152,
+                    "line": 14,
+                    "column": 6
+                  },
+                  "fullStart": 152,
+                  "endPos": {
+                    "offset": 155,
+                    "line": 14,
+                    "column": 9
+                  },
+                  "fullEnd": 156,
+                  "start": 152,
+                  "end": 155,
+                  "expression": {
+                    "id": 63,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 152,
+                      "line": 14,
+                      "column": 6
+                    },
+                    "fullStart": 152,
+                    "endPos": {
+                      "offset": 155,
+                      "line": 14,
+                      "column": 9
+                    },
+                    "fullEnd": 156,
+                    "start": 152,
+                    "end": 155,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 152,
+                        "line": 14,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 155,
+                        "line": 14,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 155,
+                            "line": 14,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 156,
+                            "line": 15,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 155,
+                          "end": 156
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 152,
+                      "end": 155
+                    }
+                  }
+                }
+              ],
+              "symbol": 13
+            },
+            {
+              "id": 70,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 158,
+                "line": 15,
+                "column": 2
+              },
+              "fullStart": 156,
+              "endPos": {
+                "offset": 165,
+                "line": 15,
+                "column": 9
+              },
+              "fullEnd": 166,
+              "start": 158,
+              "end": 165,
+              "callee": {
+                "id": 67,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 158,
+                  "line": 15,
+                  "column": 2
+                },
+                "fullStart": 156,
+                "endPos": {
+                  "offset": 161,
+                  "line": 15,
+                  "column": 5
+                },
+                "fullEnd": 162,
+                "start": 158,
+                "end": 161,
+                "expression": {
+                  "id": 66,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 158,
+                    "line": 15,
+                    "column": 2
+                  },
+                  "fullStart": 156,
+                  "endPos": {
+                    "offset": 161,
+                    "line": 15,
+                    "column": 5
+                  },
+                  "fullEnd": 162,
+                  "start": 158,
+                  "end": 161,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 158,
+                      "line": 15,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 161,
+                      "line": 15,
+                      "column": 5
+                    },
+                    "value": "id3",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 156,
+                          "line": 15,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 157,
+                          "line": 15,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 156,
+                        "end": 157
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 157,
+                          "line": 15,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 158,
+                          "line": 15,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 157,
+                        "end": 158
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 161,
+                          "line": 15,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 162,
+                          "line": 15,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 161,
+                        "end": 162
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 158,
+                    "end": 161
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 69,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 162,
+                    "line": 15,
+                    "column": 6
+                  },
+                  "fullStart": 162,
+                  "endPos": {
+                    "offset": 165,
+                    "line": 15,
+                    "column": 9
+                  },
+                  "fullEnd": 166,
+                  "start": 162,
+                  "end": 165,
+                  "expression": {
+                    "id": 68,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 162,
+                      "line": 15,
+                      "column": 6
+                    },
+                    "fullStart": 162,
+                    "endPos": {
+                      "offset": 165,
+                      "line": 15,
+                      "column": 9
+                    },
+                    "fullEnd": 166,
+                    "start": 162,
+                    "end": 165,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 162,
+                        "line": 15,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 165,
+                        "line": 15,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 165,
+                            "line": 15,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 166,
+                            "line": 16,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 165,
+                          "end": 166
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 162,
+                      "end": 165
+                    }
+                  }
+                }
+              ],
+              "symbol": 14
+            },
+            {
+              "id": 75,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 168,
+                "line": 16,
+                "column": 2
+              },
+              "fullStart": 166,
+              "endPos": {
+                "offset": 175,
+                "line": 16,
+                "column": 9
+              },
+              "fullEnd": 176,
+              "start": 168,
+              "end": 175,
+              "callee": {
+                "id": 72,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 168,
+                  "line": 16,
+                  "column": 2
+                },
+                "fullStart": 166,
+                "endPos": {
+                  "offset": 171,
+                  "line": 16,
+                  "column": 5
+                },
+                "fullEnd": 172,
+                "start": 168,
+                "end": 171,
+                "expression": {
+                  "id": 71,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 168,
+                    "line": 16,
+                    "column": 2
+                  },
+                  "fullStart": 166,
+                  "endPos": {
+                    "offset": 171,
+                    "line": 16,
+                    "column": 5
+                  },
+                  "fullEnd": 172,
+                  "start": 168,
+                  "end": 171,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 168,
+                      "line": 16,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 171,
+                      "line": 16,
+                      "column": 5
+                    },
+                    "value": "id4",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 166,
+                          "line": 16,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 167,
+                          "line": 16,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 166,
+                        "end": 167
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 167,
+                          "line": 16,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 168,
+                          "line": 16,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 167,
+                        "end": 168
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 171,
+                          "line": 16,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 172,
+                          "line": 16,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 171,
+                        "end": 172
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 168,
+                    "end": 171
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 74,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 172,
+                    "line": 16,
+                    "column": 6
+                  },
+                  "fullStart": 172,
+                  "endPos": {
+                    "offset": 175,
+                    "line": 16,
+                    "column": 9
+                  },
+                  "fullEnd": 176,
+                  "start": 172,
+                  "end": 175,
+                  "expression": {
+                    "id": 73,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 172,
+                      "line": 16,
+                      "column": 6
+                    },
+                    "fullStart": 172,
+                    "endPos": {
+                      "offset": 175,
+                      "line": 16,
+                      "column": 9
+                    },
+                    "fullEnd": 176,
+                    "start": 172,
+                    "end": 175,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 172,
+                        "line": 16,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 175,
+                        "line": 16,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 175,
+                            "line": 16,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 176,
+                            "line": 17,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 175,
+                          "end": 176
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 172,
+                      "end": 175
+                    }
+                  }
+                }
+              ],
+              "symbol": 15
+            },
+            {
+              "id": 80,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 178,
+                "line": 17,
+                "column": 2
+              },
+              "fullStart": 176,
+              "endPos": {
+                "offset": 185,
+                "line": 17,
+                "column": 9
+              },
+              "fullEnd": 186,
+              "start": 178,
+              "end": 185,
+              "callee": {
+                "id": 77,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 178,
+                  "line": 17,
+                  "column": 2
+                },
+                "fullStart": 176,
+                "endPos": {
+                  "offset": 181,
+                  "line": 17,
+                  "column": 5
+                },
+                "fullEnd": 182,
+                "start": 178,
+                "end": 181,
+                "expression": {
+                  "id": 76,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 178,
+                    "line": 17,
+                    "column": 2
+                  },
+                  "fullStart": 176,
+                  "endPos": {
+                    "offset": 181,
+                    "line": 17,
+                    "column": 5
+                  },
+                  "fullEnd": 182,
+                  "start": 178,
+                  "end": 181,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 178,
+                      "line": 17,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 181,
+                      "line": 17,
+                      "column": 5
+                    },
+                    "value": "id5",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 176,
+                          "line": 17,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 177,
+                          "line": 17,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 176,
+                        "end": 177
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 177,
+                          "line": 17,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 178,
+                          "line": 17,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 177,
+                        "end": 178
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 181,
+                          "line": 17,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 182,
+                          "line": 17,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 181,
+                        "end": 182
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 178,
+                    "end": 181
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 79,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 182,
+                    "line": 17,
+                    "column": 6
+                  },
+                  "fullStart": 182,
+                  "endPos": {
+                    "offset": 185,
+                    "line": 17,
+                    "column": 9
+                  },
+                  "fullEnd": 186,
+                  "start": 182,
+                  "end": 185,
+                  "expression": {
+                    "id": 78,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 182,
+                      "line": 17,
+                      "column": 6
+                    },
+                    "fullStart": 182,
+                    "endPos": {
+                      "offset": 185,
+                      "line": 17,
+                      "column": 9
+                    },
+                    "fullEnd": 186,
+                    "start": 182,
+                    "end": 185,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 182,
+                        "line": 17,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 185,
+                        "line": 17,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 185,
+                            "line": 17,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 186,
+                            "line": 18,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 185,
+                          "end": 186
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 182,
+                      "end": 185
+                    }
+                  }
+                }
+              ],
+              "symbol": 16
+            },
+            {
+              "id": 85,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 188,
+                "line": 18,
+                "column": 2
+              },
+              "fullStart": 186,
+              "endPos": {
+                "offset": 195,
+                "line": 18,
+                "column": 9
+              },
+              "fullEnd": 196,
+              "start": 188,
+              "end": 195,
+              "callee": {
+                "id": 82,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 188,
+                  "line": 18,
+                  "column": 2
+                },
+                "fullStart": 186,
+                "endPos": {
+                  "offset": 191,
+                  "line": 18,
+                  "column": 5
+                },
+                "fullEnd": 192,
+                "start": 188,
+                "end": 191,
+                "expression": {
+                  "id": 81,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 188,
+                    "line": 18,
+                    "column": 2
+                  },
+                  "fullStart": 186,
+                  "endPos": {
+                    "offset": 191,
+                    "line": 18,
+                    "column": 5
+                  },
+                  "fullEnd": 192,
+                  "start": 188,
+                  "end": 191,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 188,
+                      "line": 18,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 191,
+                      "line": 18,
+                      "column": 5
+                    },
+                    "value": "id6",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 186,
+                          "line": 18,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 187,
+                          "line": 18,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 186,
+                        "end": 187
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 187,
+                          "line": 18,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 188,
+                          "line": 18,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 187,
+                        "end": 188
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 191,
+                          "line": 18,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 192,
+                          "line": 18,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 191,
+                        "end": 192
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 188,
+                    "end": 191
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 84,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 192,
+                    "line": 18,
+                    "column": 6
+                  },
+                  "fullStart": 192,
+                  "endPos": {
+                    "offset": 195,
+                    "line": 18,
+                    "column": 9
+                  },
+                  "fullEnd": 196,
+                  "start": 192,
+                  "end": 195,
+                  "expression": {
+                    "id": 83,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 192,
+                      "line": 18,
+                      "column": 6
+                    },
+                    "fullStart": 192,
+                    "endPos": {
+                      "offset": 195,
+                      "line": 18,
+                      "column": 9
+                    },
+                    "fullEnd": 196,
+                    "start": 192,
+                    "end": 195,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 192,
+                        "line": 18,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 195,
+                        "line": 18,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 195,
+                            "line": 18,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 196,
+                            "line": 19,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 195,
+                          "end": 196
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 192,
+                      "end": 195
+                    }
+                  }
+                }
+              ],
+              "symbol": 17
+            },
+            {
+              "id": 90,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 198,
+                "line": 19,
+                "column": 2
+              },
+              "fullStart": 196,
+              "endPos": {
+                "offset": 205,
+                "line": 19,
+                "column": 9
+              },
+              "fullEnd": 206,
+              "start": 198,
+              "end": 205,
+              "callee": {
+                "id": 87,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 198,
+                  "line": 19,
+                  "column": 2
+                },
+                "fullStart": 196,
+                "endPos": {
+                  "offset": 201,
+                  "line": 19,
+                  "column": 5
+                },
+                "fullEnd": 202,
+                "start": 198,
+                "end": 201,
+                "expression": {
+                  "id": 86,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 198,
+                    "line": 19,
+                    "column": 2
+                  },
+                  "fullStart": 196,
+                  "endPos": {
+                    "offset": 201,
+                    "line": 19,
+                    "column": 5
+                  },
+                  "fullEnd": 202,
+                  "start": 198,
+                  "end": 201,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 198,
+                      "line": 19,
+                      "column": 2
+                    },
+                    "endPos": {
+                      "offset": 201,
+                      "line": 19,
+                      "column": 5
+                    },
+                    "value": "id7",
+                    "leadingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 196,
+                          "line": 19,
+                          "column": 0
+                        },
+                        "endPos": {
+                          "offset": 197,
+                          "line": 19,
+                          "column": 1
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 196,
+                        "end": 197
+                      },
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 197,
+                          "line": 19,
+                          "column": 1
+                        },
+                        "endPos": {
+                          "offset": 198,
+                          "line": 19,
+                          "column": 2
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 197,
+                        "end": 198
+                      }
+                    ],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 201,
+                          "line": 19,
+                          "column": 5
+                        },
+                        "endPos": {
+                          "offset": 202,
+                          "line": 19,
+                          "column": 6
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 201,
+                        "end": 202
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 198,
+                    "end": 201
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 89,
+                  "kind": "<primary-expression>",
+                  "startPos": {
+                    "offset": 202,
+                    "line": 19,
+                    "column": 6
+                  },
+                  "fullStart": 202,
+                  "endPos": {
+                    "offset": 205,
+                    "line": 19,
+                    "column": 9
+                  },
+                  "fullEnd": 206,
+                  "start": 202,
+                  "end": 205,
+                  "expression": {
+                    "id": 88,
+                    "kind": "<variable>",
+                    "startPos": {
+                      "offset": 202,
+                      "line": 19,
+                      "column": 6
+                    },
+                    "fullStart": 202,
+                    "endPos": {
+                      "offset": 205,
+                      "line": 19,
+                      "column": 9
+                    },
+                    "fullEnd": 206,
+                    "start": 202,
+                    "end": 205,
+                    "variable": {
+                      "kind": "<identifier>",
+                      "startPos": {
+                        "offset": 202,
+                        "line": 19,
+                        "column": 6
+                      },
+                      "endPos": {
+                        "offset": 205,
+                        "line": 19,
+                        "column": 9
+                      },
+                      "value": "int",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<newline>",
+                          "startPos": {
+                            "offset": 205,
+                            "line": 19,
+                            "column": 9
+                          },
+                          "endPos": {
+                            "offset": 206,
+                            "line": 20,
+                            "column": 0
+                          },
+                          "value": "\n",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 205,
+                          "end": 206
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 202,
+                      "end": 205
+                    }
+                  }
+                }
+              ],
+              "symbol": 18
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 206,
+              "line": 20,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 207,
+              "line": 20,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 207,
+                  "line": 20,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 208,
+                  "line": 21,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 207,
+                "end": 208
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 206,
+            "end": 207
+          }
+        },
+        "parent": 264,
+        "symbol": 10
+      },
+      {
+        "id": 115,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 223,
+          "line": 23,
+          "column": 0
+        },
+        "fullStart": 208,
+        "endPos": {
+          "offset": 284,
+          "line": 23,
+          "column": 61
+        },
+        "fullEnd": 285,
+        "start": 223,
+        "end": 284,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 223,
+            "line": 23,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 226,
+            "line": 23,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 208,
+                "line": 21,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 209,
+                "line": 22,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 208,
+              "end": 209
+            },
+            {
+              "kind": "<single-line-comment>",
+              "startPos": {
+                "offset": 209,
+                "line": 22,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 222,
+                "line": 22,
+                "column": 13
+              },
+              "value": " Short form",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 209,
+              "end": 222
+            },
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 222,
+                "line": 22,
+                "column": 13
+              },
+              "endPos": {
+                "offset": 223,
+                "line": 23,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 222,
+              "end": 223
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 226,
+                "line": 23,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 227,
+                "line": 23,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 226,
+              "end": 227
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 223,
+          "end": 226
+        },
+        "name": {
+          "id": 94,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 227,
+            "line": 23,
+            "column": 4
+          },
+          "fullStart": 227,
+          "endPos": {
+            "offset": 236,
+            "line": 23,
+            "column": 13
+          },
+          "fullEnd": 236,
+          "start": 227,
+          "end": 236,
+          "expression": {
+            "id": 93,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 227,
+              "line": 23,
+              "column": 4
+            },
+            "fullStart": 227,
+            "endPos": {
+              "offset": 236,
+              "line": 23,
+              "column": 13
+            },
+            "fullEnd": 236,
+            "start": 227,
+            "end": 236,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 227,
+                "line": 23,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 236,
+                "line": 23,
+                "column": 13
+              },
+              "value": "short_ref",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 227,
+              "end": 236
+            }
+          }
+        },
+        "bodyColon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 236,
+            "line": 23,
+            "column": 13
+          },
+          "endPos": {
+            "offset": 237,
+            "line": 23,
+            "column": 14
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 237,
+                "line": 23,
+                "column": 14
+              },
+              "endPos": {
+                "offset": 238,
+                "line": 23,
+                "column": 15
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 237,
+              "end": 238
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 236,
+          "end": 237
+        },
+        "body": {
+          "id": 114,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 238,
+            "line": 23,
+            "column": 15
+          },
+          "fullStart": 238,
+          "endPos": {
+            "offset": 284,
+            "line": 23,
+            "column": 61
+          },
+          "fullEnd": 285,
+          "start": 238,
+          "end": 284,
+          "callee": {
+            "id": 105,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 238,
+              "line": 23,
+              "column": 15
+            },
+            "fullStart": 238,
+            "endPos": {
+              "offset": 249,
+              "line": 23,
+              "column": 26
+            },
+            "fullEnd": 250,
+            "start": 238,
+            "end": 249,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 243,
+                "line": 23,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 244,
+                "line": 23,
+                "column": 21
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 244,
+                    "line": 23,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 245,
+                    "line": 23,
+                    "column": 22
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 244,
+                  "end": 245
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 243,
+              "end": 244
+            },
+            "leftExpression": {
+              "id": 99,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 238,
+                "line": 23,
+                "column": 15
+              },
+              "fullStart": 238,
+              "endPos": {
+                "offset": 242,
+                "line": 23,
+                "column": 19
+              },
+              "fullEnd": 243,
+              "start": 238,
+              "end": 242,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 239,
+                  "line": 23,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 240,
+                  "line": 23,
+                  "column": 17
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 239,
+                "end": 240
+              },
+              "leftExpression": {
+                "id": 96,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 238,
+                  "line": 23,
+                  "column": 15
+                },
+                "fullStart": 238,
+                "endPos": {
+                  "offset": 239,
+                  "line": 23,
+                  "column": 16
+                },
+                "fullEnd": 239,
+                "start": 238,
+                "end": 239,
+                "expression": {
+                  "id": 95,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 238,
+                    "line": 23,
+                    "column": 15
+                  },
+                  "fullStart": 238,
+                  "endPos": {
+                    "offset": 239,
+                    "line": 23,
+                    "column": 16
+                  },
+                  "fullEnd": 239,
+                  "start": 238,
+                  "end": 239,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 238,
+                      "line": 23,
+                      "column": 15
+                    },
+                    "endPos": {
+                      "offset": 239,
+                      "line": 23,
+                      "column": 16
+                    },
+                    "value": "b",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 238,
+                    "end": 239
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 98,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 240,
+                  "line": 23,
+                  "column": 17
+                },
+                "fullStart": 240,
+                "endPos": {
+                  "offset": 242,
+                  "line": 23,
+                  "column": 19
+                },
+                "fullEnd": 243,
+                "start": 240,
+                "end": 242,
+                "expression": {
+                  "id": 97,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 240,
+                    "line": 23,
+                    "column": 17
+                  },
+                  "fullStart": 240,
+                  "endPos": {
+                    "offset": 242,
+                    "line": 23,
+                    "column": 19
+                  },
+                  "fullEnd": 243,
+                  "start": 240,
+                  "end": 242,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 240,
+                      "line": 23,
+                      "column": 17
+                    },
+                    "endPos": {
+                      "offset": 242,
+                      "line": 23,
+                      "column": 19
+                    },
+                    "value": "id",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 242,
+                          "line": 23,
+                          "column": 19
+                        },
+                        "endPos": {
+                          "offset": 243,
+                          "line": 23,
+                          "column": 20
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 242,
+                        "end": 243
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 240,
+                    "end": 242
+                  }
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 104,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 245,
+                "line": 23,
+                "column": 22
+              },
+              "fullStart": 245,
+              "endPos": {
+                "offset": 249,
+                "line": 23,
+                "column": 26
+              },
+              "fullEnd": 250,
+              "start": 245,
+              "end": 249,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 246,
+                  "line": 23,
+                  "column": 23
+                },
+                "endPos": {
+                  "offset": 247,
+                  "line": 23,
+                  "column": 24
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 246,
+                "end": 247
+              },
+              "leftExpression": {
+                "id": 101,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 245,
+                  "line": 23,
+                  "column": 22
+                },
+                "fullStart": 245,
+                "endPos": {
+                  "offset": 246,
+                  "line": 23,
+                  "column": 23
+                },
+                "fullEnd": 246,
+                "start": 245,
+                "end": 246,
+                "expression": {
+                  "id": 100,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 245,
+                    "line": 23,
+                    "column": 22
+                  },
+                  "fullStart": 245,
+                  "endPos": {
+                    "offset": 246,
+                    "line": 23,
+                    "column": 23
+                  },
+                  "fullEnd": 246,
+                  "start": 245,
+                  "end": 246,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 245,
+                      "line": 23,
+                      "column": 22
+                    },
+                    "endPos": {
+                      "offset": 246,
+                      "line": 23,
+                      "column": 23
+                    },
+                    "value": "c",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 245,
+                    "end": 246
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 103,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 247,
+                  "line": 23,
+                  "column": 24
+                },
+                "fullStart": 247,
+                "endPos": {
+                  "offset": 249,
+                  "line": 23,
+                  "column": 26
+                },
+                "fullEnd": 250,
+                "start": 247,
+                "end": 249,
+                "expression": {
+                  "id": 102,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 247,
+                    "line": 23,
+                    "column": 24
+                  },
+                  "fullStart": 247,
+                  "endPos": {
+                    "offset": 249,
+                    "line": 23,
+                    "column": 26
+                  },
+                  "fullEnd": 250,
+                  "start": 247,
+                  "end": 249,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 247,
+                      "line": 23,
+                      "column": 24
+                    },
+                    "endPos": {
+                      "offset": 249,
+                      "line": 23,
+                      "column": 26
+                    },
+                    "value": "id",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 249,
+                          "line": 23,
+                          "column": 26
+                        },
+                        "endPos": {
+                          "offset": 250,
+                          "line": 23,
+                          "column": 27
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 249,
+                        "end": 250
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 247,
+                    "end": 249
+                  }
+                }
+              }
+            }
+          },
+          "args": [
+            {
+              "id": 113,
+              "kind": "<list-expression>",
+              "startPos": {
+                "offset": 250,
+                "line": 23,
+                "column": 27
+              },
+              "fullStart": 250,
+              "endPos": {
+                "offset": 284,
+                "line": 23,
+                "column": 61
+              },
+              "fullEnd": 285,
+              "start": 250,
+              "end": 284,
+              "listOpenBracket": {
+                "kind": "<lbracket>",
+                "startPos": {
+                  "offset": 250,
+                  "line": 23,
+                  "column": 27
+                },
+                "endPos": {
+                  "offset": 251,
+                  "line": 23,
+                  "column": 28
+                },
+                "value": "[",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 250,
+                "end": 251
+              },
+              "elementList": [
+                {
+                  "id": 109,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 251,
+                    "line": 23,
+                    "column": 28
+                  },
+                  "fullStart": 251,
+                  "endPos": {
+                    "offset": 265,
+                    "line": 23,
+                    "column": 42
+                  },
+                  "fullEnd": 265,
+                  "start": 251,
+                  "end": 265,
+                  "name": {
+                    "id": 106,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 251,
+                      "line": 23,
+                      "column": 28
+                    },
+                    "fullStart": 251,
+                    "endPos": {
+                      "offset": 256,
+                      "line": 23,
+                      "column": 33
+                    },
+                    "fullEnd": 256,
+                    "start": 251,
+                    "end": 256,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 251,
+                          "line": 23,
+                          "column": 28
+                        },
+                        "endPos": {
+                          "offset": 256,
+                          "line": 23,
+                          "column": 33
+                        },
+                        "value": "color",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 251,
+                        "end": 256
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 108,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 258,
+                      "line": 23,
+                      "column": 35
+                    },
+                    "fullStart": 258,
+                    "endPos": {
+                      "offset": 265,
+                      "line": 23,
+                      "column": 42
+                    },
+                    "fullEnd": 265,
+                    "start": 258,
+                    "end": 265,
+                    "expression": {
+                      "id": 107,
+                      "kind": "<literal>",
+                      "startPos": {
+                        "offset": 258,
+                        "line": 23,
+                        "column": 35
+                      },
+                      "fullStart": 258,
+                      "endPos": {
+                        "offset": 265,
+                        "line": 23,
+                        "column": 42
+                      },
+                      "fullEnd": 265,
+                      "start": 258,
+                      "end": 265,
+                      "literal": {
+                        "kind": "<color>",
+                        "startPos": {
+                          "offset": 258,
+                          "line": 23,
+                          "column": 35
+                        },
+                        "endPos": {
+                          "offset": 265,
+                          "line": 23,
+                          "column": 42
+                        },
+                        "value": "#aabbcc",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 258,
+                        "end": 265
+                      }
+                    }
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 256,
+                      "line": 23,
+                      "column": 33
+                    },
+                    "endPos": {
+                      "offset": 257,
+                      "line": 23,
+                      "column": 34
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 257,
+                          "line": 23,
+                          "column": 34
+                        },
+                        "endPos": {
+                          "offset": 258,
+                          "line": 23,
+                          "column": 35
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 257,
+                        "end": 258
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 256,
+                    "end": 257
+                  }
+                },
+                {
+                  "id": 112,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 267,
+                    "line": 23,
+                    "column": 44
+                  },
+                  "fullStart": 267,
+                  "endPos": {
+                    "offset": 283,
+                    "line": 23,
+                    "column": 60
+                  },
+                  "fullEnd": 283,
+                  "start": 267,
+                  "end": 283,
+                  "name": {
+                    "id": 110,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 267,
+                      "line": 23,
+                      "column": 44
+                    },
+                    "fullStart": 267,
+                    "endPos": {
+                      "offset": 273,
+                      "line": 23,
+                      "column": 50
+                    },
+                    "fullEnd": 273,
+                    "start": 267,
+                    "end": 273,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 267,
+                          "line": 23,
+                          "column": 44
+                        },
+                        "endPos": {
+                          "offset": 273,
+                          "line": 23,
+                          "column": 50
+                        },
+                        "value": "update",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 267,
+                        "end": 273
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 111,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 275,
+                      "line": 23,
+                      "column": 52
+                    },
+                    "fullStart": 275,
+                    "endPos": {
+                      "offset": 283,
+                      "line": 23,
+                      "column": 60
+                    },
+                    "fullEnd": 283,
+                    "start": 275,
+                    "end": 283,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 275,
+                          "line": 23,
+                          "column": 52
+                        },
+                        "endPos": {
+                          "offset": 278,
+                          "line": 23,
+                          "column": 55
+                        },
+                        "value": "set",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 278,
+                              "line": 23,
+                              "column": 55
+                            },
+                            "endPos": {
+                              "offset": 279,
+                              "line": 23,
+                              "column": 56
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 278,
+                            "end": 279
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 275,
+                        "end": 278
+                      },
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 279,
+                          "line": 23,
+                          "column": 56
+                        },
+                        "endPos": {
+                          "offset": 283,
+                          "line": 23,
+                          "column": 60
+                        },
+                        "value": "null",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 279,
+                        "end": 283
+                      }
+                    ]
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 273,
+                      "line": 23,
+                      "column": 50
+                    },
+                    "endPos": {
+                      "offset": 274,
+                      "line": 23,
+                      "column": 51
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 274,
+                          "line": 23,
+                          "column": 51
+                        },
+                        "endPos": {
+                          "offset": 275,
+                          "line": 23,
+                          "column": 52
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 274,
+                        "end": 275
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 273,
+                    "end": 274
+                  }
+                }
+              ],
+              "commaList": [
+                {
+                  "kind": "<comma>",
+                  "startPos": {
+                    "offset": 265,
+                    "line": 23,
+                    "column": 42
+                  },
+                  "endPos": {
+                    "offset": 266,
+                    "line": 23,
+                    "column": 43
+                  },
+                  "value": ",",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 266,
+                        "line": 23,
+                        "column": 43
+                      },
+                      "endPos": {
+                        "offset": 267,
+                        "line": 23,
+                        "column": 44
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 266,
+                      "end": 267
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 265,
+                  "end": 266
+                }
+              ],
+              "listCloseBracket": {
+                "kind": "<rbracket>",
+                "startPos": {
+                  "offset": 283,
+                  "line": 23,
+                  "column": 60
+                },
+                "endPos": {
+                  "offset": 284,
+                  "line": 23,
+                  "column": 61
+                },
+                "value": "]",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 284,
+                      "line": 23,
+                      "column": 61
+                    },
+                    "endPos": {
+                      "offset": 285,
+                      "line": 24,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 284,
+                    "end": 285
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 283,
+                "end": 284
+              }
+            }
+          ]
+        },
+        "parent": 264
+      },
+      {
+        "id": 140,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 299,
+          "line": 26,
+          "column": 0
+        },
+        "fullStart": 285,
+        "endPos": {
+          "offset": 365,
+          "line": 28,
+          "column": 1
+        },
+        "fullEnd": 366,
+        "start": 299,
+        "end": 365,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 299,
+            "line": 26,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 302,
+            "line": 26,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 285,
+                "line": 24,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 286,
+                "line": 25,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 285,
+              "end": 286
+            },
+            {
+              "kind": "<single-line-comment>",
+              "startPos": {
+                "offset": 286,
+                "line": 25,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 298,
+                "line": 25,
+                "column": 12
+              },
+              "value": " Long form",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 286,
+              "end": 298
+            },
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 298,
+                "line": 25,
+                "column": 12
+              },
+              "endPos": {
+                "offset": 299,
+                "line": 26,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 298,
+              "end": 299
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 302,
+                "line": 26,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 303,
+                "line": 26,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 302,
+              "end": 303
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 299,
+          "end": 302
+        },
+        "name": {
+          "id": 117,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 303,
+            "line": 26,
+            "column": 4
+          },
+          "fullStart": 303,
+          "endPos": {
+            "offset": 311,
+            "line": 26,
+            "column": 12
+          },
+          "fullEnd": 312,
+          "start": 303,
+          "end": 311,
+          "expression": {
+            "id": 116,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 303,
+              "line": 26,
+              "column": 4
+            },
+            "fullStart": 303,
+            "endPos": {
+              "offset": 311,
+              "line": 26,
+              "column": 12
+            },
+            "fullEnd": 312,
+            "start": 303,
+            "end": 311,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 303,
+                "line": 26,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 311,
+                "line": 26,
+                "column": 12
+              },
+              "value": "long_ref",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 311,
+                    "line": 26,
+                    "column": 12
+                  },
+                  "endPos": {
+                    "offset": 312,
+                    "line": 26,
+                    "column": 13
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 311,
+                  "end": 312
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 303,
+              "end": 311
+            }
+          }
+        },
+        "body": {
+          "id": 139,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 312,
+            "line": 26,
+            "column": 13
+          },
+          "fullStart": 312,
+          "endPos": {
+            "offset": 365,
+            "line": 28,
+            "column": 1
+          },
+          "fullEnd": 366,
+          "start": 312,
+          "end": 365,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 312,
+              "line": 26,
+              "column": 13
+            },
+            "endPos": {
+              "offset": 313,
+              "line": 26,
+              "column": 14
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 313,
+                  "line": 26,
+                  "column": 14
+                },
+                "endPos": {
+                  "offset": 314,
+                  "line": 27,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 313,
+                "end": 314
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 312,
+            "end": 313
+          },
+          "body": [
+            {
+              "id": 138,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 316,
+                "line": 27,
+                "column": 2
+              },
+              "fullStart": 314,
+              "endPos": {
+                "offset": 363,
+                "line": 27,
+                "column": 49
+              },
+              "fullEnd": 364,
+              "start": 316,
+              "end": 363,
+              "callee": {
+                "id": 128,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 316,
+                  "line": 27,
+                  "column": 2
+                },
+                "fullStart": 314,
+                "endPos": {
+                  "offset": 329,
+                  "line": 27,
+                  "column": 15
+                },
+                "fullEnd": 330,
+                "start": 316,
+                "end": 329,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 321,
+                    "line": 27,
+                    "column": 7
+                  },
+                  "endPos": {
+                    "offset": 322,
+                    "line": 27,
+                    "column": 8
+                  },
+                  "value": "<",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 322,
+                        "line": 27,
+                        "column": 8
+                      },
+                      "endPos": {
+                        "offset": 323,
+                        "line": 27,
+                        "column": 9
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 322,
+                      "end": 323
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 321,
+                  "end": 322
+                },
+                "leftExpression": {
+                  "id": 122,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 316,
+                    "line": 27,
+                    "column": 2
+                  },
+                  "fullStart": 314,
+                  "endPos": {
+                    "offset": 320,
+                    "line": 27,
+                    "column": 6
+                  },
+                  "fullEnd": 321,
+                  "start": 316,
+                  "end": 320,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 317,
+                      "line": 27,
+                      "column": 3
+                    },
+                    "endPos": {
+                      "offset": 318,
+                      "line": 27,
+                      "column": 4
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 317,
+                    "end": 318
+                  },
+                  "leftExpression": {
+                    "id": 119,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 316,
+                      "line": 27,
+                      "column": 2
+                    },
+                    "fullStart": 314,
+                    "endPos": {
+                      "offset": 317,
+                      "line": 27,
+                      "column": 3
+                    },
+                    "fullEnd": 317,
+                    "start": 316,
+                    "end": 317,
+                    "expression": {
+                      "id": 118,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 316,
+                        "line": 27,
+                        "column": 2
+                      },
+                      "fullStart": 314,
+                      "endPos": {
+                        "offset": 317,
+                        "line": 27,
+                        "column": 3
+                      },
+                      "fullEnd": 317,
+                      "start": 316,
+                      "end": 317,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 316,
+                          "line": 27,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 317,
+                          "line": 27,
+                          "column": 3
+                        },
+                        "value": "c",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 314,
+                              "line": 27,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 315,
+                              "line": 27,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 314,
+                            "end": 315
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 315,
+                              "line": 27,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 316,
+                              "line": 27,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 315,
+                            "end": 316
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 316,
+                        "end": 317
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 121,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 318,
+                      "line": 27,
+                      "column": 4
+                    },
+                    "fullStart": 318,
+                    "endPos": {
+                      "offset": 320,
+                      "line": 27,
+                      "column": 6
+                    },
+                    "fullEnd": 321,
+                    "start": 318,
+                    "end": 320,
+                    "expression": {
+                      "id": 120,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 318,
+                        "line": 27,
+                        "column": 4
+                      },
+                      "fullStart": 318,
+                      "endPos": {
+                        "offset": 320,
+                        "line": 27,
+                        "column": 6
+                      },
+                      "fullEnd": 321,
+                      "start": 318,
+                      "end": 320,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 318,
+                          "line": 27,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 320,
+                          "line": 27,
+                          "column": 6
+                        },
+                        "value": "id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 320,
+                              "line": 27,
+                              "column": 6
+                            },
+                            "endPos": {
+                              "offset": 321,
+                              "line": 27,
+                              "column": 7
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 320,
+                            "end": 321
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 318,
+                        "end": 320
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 127,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 323,
+                    "line": 27,
+                    "column": 9
+                  },
+                  "fullStart": 323,
+                  "endPos": {
+                    "offset": 329,
+                    "line": 27,
+                    "column": 15
+                  },
+                  "fullEnd": 330,
+                  "start": 323,
+                  "end": 329,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 324,
+                      "line": 27,
+                      "column": 10
+                    },
+                    "endPos": {
+                      "offset": 325,
+                      "line": 27,
+                      "column": 11
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 324,
+                    "end": 325
+                  },
+                  "leftExpression": {
+                    "id": 124,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 323,
+                      "line": 27,
+                      "column": 9
+                    },
+                    "fullStart": 323,
+                    "endPos": {
+                      "offset": 324,
+                      "line": 27,
+                      "column": 10
+                    },
+                    "fullEnd": 324,
+                    "start": 323,
+                    "end": 324,
+                    "expression": {
+                      "id": 123,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 323,
+                        "line": 27,
+                        "column": 9
+                      },
+                      "fullStart": 323,
+                      "endPos": {
+                        "offset": 324,
+                        "line": 27,
+                        "column": 10
+                      },
+                      "fullEnd": 324,
+                      "start": 323,
+                      "end": 324,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 323,
+                          "line": 27,
+                          "column": 9
+                        },
+                        "endPos": {
+                          "offset": 324,
+                          "line": 27,
+                          "column": 10
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 323,
+                        "end": 324
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 126,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 325,
+                      "line": 27,
+                      "column": 11
+                    },
+                    "fullStart": 325,
+                    "endPos": {
+                      "offset": 329,
+                      "line": 27,
+                      "column": 15
+                    },
+                    "fullEnd": 330,
+                    "start": 325,
+                    "end": 329,
+                    "expression": {
+                      "id": 125,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 325,
+                        "line": 27,
+                        "column": 11
+                      },
+                      "fullStart": 325,
+                      "endPos": {
+                        "offset": 329,
+                        "line": 27,
+                        "column": 15
+                      },
+                      "fullEnd": 330,
+                      "start": 325,
+                      "end": 329,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 325,
+                          "line": 27,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 329,
+                          "line": 27,
+                          "column": 15
+                        },
+                        "value": "c_id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 329,
+                              "line": 27,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 330,
+                              "line": 27,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 329,
+                            "end": 330
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 325,
+                        "end": 329
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 137,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 330,
+                    "line": 27,
+                    "column": 16
+                  },
+                  "fullStart": 330,
+                  "endPos": {
+                    "offset": 363,
+                    "line": 27,
+                    "column": 49
+                  },
+                  "fullEnd": 364,
+                  "start": 330,
+                  "end": 363,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 330,
+                      "line": 27,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 331,
+                      "line": 27,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 330,
+                    "end": 331
+                  },
+                  "elementList": [
+                    {
+                      "id": 132,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 331,
+                        "line": 27,
+                        "column": 17
+                      },
+                      "fullStart": 331,
+                      "endPos": {
+                        "offset": 345,
+                        "line": 27,
+                        "column": 31
+                      },
+                      "fullEnd": 345,
+                      "start": 331,
+                      "end": 345,
+                      "name": {
+                        "id": 129,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 331,
+                          "line": 27,
+                          "column": 17
+                        },
+                        "fullStart": 331,
+                        "endPos": {
+                          "offset": 336,
+                          "line": 27,
+                          "column": 22
+                        },
+                        "fullEnd": 336,
+                        "start": 331,
+                        "end": 336,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 331,
+                              "line": 27,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 336,
+                              "line": 27,
+                              "column": 22
+                            },
+                            "value": "color",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 331,
+                            "end": 336
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 131,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 338,
+                          "line": 27,
+                          "column": 24
+                        },
+                        "fullStart": 338,
+                        "endPos": {
+                          "offset": 345,
+                          "line": 27,
+                          "column": 31
+                        },
+                        "fullEnd": 345,
+                        "start": 338,
+                        "end": 345,
+                        "expression": {
+                          "id": 130,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 338,
+                            "line": 27,
+                            "column": 24
+                          },
+                          "fullStart": 338,
+                          "endPos": {
+                            "offset": 345,
+                            "line": 27,
+                            "column": 31
+                          },
+                          "fullEnd": 345,
+                          "start": 338,
+                          "end": 345,
+                          "literal": {
+                            "kind": "<color>",
+                            "startPos": {
+                              "offset": 338,
+                              "line": 27,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 345,
+                              "line": 27,
+                              "column": 31
+                            },
+                            "value": "#123456",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 338,
+                            "end": 345
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 336,
+                          "line": 27,
+                          "column": 22
+                        },
+                        "endPos": {
+                          "offset": 337,
+                          "line": 27,
+                          "column": 23
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 337,
+                              "line": 27,
+                              "column": 23
+                            },
+                            "endPos": {
+                              "offset": 338,
+                              "line": 27,
+                              "column": 24
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 337,
+                            "end": 338
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 336,
+                        "end": 337
+                      }
+                    },
+                    {
+                      "id": 136,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 347,
+                        "line": 27,
+                        "column": 33
+                      },
+                      "fullStart": 347,
+                      "endPos": {
+                        "offset": 362,
+                        "line": 27,
+                        "column": 48
+                      },
+                      "fullEnd": 362,
+                      "start": 347,
+                      "end": 362,
+                      "name": {
+                        "id": 133,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 347,
+                          "line": 27,
+                          "column": 33
+                        },
+                        "fullStart": 347,
+                        "endPos": {
+                          "offset": 353,
+                          "line": 27,
+                          "column": 39
+                        },
+                        "fullEnd": 353,
+                        "start": 347,
+                        "end": 353,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 347,
+                              "line": 27,
+                              "column": 33
+                            },
+                            "endPos": {
+                              "offset": 353,
+                              "line": 27,
+                              "column": 39
+                            },
+                            "value": "delete",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 347,
+                            "end": 353
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 135,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 355,
+                          "line": 27,
+                          "column": 41
+                        },
+                        "fullStart": 355,
+                        "endPos": {
+                          "offset": 362,
+                          "line": 27,
+                          "column": 48
+                        },
+                        "fullEnd": 362,
+                        "start": 355,
+                        "end": 362,
+                        "expression": {
+                          "id": 134,
+                          "kind": "<variable>",
+                          "startPos": {
+                            "offset": 355,
+                            "line": 27,
+                            "column": 41
+                          },
+                          "fullStart": 355,
+                          "endPos": {
+                            "offset": 362,
+                            "line": 27,
+                            "column": 48
+                          },
+                          "fullEnd": 362,
+                          "start": 355,
+                          "end": 362,
+                          "variable": {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 355,
+                              "line": 27,
+                              "column": 41
+                            },
+                            "endPos": {
+                              "offset": 362,
+                              "line": 27,
+                              "column": 48
+                            },
+                            "value": "cascade",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 355,
+                            "end": 362
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 353,
+                          "line": 27,
+                          "column": 39
+                        },
+                        "endPos": {
+                          "offset": 354,
+                          "line": 27,
+                          "column": 40
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 354,
+                              "line": 27,
+                              "column": 40
+                            },
+                            "endPos": {
+                              "offset": 355,
+                              "line": 27,
+                              "column": 41
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 354,
+                            "end": 355
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 353,
+                        "end": 354
+                      }
+                    }
+                  ],
+                  "commaList": [
+                    {
+                      "kind": "<comma>",
+                      "startPos": {
+                        "offset": 345,
+                        "line": 27,
+                        "column": 31
+                      },
+                      "endPos": {
+                        "offset": 346,
+                        "line": 27,
+                        "column": 32
+                      },
+                      "value": ",",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [
+                        {
+                          "kind": "<space>",
+                          "startPos": {
+                            "offset": 346,
+                            "line": 27,
+                            "column": 32
+                          },
+                          "endPos": {
+                            "offset": 347,
+                            "line": 27,
+                            "column": 33
+                          },
+                          "value": " ",
+                          "leadingTrivia": [],
+                          "trailingTrivia": [],
+                          "leadingInvalid": [],
+                          "trailingInvalid": [],
+                          "isInvalid": false,
+                          "start": 346,
+                          "end": 347
+                        }
+                      ],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 345,
+                      "end": 346
+                    }
+                  ],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 362,
+                      "line": 27,
+                      "column": 48
+                    },
+                    "endPos": {
+                      "offset": 363,
+                      "line": 27,
+                      "column": 49
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 363,
+                          "line": 27,
+                          "column": 49
+                        },
+                        "endPos": {
+                          "offset": 364,
+                          "line": 28,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 363,
+                        "end": 364
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 362,
+                    "end": 363
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 364,
+              "line": 28,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 365,
+              "line": 28,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 365,
+                  "line": 28,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 366,
+                  "line": 29,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 365,
+                "end": 366
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 364,
+            "end": 365
+          }
+        },
+        "parent": 264
+      },
+      {
+        "id": 161,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 367,
+          "line": 30,
+          "column": 0
+        },
+        "fullStart": 366,
+        "endPos": {
+          "offset": 418,
+          "line": 32,
+          "column": 1
+        },
+        "fullEnd": 419,
+        "start": 367,
+        "end": 418,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 367,
+            "line": 30,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 370,
+            "line": 30,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 366,
+                "line": 29,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 367,
+                "line": 30,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 366,
+              "end": 367
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 370,
+                "line": 30,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 371,
+                "line": 30,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 370,
+              "end": 371
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 367,
+          "end": 370
+        },
+        "name": {
+          "id": 142,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 371,
+            "line": 30,
+            "column": 4
+          },
+          "fullStart": 371,
+          "endPos": {
+            "offset": 381,
+            "line": 30,
+            "column": 14
+          },
+          "fullEnd": 382,
+          "start": 371,
+          "end": 381,
+          "expression": {
+            "id": 141,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 371,
+              "line": 30,
+              "column": 4
+            },
+            "fullStart": 371,
+            "endPos": {
+              "offset": 381,
+              "line": 30,
+              "column": 14
+            },
+            "fullEnd": 382,
+            "start": 371,
+            "end": 381,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 371,
+                "line": 30,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 381,
+                "line": 30,
+                "column": 14
+              },
+              "value": "error_ref2",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 381,
+                    "line": 30,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 382,
+                    "line": 30,
+                    "column": 15
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 381,
+                  "end": 382
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 371,
+              "end": 381
+            }
+          }
+        },
+        "attributeList": {
+          "id": 147,
+          "kind": "<list-expression>",
+          "startPos": {
+            "offset": 382,
+            "line": 30,
+            "column": 15
+          },
+          "fullStart": 382,
+          "endPos": {
+            "offset": 398,
+            "line": 30,
+            "column": 31
+          },
+          "fullEnd": 399,
+          "start": 382,
+          "end": 398,
+          "listOpenBracket": {
+            "kind": "<lbracket>",
+            "startPos": {
+              "offset": 382,
+              "line": 30,
+              "column": 15
+            },
+            "endPos": {
+              "offset": 383,
+              "line": 30,
+              "column": 16
+            },
+            "value": "[",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 382,
+            "end": 383
+          },
+          "elementList": [
+            {
+              "id": 146,
+              "kind": "<attribute>",
+              "startPos": {
+                "offset": 383,
+                "line": 30,
+                "column": 16
+              },
+              "fullStart": 383,
+              "endPos": {
+                "offset": 397,
+                "line": 30,
+                "column": 30
+              },
+              "fullEnd": 397,
+              "start": 383,
+              "end": 397,
+              "name": {
+                "id": 143,
+                "kind": "<identifer-stream>",
+                "startPos": {
+                  "offset": 383,
+                  "line": 30,
+                  "column": 16
+                },
+                "fullStart": 383,
+                "endPos": {
+                  "offset": 388,
+                  "line": 30,
+                  "column": 21
+                },
+                "fullEnd": 388,
+                "start": 383,
+                "end": 388,
+                "identifiers": [
+                  {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 383,
+                      "line": 30,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 388,
+                      "line": 30,
+                      "column": 21
+                    },
+                    "value": "color",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 383,
+                    "end": 388
+                  }
+                ]
+              },
+              "value": {
+                "id": 145,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 390,
+                  "line": 30,
+                  "column": 23
+                },
+                "fullStart": 390,
+                "endPos": {
+                  "offset": 397,
+                  "line": 30,
+                  "column": 30
+                },
+                "fullEnd": 397,
+                "start": 390,
+                "end": 397,
+                "expression": {
+                  "id": 144,
+                  "kind": "<literal>",
+                  "startPos": {
+                    "offset": 390,
+                    "line": 30,
+                    "column": 23
+                  },
+                  "fullStart": 390,
+                  "endPos": {
+                    "offset": 397,
+                    "line": 30,
+                    "column": 30
+                  },
+                  "fullEnd": 397,
+                  "start": 390,
+                  "end": 397,
+                  "literal": {
+                    "kind": "<color>",
+                    "startPos": {
+                      "offset": 390,
+                      "line": 30,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 397,
+                      "line": 30,
+                      "column": 30
+                    },
+                    "value": "#123456",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 390,
+                    "end": 397
+                  }
+                }
+              },
+              "colon": {
+                "kind": "<colon>",
+                "startPos": {
+                  "offset": 388,
+                  "line": 30,
+                  "column": 21
+                },
+                "endPos": {
+                  "offset": 389,
+                  "line": 30,
+                  "column": 22
+                },
+                "value": ":",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 389,
+                      "line": 30,
+                      "column": 22
+                    },
+                    "endPos": {
+                      "offset": 390,
+                      "line": 30,
+                      "column": 23
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 389,
+                    "end": 390
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 388,
+                "end": 389
+              }
+            }
+          ],
+          "commaList": [],
+          "listCloseBracket": {
+            "kind": "<rbracket>",
+            "startPos": {
+              "offset": 397,
+              "line": 30,
+              "column": 30
+            },
+            "endPos": {
+              "offset": 398,
+              "line": 30,
+              "column": 31
+            },
+            "value": "]",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<space>",
+                "startPos": {
+                  "offset": 398,
+                  "line": 30,
+                  "column": 31
+                },
+                "endPos": {
+                  "offset": 399,
+                  "line": 30,
+                  "column": 32
+                },
+                "value": " ",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 398,
+                "end": 399
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 397,
+            "end": 398
+          }
+        },
+        "body": {
+          "id": 160,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 399,
+            "line": 30,
+            "column": 32
+          },
+          "fullStart": 399,
+          "endPos": {
+            "offset": 418,
+            "line": 32,
+            "column": 1
+          },
+          "fullEnd": 419,
+          "start": 399,
+          "end": 418,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 399,
+              "line": 30,
+              "column": 32
+            },
+            "endPos": {
+              "offset": 400,
+              "line": 30,
+              "column": 33
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 400,
+                  "line": 30,
+                  "column": 33
+                },
+                "endPos": {
+                  "offset": 401,
+                  "line": 31,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 400,
+                "end": 401
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 399,
+            "end": 400
+          },
+          "body": [
+            {
+              "id": 159,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 403,
+                "line": 31,
+                "column": 2
+              },
+              "fullStart": 401,
+              "endPos": {
+                "offset": 416,
+                "line": 31,
+                "column": 15
+              },
+              "fullEnd": 417,
+              "start": 403,
+              "end": 416,
+              "callee": {
+                "id": 158,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 403,
+                  "line": 31,
+                  "column": 2
+                },
+                "fullStart": 401,
+                "endPos": {
+                  "offset": 416,
+                  "line": 31,
+                  "column": 15
+                },
+                "fullEnd": 417,
+                "start": 403,
+                "end": 416,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 409,
+                    "line": 31,
+                    "column": 8
+                  },
+                  "endPos": {
+                    "offset": 410,
+                    "line": 31,
+                    "column": 9
+                  },
+                  "value": "<",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 410,
+                        "line": 31,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 411,
+                        "line": 31,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 410,
+                      "end": 411
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 409,
+                  "end": 410
+                },
+                "leftExpression": {
+                  "id": 152,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 403,
+                    "line": 31,
+                    "column": 2
+                  },
+                  "fullStart": 401,
+                  "endPos": {
+                    "offset": 408,
+                    "line": 31,
+                    "column": 7
+                  },
+                  "fullEnd": 409,
+                  "start": 403,
+                  "end": 408,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 404,
+                      "line": 31,
+                      "column": 3
+                    },
+                    "endPos": {
+                      "offset": 405,
+                      "line": 31,
+                      "column": 4
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 404,
+                    "end": 405
+                  },
+                  "leftExpression": {
+                    "id": 149,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 403,
+                      "line": 31,
+                      "column": 2
+                    },
+                    "fullStart": 401,
+                    "endPos": {
+                      "offset": 404,
+                      "line": 31,
+                      "column": 3
+                    },
+                    "fullEnd": 404,
+                    "start": 403,
+                    "end": 404,
+                    "expression": {
+                      "id": 148,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 403,
+                        "line": 31,
+                        "column": 2
+                      },
+                      "fullStart": 401,
+                      "endPos": {
+                        "offset": 404,
+                        "line": 31,
+                        "column": 3
+                      },
+                      "fullEnd": 404,
+                      "start": 403,
+                      "end": 404,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 403,
+                          "line": 31,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 404,
+                          "line": 31,
+                          "column": 3
+                        },
+                        "value": "c",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 401,
+                              "line": 31,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 402,
+                              "line": 31,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 401,
+                            "end": 402
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 402,
+                              "line": 31,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 403,
+                              "line": 31,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 402,
+                            "end": 403
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 403,
+                        "end": 404
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 151,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 405,
+                      "line": 31,
+                      "column": 4
+                    },
+                    "fullStart": 405,
+                    "endPos": {
+                      "offset": 408,
+                      "line": 31,
+                      "column": 7
+                    },
+                    "fullEnd": 409,
+                    "start": 405,
+                    "end": 408,
+                    "expression": {
+                      "id": 150,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 405,
+                        "line": 31,
+                        "column": 4
+                      },
+                      "fullStart": 405,
+                      "endPos": {
+                        "offset": 408,
+                        "line": 31,
+                        "column": 7
+                      },
+                      "fullEnd": 409,
+                      "start": 405,
+                      "end": 408,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 405,
+                          "line": 31,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 408,
+                          "line": 31,
+                          "column": 7
+                        },
+                        "value": "id2",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 408,
+                              "line": 31,
+                              "column": 7
+                            },
+                            "endPos": {
+                              "offset": 409,
+                              "line": 31,
+                              "column": 8
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 408,
+                            "end": 409
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 405,
+                        "end": 408
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 157,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 411,
+                    "line": 31,
+                    "column": 10
+                  },
+                  "fullStart": 411,
+                  "endPos": {
+                    "offset": 416,
+                    "line": 31,
+                    "column": 15
+                  },
+                  "fullEnd": 417,
+                  "start": 411,
+                  "end": 416,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 412,
+                      "line": 31,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 413,
+                      "line": 31,
+                      "column": 12
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 412,
+                    "end": 413
+                  },
+                  "leftExpression": {
+                    "id": 154,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 411,
+                      "line": 31,
+                      "column": 10
+                    },
+                    "fullStart": 411,
+                    "endPos": {
+                      "offset": 412,
+                      "line": 31,
+                      "column": 11
+                    },
+                    "fullEnd": 412,
+                    "start": 411,
+                    "end": 412,
+                    "expression": {
+                      "id": 153,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 411,
+                        "line": 31,
+                        "column": 10
+                      },
+                      "fullStart": 411,
+                      "endPos": {
+                        "offset": 412,
+                        "line": 31,
+                        "column": 11
+                      },
+                      "fullEnd": 412,
+                      "start": 411,
+                      "end": 412,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 411,
+                          "line": 31,
+                          "column": 10
+                        },
+                        "endPos": {
+                          "offset": 412,
+                          "line": 31,
+                          "column": 11
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 411,
+                        "end": 412
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 156,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 413,
+                      "line": 31,
+                      "column": 12
+                    },
+                    "fullStart": 413,
+                    "endPos": {
+                      "offset": 416,
+                      "line": 31,
+                      "column": 15
+                    },
+                    "fullEnd": 417,
+                    "start": 413,
+                    "end": 416,
+                    "expression": {
+                      "id": 155,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 413,
+                        "line": 31,
+                        "column": 12
+                      },
+                      "fullStart": 413,
+                      "endPos": {
+                        "offset": 416,
+                        "line": 31,
+                        "column": 15
+                      },
+                      "fullEnd": 417,
+                      "start": 413,
+                      "end": 416,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 413,
+                          "line": 31,
+                          "column": 12
+                        },
+                        "endPos": {
+                          "offset": 416,
+                          "line": 31,
+                          "column": 15
+                        },
+                        "value": "id2",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<newline>",
+                            "startPos": {
+                              "offset": 416,
+                              "line": 31,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 417,
+                              "line": 32,
+                              "column": 0
+                            },
+                            "value": "\n",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 416,
+                            "end": 417
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 413,
+                        "end": 416
+                      }
+                    }
+                  }
+                }
+              },
+              "args": []
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 417,
+              "line": 32,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 418,
+              "line": 32,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 418,
+                  "line": 32,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 419,
+                  "line": 33,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 418,
+                "end": 419
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 417,
+            "end": 418
+          }
+        },
+        "parent": 264
+      },
+      {
+        "id": 182,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 420,
+          "line": 34,
+          "column": 0
+        },
+        "fullStart": 419,
+        "endPos": {
+          "offset": 476,
+          "line": 36,
+          "column": 1
+        },
+        "fullEnd": 477,
+        "start": 420,
+        "end": 476,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 420,
+            "line": 34,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 423,
+            "line": 34,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 419,
+                "line": 33,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 420,
+                "line": 34,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 419,
+              "end": 420
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 423,
+                "line": 34,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 424,
+                "line": 34,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 423,
+              "end": 424
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 420,
+          "end": 423
+        },
+        "name": {
+          "id": 163,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 424,
+            "line": 34,
+            "column": 4
+          },
+          "fullStart": 424,
+          "endPos": {
+            "offset": 434,
+            "line": 34,
+            "column": 14
+          },
+          "fullEnd": 435,
+          "start": 424,
+          "end": 434,
+          "expression": {
+            "id": 162,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 424,
+              "line": 34,
+              "column": 4
+            },
+            "fullStart": 424,
+            "endPos": {
+              "offset": 434,
+              "line": 34,
+              "column": 14
+            },
+            "fullEnd": 435,
+            "start": 424,
+            "end": 434,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 424,
+                "line": 34,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 434,
+                "line": 34,
+                "column": 14
+              },
+              "value": "error_ref3",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 434,
+                    "line": 34,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 435,
+                    "line": 34,
+                    "column": 15
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 434,
+                  "end": 435
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 424,
+              "end": 434
+            }
+          }
+        },
+        "body": {
+          "id": 181,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 435,
+            "line": 34,
+            "column": 15
+          },
+          "fullStart": 435,
+          "endPos": {
+            "offset": 476,
+            "line": 36,
+            "column": 1
+          },
+          "fullEnd": 477,
+          "start": 435,
+          "end": 476,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 435,
+              "line": 34,
+              "column": 15
+            },
+            "endPos": {
+              "offset": 436,
+              "line": 34,
+              "column": 16
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 436,
+                  "line": 34,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 437,
+                  "line": 35,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 436,
+                "end": 437
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 435,
+            "end": 436
+          },
+          "body": [
+            {
+              "id": 180,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 439,
+                "line": 35,
+                "column": 2
+              },
+              "fullStart": 437,
+              "endPos": {
+                "offset": 474,
+                "line": 35,
+                "column": 37
+              },
+              "fullEnd": 475,
+              "start": 439,
+              "end": 474,
+              "callee": {
+                "id": 174,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 439,
+                  "line": 35,
+                  "column": 2
+                },
+                "fullStart": 437,
+                "endPos": {
+                  "offset": 452,
+                  "line": 35,
+                  "column": 15
+                },
+                "fullEnd": 453,
+                "start": 439,
+                "end": 452,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 445,
+                    "line": 35,
+                    "column": 8
+                  },
+                  "endPos": {
+                    "offset": 446,
+                    "line": 35,
+                    "column": 9
+                  },
+                  "value": "<",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 446,
+                        "line": 35,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 447,
+                        "line": 35,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 446,
+                      "end": 447
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 445,
+                  "end": 446
+                },
+                "leftExpression": {
+                  "id": 168,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 439,
+                    "line": 35,
+                    "column": 2
+                  },
+                  "fullStart": 437,
+                  "endPos": {
+                    "offset": 444,
+                    "line": 35,
+                    "column": 7
+                  },
+                  "fullEnd": 445,
+                  "start": 439,
+                  "end": 444,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 440,
+                      "line": 35,
+                      "column": 3
+                    },
+                    "endPos": {
+                      "offset": 441,
+                      "line": 35,
+                      "column": 4
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 440,
+                    "end": 441
+                  },
+                  "leftExpression": {
+                    "id": 165,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 439,
+                      "line": 35,
+                      "column": 2
+                    },
+                    "fullStart": 437,
+                    "endPos": {
+                      "offset": 440,
+                      "line": 35,
+                      "column": 3
+                    },
+                    "fullEnd": 440,
+                    "start": 439,
+                    "end": 440,
+                    "expression": {
+                      "id": 164,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 439,
+                        "line": 35,
+                        "column": 2
+                      },
+                      "fullStart": 437,
+                      "endPos": {
+                        "offset": 440,
+                        "line": 35,
+                        "column": 3
+                      },
+                      "fullEnd": 440,
+                      "start": 439,
+                      "end": 440,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 439,
+                          "line": 35,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 440,
+                          "line": 35,
+                          "column": 3
+                        },
+                        "value": "c",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 437,
+                              "line": 35,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 438,
+                              "line": 35,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 437,
+                            "end": 438
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 438,
+                              "line": 35,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 439,
+                              "line": 35,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 438,
+                            "end": 439
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 439,
+                        "end": 440
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 167,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 441,
+                      "line": 35,
+                      "column": 4
+                    },
+                    "fullStart": 441,
+                    "endPos": {
+                      "offset": 444,
+                      "line": 35,
+                      "column": 7
+                    },
+                    "fullEnd": 445,
+                    "start": 441,
+                    "end": 444,
+                    "expression": {
+                      "id": 166,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 441,
+                        "line": 35,
+                        "column": 4
+                      },
+                      "fullStart": 441,
+                      "endPos": {
+                        "offset": 444,
+                        "line": 35,
+                        "column": 7
+                      },
+                      "fullEnd": 445,
+                      "start": 441,
+                      "end": 444,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 441,
+                          "line": 35,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 444,
+                          "line": 35,
+                          "column": 7
+                        },
+                        "value": "id3",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 444,
+                              "line": 35,
+                              "column": 7
+                            },
+                            "endPos": {
+                              "offset": 445,
+                              "line": 35,
+                              "column": 8
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 444,
+                            "end": 445
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 441,
+                        "end": 444
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 173,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 447,
+                    "line": 35,
+                    "column": 10
+                  },
+                  "fullStart": 447,
+                  "endPos": {
+                    "offset": 452,
+                    "line": 35,
+                    "column": 15
+                  },
+                  "fullEnd": 453,
+                  "start": 447,
+                  "end": 452,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 448,
+                      "line": 35,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 449,
+                      "line": 35,
+                      "column": 12
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 448,
+                    "end": 449
+                  },
+                  "leftExpression": {
+                    "id": 170,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 447,
+                      "line": 35,
+                      "column": 10
+                    },
+                    "fullStart": 447,
+                    "endPos": {
+                      "offset": 448,
+                      "line": 35,
+                      "column": 11
+                    },
+                    "fullEnd": 448,
+                    "start": 447,
+                    "end": 448,
+                    "expression": {
+                      "id": 169,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 447,
+                        "line": 35,
+                        "column": 10
+                      },
+                      "fullStart": 447,
+                      "endPos": {
+                        "offset": 448,
+                        "line": 35,
+                        "column": 11
+                      },
+                      "fullEnd": 448,
+                      "start": 447,
+                      "end": 448,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 447,
+                          "line": 35,
+                          "column": 10
+                        },
+                        "endPos": {
+                          "offset": 448,
+                          "line": 35,
+                          "column": 11
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 447,
+                        "end": 448
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 172,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 449,
+                      "line": 35,
+                      "column": 12
+                    },
+                    "fullStart": 449,
+                    "endPos": {
+                      "offset": 452,
+                      "line": 35,
+                      "column": 15
+                    },
+                    "fullEnd": 453,
+                    "start": 449,
+                    "end": 452,
+                    "expression": {
+                      "id": 171,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 449,
+                        "line": 35,
+                        "column": 12
+                      },
+                      "fullStart": 449,
+                      "endPos": {
+                        "offset": 452,
+                        "line": 35,
+                        "column": 15
+                      },
+                      "fullEnd": 453,
+                      "start": 449,
+                      "end": 452,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 449,
+                          "line": 35,
+                          "column": 12
+                        },
+                        "endPos": {
+                          "offset": 452,
+                          "line": 35,
+                          "column": 15
+                        },
+                        "value": "id3",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 452,
+                              "line": 35,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 453,
+                              "line": 35,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 452,
+                            "end": 453
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 449,
+                        "end": 452
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 179,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 453,
+                    "line": 35,
+                    "column": 16
+                  },
+                  "fullStart": 453,
+                  "endPos": {
+                    "offset": 474,
+                    "line": 35,
+                    "column": 37
+                  },
+                  "fullEnd": 475,
+                  "start": 453,
+                  "end": 474,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 453,
+                      "line": 35,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 454,
+                      "line": 35,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 453,
+                    "end": 454
+                  },
+                  "elementList": [
+                    {
+                      "id": 178,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 454,
+                        "line": 35,
+                        "column": 17
+                      },
+                      "fullStart": 454,
+                      "endPos": {
+                        "offset": 473,
+                        "line": 35,
+                        "column": 36
+                      },
+                      "fullEnd": 473,
+                      "start": 454,
+                      "end": 473,
+                      "name": {
+                        "id": 175,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 454,
+                          "line": 35,
+                          "column": 17
+                        },
+                        "fullStart": 454,
+                        "endPos": {
+                          "offset": 459,
+                          "line": 35,
+                          "column": 22
+                        },
+                        "fullEnd": 459,
+                        "start": 454,
+                        "end": 459,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 454,
+                              "line": 35,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 459,
+                              "line": 35,
+                              "column": 22
+                            },
+                            "value": "color",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 454,
+                            "end": 459
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 177,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 461,
+                          "line": 35,
+                          "column": 24
+                        },
+                        "fullStart": 461,
+                        "endPos": {
+                          "offset": 473,
+                          "line": 35,
+                          "column": 36
+                        },
+                        "fullEnd": 473,
+                        "start": 461,
+                        "end": 473,
+                        "expression": {
+                          "id": 176,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 461,
+                            "line": 35,
+                            "column": 24
+                          },
+                          "fullStart": 461,
+                          "endPos": {
+                            "offset": 473,
+                            "line": 35,
+                            "column": 36
+                          },
+                          "fullEnd": 473,
+                          "start": 461,
+                          "end": 473,
+                          "literal": {
+                            "kind": "<color>",
+                            "startPos": {
+                              "offset": 461,
+                              "line": 35,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 473,
+                              "line": 35,
+                              "column": 36
+                            },
+                            "value": "#not_a_color",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 461,
+                            "end": 473
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 459,
+                          "line": 35,
+                          "column": 22
+                        },
+                        "endPos": {
+                          "offset": 460,
+                          "line": 35,
+                          "column": 23
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 460,
+                              "line": 35,
+                              "column": 23
+                            },
+                            "endPos": {
+                              "offset": 461,
+                              "line": 35,
+                              "column": 24
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 460,
+                            "end": 461
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 459,
+                        "end": 460
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 473,
+                      "line": 35,
+                      "column": 36
+                    },
+                    "endPos": {
+                      "offset": 474,
+                      "line": 35,
+                      "column": 37
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 474,
+                          "line": 35,
+                          "column": 37
+                        },
+                        "endPos": {
+                          "offset": 475,
+                          "line": 36,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 474,
+                        "end": 475
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 473,
+                    "end": 474
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 475,
+              "line": 36,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 476,
+              "line": 36,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 476,
+                  "line": 36,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 477,
+                  "line": 37,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 476,
+                "end": 477
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 475,
+            "end": 476
+          }
+        },
+        "parent": 264
+      },
+      {
+        "id": 203,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 478,
+          "line": 38,
+          "column": 0
+        },
+        "fullStart": 477,
+        "endPos": {
+          "offset": 529,
+          "line": 40,
+          "column": 1
+        },
+        "fullEnd": 530,
+        "start": 478,
+        "end": 529,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 478,
+            "line": 38,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 481,
+            "line": 38,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 477,
+                "line": 37,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 478,
+                "line": 38,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 477,
+              "end": 478
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 481,
+                "line": 38,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 482,
+                "line": 38,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 481,
+              "end": 482
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 478,
+          "end": 481
+        },
+        "name": {
+          "id": 184,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 482,
+            "line": 38,
+            "column": 4
+          },
+          "fullStart": 482,
+          "endPos": {
+            "offset": 492,
+            "line": 38,
+            "column": 14
+          },
+          "fullEnd": 493,
+          "start": 482,
+          "end": 492,
+          "expression": {
+            "id": 183,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 482,
+              "line": 38,
+              "column": 4
+            },
+            "fullStart": 482,
+            "endPos": {
+              "offset": 492,
+              "line": 38,
+              "column": 14
+            },
+            "fullEnd": 493,
+            "start": 482,
+            "end": 492,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 482,
+                "line": 38,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 492,
+                "line": 38,
+                "column": 14
+              },
+              "value": "error_ref4",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 492,
+                    "line": 38,
+                    "column": 14
+                  },
+                  "endPos": {
+                    "offset": 493,
+                    "line": 38,
+                    "column": 15
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 492,
+                  "end": 493
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 482,
+              "end": 492
+            }
+          }
+        },
+        "body": {
+          "id": 202,
+          "kind": "<block-expression>",
+          "startPos": {
+            "offset": 493,
+            "line": 38,
+            "column": 15
+          },
+          "fullStart": 493,
+          "endPos": {
+            "offset": 529,
+            "line": 40,
+            "column": 1
+          },
+          "fullEnd": 530,
+          "start": 493,
+          "end": 529,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
+            "startPos": {
+              "offset": 493,
+              "line": 38,
+              "column": 15
+            },
+            "endPos": {
+              "offset": 494,
+              "line": 38,
+              "column": 16
+            },
+            "value": "{",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 494,
+                  "line": 38,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 495,
+                  "line": 39,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 494,
+                "end": 495
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 493,
+            "end": 494
+          },
+          "body": [
+            {
+              "id": 201,
+              "kind": "<function-application>",
+              "startPos": {
+                "offset": 497,
+                "line": 39,
+                "column": 2
+              },
+              "fullStart": 495,
+              "endPos": {
+                "offset": 527,
+                "line": 39,
+                "column": 32
+              },
+              "fullEnd": 528,
+              "start": 497,
+              "end": 527,
+              "callee": {
+                "id": 195,
+                "kind": "<infix-expression>",
+                "startPos": {
+                  "offset": 497,
+                  "line": 39,
+                  "column": 2
+                },
+                "fullStart": 495,
+                "endPos": {
+                  "offset": 510,
+                  "line": 39,
+                  "column": 15
+                },
+                "fullEnd": 511,
+                "start": 497,
+                "end": 510,
+                "op": {
+                  "kind": "<op>",
+                  "startPos": {
+                    "offset": 503,
+                    "line": 39,
+                    "column": 8
+                  },
+                  "endPos": {
+                    "offset": 504,
+                    "line": 39,
+                    "column": 9
+                  },
+                  "value": "<",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "<space>",
+                      "startPos": {
+                        "offset": 504,
+                        "line": 39,
+                        "column": 9
+                      },
+                      "endPos": {
+                        "offset": 505,
+                        "line": 39,
+                        "column": 10
+                      },
+                      "value": " ",
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "leadingInvalid": [],
+                      "trailingInvalid": [],
+                      "isInvalid": false,
+                      "start": 504,
+                      "end": 505
+                    }
+                  ],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 503,
+                  "end": 504
+                },
+                "leftExpression": {
+                  "id": 189,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 497,
+                    "line": 39,
+                    "column": 2
+                  },
+                  "fullStart": 495,
+                  "endPos": {
+                    "offset": 502,
+                    "line": 39,
+                    "column": 7
+                  },
+                  "fullEnd": 503,
+                  "start": 497,
+                  "end": 502,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 498,
+                      "line": 39,
+                      "column": 3
+                    },
+                    "endPos": {
+                      "offset": 499,
+                      "line": 39,
+                      "column": 4
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 498,
+                    "end": 499
+                  },
+                  "leftExpression": {
+                    "id": 186,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 497,
+                      "line": 39,
+                      "column": 2
+                    },
+                    "fullStart": 495,
+                    "endPos": {
+                      "offset": 498,
+                      "line": 39,
+                      "column": 3
+                    },
+                    "fullEnd": 498,
+                    "start": 497,
+                    "end": 498,
+                    "expression": {
+                      "id": 185,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 497,
+                        "line": 39,
+                        "column": 2
+                      },
+                      "fullStart": 495,
+                      "endPos": {
+                        "offset": 498,
+                        "line": 39,
+                        "column": 3
+                      },
+                      "fullEnd": 498,
+                      "start": 497,
+                      "end": 498,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 497,
+                          "line": 39,
+                          "column": 2
+                        },
+                        "endPos": {
+                          "offset": 498,
+                          "line": 39,
+                          "column": 3
+                        },
+                        "value": "c",
+                        "leadingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 495,
+                              "line": 39,
+                              "column": 0
+                            },
+                            "endPos": {
+                              "offset": 496,
+                              "line": 39,
+                              "column": 1
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 495,
+                            "end": 496
+                          },
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 496,
+                              "line": 39,
+                              "column": 1
+                            },
+                            "endPos": {
+                              "offset": 497,
+                              "line": 39,
+                              "column": 2
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 496,
+                            "end": 497
+                          }
+                        ],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 497,
+                        "end": 498
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 188,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 499,
+                      "line": 39,
+                      "column": 4
+                    },
+                    "fullStart": 499,
+                    "endPos": {
+                      "offset": 502,
+                      "line": 39,
+                      "column": 7
+                    },
+                    "fullEnd": 503,
+                    "start": 499,
+                    "end": 502,
+                    "expression": {
+                      "id": 187,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 499,
+                        "line": 39,
+                        "column": 4
+                      },
+                      "fullStart": 499,
+                      "endPos": {
+                        "offset": 502,
+                        "line": 39,
+                        "column": 7
+                      },
+                      "fullEnd": 503,
+                      "start": 499,
+                      "end": 502,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 499,
+                          "line": 39,
+                          "column": 4
+                        },
+                        "endPos": {
+                          "offset": 502,
+                          "line": 39,
+                          "column": 7
+                        },
+                        "value": "id4",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 502,
+                              "line": 39,
+                              "column": 7
+                            },
+                            "endPos": {
+                              "offset": 503,
+                              "line": 39,
+                              "column": 8
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 502,
+                            "end": 503
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 499,
+                        "end": 502
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 194,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 505,
+                    "line": 39,
+                    "column": 10
+                  },
+                  "fullStart": 505,
+                  "endPos": {
+                    "offset": 510,
+                    "line": 39,
+                    "column": 15
+                  },
+                  "fullEnd": 511,
+                  "start": 505,
+                  "end": 510,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 506,
+                      "line": 39,
+                      "column": 11
+                    },
+                    "endPos": {
+                      "offset": 507,
+                      "line": 39,
+                      "column": 12
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 506,
+                    "end": 507
+                  },
+                  "leftExpression": {
+                    "id": 191,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 505,
+                      "line": 39,
+                      "column": 10
+                    },
+                    "fullStart": 505,
+                    "endPos": {
+                      "offset": 506,
+                      "line": 39,
+                      "column": 11
+                    },
+                    "fullEnd": 506,
+                    "start": 505,
+                    "end": 506,
+                    "expression": {
+                      "id": 190,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 505,
+                        "line": 39,
+                        "column": 10
+                      },
+                      "fullStart": 505,
+                      "endPos": {
+                        "offset": 506,
+                        "line": 39,
+                        "column": 11
+                      },
+                      "fullEnd": 506,
+                      "start": 505,
+                      "end": 506,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 505,
+                          "line": 39,
+                          "column": 10
+                        },
+                        "endPos": {
+                          "offset": 506,
+                          "line": 39,
+                          "column": 11
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 505,
+                        "end": 506
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 193,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 507,
+                      "line": 39,
+                      "column": 12
+                    },
+                    "fullStart": 507,
+                    "endPos": {
+                      "offset": 510,
+                      "line": 39,
+                      "column": 15
+                    },
+                    "fullEnd": 511,
+                    "start": 507,
+                    "end": 510,
+                    "expression": {
+                      "id": 192,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 507,
+                        "line": 39,
+                        "column": 12
+                      },
+                      "fullStart": 507,
+                      "endPos": {
+                        "offset": 510,
+                        "line": 39,
+                        "column": 15
+                      },
+                      "fullEnd": 511,
+                      "start": 507,
+                      "end": 510,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 507,
+                          "line": 39,
+                          "column": 12
+                        },
+                        "endPos": {
+                          "offset": 510,
+                          "line": 39,
+                          "column": 15
+                        },
+                        "value": "id4",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 510,
+                              "line": 39,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 511,
+                              "line": 39,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 510,
+                            "end": 511
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 507,
+                        "end": 510
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 200,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 511,
+                    "line": 39,
+                    "column": 16
+                  },
+                  "fullStart": 511,
+                  "endPos": {
+                    "offset": 527,
+                    "line": 39,
+                    "column": 32
+                  },
+                  "fullEnd": 528,
+                  "start": 511,
+                  "end": 527,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 511,
+                      "line": 39,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 512,
+                      "line": 39,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 511,
+                    "end": 512
+                  },
+                  "elementList": [
+                    {
+                      "id": 199,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 512,
+                        "line": 39,
+                        "column": 17
+                      },
+                      "fullStart": 512,
+                      "endPos": {
+                        "offset": 526,
+                        "line": 39,
+                        "column": 31
+                      },
+                      "fullEnd": 526,
+                      "start": 512,
+                      "end": 526,
+                      "name": {
+                        "id": 196,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 512,
+                          "line": 39,
+                          "column": 17
+                        },
+                        "fullStart": 512,
+                        "endPos": {
+                          "offset": 517,
+                          "line": 39,
+                          "column": 22
+                        },
+                        "fullEnd": 517,
+                        "start": 512,
+                        "end": 517,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 512,
+                              "line": 39,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 517,
+                              "line": 39,
+                              "column": 22
+                            },
+                            "value": "hello",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 512,
+                            "end": 517
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 198,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 519,
+                          "line": 39,
+                          "column": 24
+                        },
+                        "fullStart": 519,
+                        "endPos": {
+                          "offset": 526,
+                          "line": 39,
+                          "column": 31
+                        },
+                        "fullEnd": 526,
+                        "start": 519,
+                        "end": 526,
+                        "expression": {
+                          "id": 197,
+                          "kind": "<variable>",
+                          "startPos": {
+                            "offset": 519,
+                            "line": 39,
+                            "column": 24
+                          },
+                          "fullStart": 519,
+                          "endPos": {
+                            "offset": 526,
+                            "line": 39,
+                            "column": 31
+                          },
+                          "fullEnd": 526,
+                          "start": 519,
+                          "end": 526,
+                          "variable": {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 519,
+                              "line": 39,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 526,
+                              "line": 39,
+                              "column": 31
+                            },
+                            "value": "goodbye",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 519,
+                            "end": 526
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 517,
+                          "line": 39,
+                          "column": 22
+                        },
+                        "endPos": {
+                          "offset": 518,
+                          "line": 39,
+                          "column": 23
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 518,
+                              "line": 39,
+                              "column": 23
+                            },
+                            "endPos": {
+                              "offset": 519,
+                              "line": 39,
+                              "column": 24
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 518,
+                            "end": 519
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 517,
+                        "end": 518
+                      }
+                    }
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
+                    "startPos": {
+                      "offset": 526,
+                      "line": 39,
+                      "column": 31
+                    },
+                    "endPos": {
+                      "offset": 527,
+                      "line": 39,
+                      "column": 32
+                    },
+                    "value": "]",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 527,
+                          "line": 39,
+                          "column": 32
+                        },
+                        "endPos": {
+                          "offset": 528,
+                          "line": 40,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 527,
+                        "end": 528
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 526,
+                    "end": 527
+                  }
+                }
+              ]
+            }
+          ],
+          "blockCloseBrace": {
+            "kind": "<rbrace>",
+            "startPos": {
+              "offset": 528,
+              "line": 40,
+              "column": 0
+            },
+            "endPos": {
+              "offset": 529,
+              "line": 40,
+              "column": 1
+            },
+            "value": "}",
+            "leadingTrivia": [],
+            "trailingTrivia": [
+              {
+                "kind": "<newline>",
+                "startPos": {
+                  "offset": 529,
+                  "line": 40,
+                  "column": 1
+                },
+                "endPos": {
+                  "offset": 530,
+                  "line": 41,
+                  "column": 0
+                },
+                "value": "\n",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 529,
+                "end": 530
+              }
+            ],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 528,
+            "end": 529
+          }
+        },
+        "parent": 264
+      },
+      {
+        "id": 223,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 531,
+          "line": 42,
+          "column": 0
+        },
+        "fullStart": 530,
+        "endPos": {
+          "offset": 582,
+          "line": 42,
+          "column": 51
+        },
+        "fullEnd": 583,
+        "start": 531,
+        "end": 582,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 531,
+            "line": 42,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 534,
+            "line": 42,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [
+            {
+              "kind": "<newline>",
+              "startPos": {
+                "offset": 530,
+                "line": 41,
+                "column": 0
+              },
+              "endPos": {
+                "offset": 531,
+                "line": 42,
+                "column": 0
+              },
+              "value": "\n",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 530,
+              "end": 531
+            }
+          ],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 534,
+                "line": 42,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 535,
+                "line": 42,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 534,
+              "end": 535
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 531,
+          "end": 534
+        },
+        "name": {
+          "id": 205,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 535,
+            "line": 42,
+            "column": 4
+          },
+          "fullStart": 535,
+          "endPos": {
+            "offset": 550,
+            "line": 42,
+            "column": 19
+          },
+          "fullEnd": 551,
+          "start": 535,
+          "end": 550,
+          "expression": {
+            "id": 204,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 535,
+              "line": 42,
+              "column": 4
+            },
+            "fullStart": 535,
+            "endPos": {
+              "offset": 550,
+              "line": 42,
+              "column": 19
+            },
+            "fullEnd": 551,
+            "start": 535,
+            "end": 550,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 535,
+                "line": 42,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 550,
+                "line": 42,
+                "column": 19
+              },
+              "value": "error_shortref2",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 550,
+                    "line": 42,
+                    "column": 19
+                  },
+                  "endPos": {
+                    "offset": 551,
+                    "line": 42,
+                    "column": 20
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 550,
+                  "end": 551
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 535,
+              "end": 550
+            }
+          }
+        },
+        "attributeList": {
+          "id": 210,
+          "kind": "<list-expression>",
+          "startPos": {
+            "offset": 551,
+            "line": 42,
+            "column": 20
+          },
+          "fullStart": 551,
+          "endPos": {
+            "offset": 567,
+            "line": 42,
+            "column": 36
+          },
+          "fullEnd": 567,
+          "start": 551,
+          "end": 567,
+          "listOpenBracket": {
+            "kind": "<lbracket>",
+            "startPos": {
+              "offset": 551,
+              "line": 42,
+              "column": 20
+            },
+            "endPos": {
+              "offset": 552,
+              "line": 42,
+              "column": 21
+            },
+            "value": "[",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 551,
+            "end": 552
+          },
+          "elementList": [
+            {
+              "id": 209,
+              "kind": "<attribute>",
+              "startPos": {
+                "offset": 552,
+                "line": 42,
+                "column": 21
+              },
+              "fullStart": 552,
+              "endPos": {
+                "offset": 566,
+                "line": 42,
+                "column": 35
+              },
+              "fullEnd": 566,
+              "start": 552,
+              "end": 566,
+              "name": {
+                "id": 206,
+                "kind": "<identifer-stream>",
+                "startPos": {
+                  "offset": 552,
+                  "line": 42,
+                  "column": 21
+                },
+                "fullStart": 552,
+                "endPos": {
+                  "offset": 557,
+                  "line": 42,
+                  "column": 26
+                },
+                "fullEnd": 557,
+                "start": 552,
+                "end": 557,
+                "identifiers": [
+                  {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 552,
+                      "line": 42,
+                      "column": 21
+                    },
+                    "endPos": {
+                      "offset": 557,
+                      "line": 42,
+                      "column": 26
+                    },
+                    "value": "color",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 552,
+                    "end": 557
+                  }
+                ]
+              },
+              "value": {
+                "id": 208,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 559,
+                  "line": 42,
+                  "column": 28
+                },
+                "fullStart": 559,
+                "endPos": {
+                  "offset": 566,
+                  "line": 42,
+                  "column": 35
+                },
+                "fullEnd": 566,
+                "start": 559,
+                "end": 566,
+                "expression": {
+                  "id": 207,
+                  "kind": "<literal>",
+                  "startPos": {
+                    "offset": 559,
+                    "line": 42,
+                    "column": 28
+                  },
+                  "fullStart": 559,
+                  "endPos": {
+                    "offset": 566,
+                    "line": 42,
+                    "column": 35
+                  },
+                  "fullEnd": 566,
+                  "start": 559,
+                  "end": 566,
+                  "literal": {
+                    "kind": "<color>",
+                    "startPos": {
+                      "offset": 559,
+                      "line": 42,
+                      "column": 28
+                    },
+                    "endPos": {
+                      "offset": 566,
+                      "line": 42,
+                      "column": 35
+                    },
+                    "value": "#123456",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 559,
+                    "end": 566
+                  }
+                }
+              },
+              "colon": {
+                "kind": "<colon>",
+                "startPos": {
+                  "offset": 557,
+                  "line": 42,
+                  "column": 26
+                },
+                "endPos": {
+                  "offset": 558,
+                  "line": 42,
+                  "column": 27
+                },
+                "value": ":",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<space>",
+                    "startPos": {
+                      "offset": 558,
+                      "line": 42,
+                      "column": 27
+                    },
+                    "endPos": {
+                      "offset": 559,
+                      "line": 42,
+                      "column": 28
+                    },
+                    "value": " ",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 558,
+                    "end": 559
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 557,
+                "end": 558
+              }
+            }
+          ],
+          "commaList": [],
+          "listCloseBracket": {
+            "kind": "<rbracket>",
+            "startPos": {
+              "offset": 566,
+              "line": 42,
+              "column": 35
+            },
+            "endPos": {
+              "offset": 567,
+              "line": 42,
+              "column": 36
+            },
+            "value": "]",
+            "leadingTrivia": [],
+            "trailingTrivia": [],
+            "leadingInvalid": [],
+            "trailingInvalid": [],
+            "isInvalid": false,
+            "start": 566,
+            "end": 567
+          }
+        },
+        "bodyColon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 567,
+            "line": 42,
+            "column": 36
+          },
+          "endPos": {
+            "offset": 568,
+            "line": 42,
+            "column": 37
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 568,
+                "line": 42,
+                "column": 37
+              },
+              "endPos": {
+                "offset": 569,
+                "line": 42,
+                "column": 38
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 568,
+              "end": 569
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 567,
+          "end": 568
+        },
+        "body": {
+          "id": 222,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 569,
+            "line": 42,
+            "column": 38
+          },
+          "fullStart": 569,
+          "endPos": {
+            "offset": 582,
+            "line": 42,
+            "column": 51
+          },
+          "fullEnd": 583,
+          "start": 569,
+          "end": 582,
+          "callee": {
+            "id": 221,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 569,
+              "line": 42,
+              "column": 38
+            },
+            "fullStart": 569,
+            "endPos": {
+              "offset": 582,
+              "line": 42,
+              "column": 51
+            },
+            "fullEnd": 583,
+            "start": 569,
+            "end": 582,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 575,
+                "line": 42,
+                "column": 44
+              },
+              "endPos": {
+                "offset": 576,
+                "line": 42,
+                "column": 45
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 576,
+                    "line": 42,
+                    "column": 45
+                  },
+                  "endPos": {
+                    "offset": 577,
+                    "line": 42,
+                    "column": 46
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 576,
+                  "end": 577
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 575,
+              "end": 576
+            },
+            "leftExpression": {
+              "id": 215,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 569,
+                "line": 42,
+                "column": 38
+              },
+              "fullStart": 569,
+              "endPos": {
+                "offset": 574,
+                "line": 42,
+                "column": 43
+              },
+              "fullEnd": 575,
+              "start": 569,
+              "end": 574,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 570,
+                  "line": 42,
+                  "column": 39
+                },
+                "endPos": {
+                  "offset": 571,
+                  "line": 42,
+                  "column": 40
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 570,
+                "end": 571
+              },
+              "leftExpression": {
+                "id": 212,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 569,
+                  "line": 42,
+                  "column": 38
+                },
+                "fullStart": 569,
+                "endPos": {
+                  "offset": 570,
+                  "line": 42,
+                  "column": 39
+                },
+                "fullEnd": 570,
+                "start": 569,
+                "end": 570,
+                "expression": {
+                  "id": 211,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 569,
+                    "line": 42,
+                    "column": 38
+                  },
+                  "fullStart": 569,
+                  "endPos": {
+                    "offset": 570,
+                    "line": 42,
+                    "column": 39
+                  },
+                  "fullEnd": 570,
+                  "start": 569,
+                  "end": 570,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 569,
+                      "line": 42,
+                      "column": 38
+                    },
+                    "endPos": {
+                      "offset": 570,
+                      "line": 42,
+                      "column": 39
+                    },
+                    "value": "c",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 569,
+                    "end": 570
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 214,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 571,
+                  "line": 42,
+                  "column": 40
+                },
+                "fullStart": 571,
+                "endPos": {
+                  "offset": 574,
+                  "line": 42,
+                  "column": 43
+                },
+                "fullEnd": 575,
+                "start": 571,
+                "end": 574,
+                "expression": {
+                  "id": 213,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 571,
+                    "line": 42,
+                    "column": 40
+                  },
+                  "fullStart": 571,
+                  "endPos": {
+                    "offset": 574,
+                    "line": 42,
+                    "column": 43
+                  },
+                  "fullEnd": 575,
+                  "start": 571,
+                  "end": 574,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 571,
+                      "line": 42,
+                      "column": 40
+                    },
+                    "endPos": {
+                      "offset": 574,
+                      "line": 42,
+                      "column": 43
+                    },
+                    "value": "id5",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 574,
+                          "line": 42,
+                          "column": 43
+                        },
+                        "endPos": {
+                          "offset": 575,
+                          "line": 42,
+                          "column": 44
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 574,
+                        "end": 575
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 571,
+                    "end": 574
+                  }
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 220,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 577,
+                "line": 42,
+                "column": 46
+              },
+              "fullStart": 577,
+              "endPos": {
+                "offset": 582,
+                "line": 42,
+                "column": 51
+              },
+              "fullEnd": 583,
+              "start": 577,
+              "end": 582,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 578,
+                  "line": 42,
+                  "column": 47
+                },
+                "endPos": {
+                  "offset": 579,
+                  "line": 42,
+                  "column": 48
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 578,
+                "end": 579
+              },
+              "leftExpression": {
+                "id": 217,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 577,
+                  "line": 42,
+                  "column": 46
+                },
+                "fullStart": 577,
+                "endPos": {
+                  "offset": 578,
+                  "line": 42,
+                  "column": 47
+                },
+                "fullEnd": 578,
+                "start": 577,
+                "end": 578,
+                "expression": {
+                  "id": 216,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 577,
+                    "line": 42,
+                    "column": 46
+                  },
+                  "fullStart": 577,
+                  "endPos": {
+                    "offset": 578,
+                    "line": 42,
+                    "column": 47
+                  },
+                  "fullEnd": 578,
+                  "start": 577,
+                  "end": 578,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 577,
+                      "line": 42,
+                      "column": 46
+                    },
+                    "endPos": {
+                      "offset": 578,
+                      "line": 42,
+                      "column": 47
+                    },
+                    "value": "b",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 577,
+                    "end": 578
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 219,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 579,
+                  "line": 42,
+                  "column": 48
+                },
+                "fullStart": 579,
+                "endPos": {
+                  "offset": 582,
+                  "line": 42,
+                  "column": 51
+                },
+                "fullEnd": 583,
+                "start": 579,
+                "end": 582,
+                "expression": {
+                  "id": 218,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 579,
+                    "line": 42,
+                    "column": 48
+                  },
+                  "fullStart": 579,
+                  "endPos": {
+                    "offset": 582,
+                    "line": 42,
+                    "column": 51
+                  },
+                  "fullEnd": 583,
+                  "start": 579,
+                  "end": 582,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 579,
+                      "line": 42,
+                      "column": 48
+                    },
+                    "endPos": {
+                      "offset": 582,
+                      "line": 42,
+                      "column": 51
+                    },
+                    "value": "id5",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
+                        "startPos": {
+                          "offset": 582,
+                          "line": 42,
+                          "column": 51
+                        },
+                        "endPos": {
+                          "offset": 583,
+                          "line": 43,
+                          "column": 0
+                        },
+                        "value": "\n",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 582,
+                        "end": 583
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 579,
+                    "end": 582
+                  }
+                }
+              }
+            }
+          },
+          "args": []
+        },
+        "parent": 264
+      },
+      {
+        "id": 243,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 583,
+          "line": 43,
+          "column": 0
+        },
+        "fullStart": 583,
+        "endPos": {
+          "offset": 639,
+          "line": 43,
+          "column": 56
+        },
+        "fullEnd": 640,
+        "start": 583,
+        "end": 639,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 583,
+            "line": 43,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 586,
+            "line": 43,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 586,
+                "line": 43,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 587,
+                "line": 43,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 586,
+              "end": 587
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 583,
+          "end": 586
+        },
+        "name": {
+          "id": 225,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 587,
+            "line": 43,
+            "column": 4
+          },
+          "fullStart": 587,
+          "endPos": {
+            "offset": 602,
+            "line": 43,
+            "column": 19
+          },
+          "fullEnd": 602,
+          "start": 587,
+          "end": 602,
+          "expression": {
+            "id": 224,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 587,
+              "line": 43,
+              "column": 4
+            },
+            "fullStart": 587,
+            "endPos": {
+              "offset": 602,
+              "line": 43,
+              "column": 19
+            },
+            "fullEnd": 602,
+            "start": 587,
+            "end": 602,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 587,
+                "line": 43,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 602,
+                "line": 43,
+                "column": 19
+              },
+              "value": "error_shortref3",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 587,
+              "end": 602
+            }
+          }
+        },
+        "bodyColon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 602,
+            "line": 43,
+            "column": 19
+          },
+          "endPos": {
+            "offset": 603,
+            "line": 43,
+            "column": 20
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 603,
+                "line": 43,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 604,
+                "line": 43,
+                "column": 21
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 603,
+              "end": 604
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 602,
+          "end": 603
+        },
+        "body": {
+          "id": 242,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 604,
+            "line": 43,
+            "column": 21
+          },
+          "fullStart": 604,
+          "endPos": {
+            "offset": 639,
+            "line": 43,
+            "column": 56
+          },
+          "fullEnd": 640,
+          "start": 604,
+          "end": 639,
+          "callee": {
+            "id": 236,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 604,
+              "line": 43,
+              "column": 21
+            },
+            "fullStart": 604,
+            "endPos": {
+              "offset": 617,
+              "line": 43,
+              "column": 34
+            },
+            "fullEnd": 618,
+            "start": 604,
+            "end": 617,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 610,
+                "line": 43,
+                "column": 27
+              },
+              "endPos": {
+                "offset": 611,
+                "line": 43,
+                "column": 28
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 611,
+                    "line": 43,
+                    "column": 28
+                  },
+                  "endPos": {
+                    "offset": 612,
+                    "line": 43,
+                    "column": 29
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 611,
+                  "end": 612
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 610,
+              "end": 611
+            },
+            "leftExpression": {
+              "id": 230,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 604,
+                "line": 43,
+                "column": 21
+              },
+              "fullStart": 604,
+              "endPos": {
+                "offset": 609,
+                "line": 43,
+                "column": 26
+              },
+              "fullEnd": 610,
+              "start": 604,
+              "end": 609,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 605,
+                  "line": 43,
+                  "column": 22
+                },
+                "endPos": {
+                  "offset": 606,
+                  "line": 43,
+                  "column": 23
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 605,
+                "end": 606
+              },
+              "leftExpression": {
+                "id": 227,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 604,
+                  "line": 43,
+                  "column": 21
+                },
+                "fullStart": 604,
+                "endPos": {
+                  "offset": 605,
+                  "line": 43,
+                  "column": 22
+                },
+                "fullEnd": 605,
+                "start": 604,
+                "end": 605,
+                "expression": {
+                  "id": 226,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 604,
+                    "line": 43,
+                    "column": 21
+                  },
+                  "fullStart": 604,
+                  "endPos": {
+                    "offset": 605,
+                    "line": 43,
+                    "column": 22
+                  },
+                  "fullEnd": 605,
+                  "start": 604,
+                  "end": 605,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 604,
+                      "line": 43,
+                      "column": 21
+                    },
+                    "endPos": {
+                      "offset": 605,
+                      "line": 43,
+                      "column": 22
+                    },
+                    "value": "c",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 604,
+                    "end": 605
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 229,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 606,
+                  "line": 43,
+                  "column": 23
+                },
+                "fullStart": 606,
+                "endPos": {
+                  "offset": 609,
+                  "line": 43,
+                  "column": 26
+                },
+                "fullEnd": 610,
+                "start": 606,
+                "end": 609,
+                "expression": {
+                  "id": 228,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 606,
+                    "line": 43,
+                    "column": 23
+                  },
+                  "fullStart": 606,
+                  "endPos": {
+                    "offset": 609,
+                    "line": 43,
+                    "column": 26
+                  },
+                  "fullEnd": 610,
+                  "start": 606,
+                  "end": 609,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 606,
+                      "line": 43,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 609,
+                      "line": 43,
+                      "column": 26
+                    },
+                    "value": "id6",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 609,
+                          "line": 43,
+                          "column": 26
+                        },
+                        "endPos": {
+                          "offset": 610,
+                          "line": 43,
+                          "column": 27
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 609,
+                        "end": 610
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 606,
+                    "end": 609
+                  }
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 235,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 612,
+                "line": 43,
+                "column": 29
+              },
+              "fullStart": 612,
+              "endPos": {
+                "offset": 617,
+                "line": 43,
+                "column": 34
+              },
+              "fullEnd": 618,
+              "start": 612,
+              "end": 617,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 613,
+                  "line": 43,
+                  "column": 30
+                },
+                "endPos": {
+                  "offset": 614,
+                  "line": 43,
+                  "column": 31
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 613,
+                "end": 614
+              },
+              "leftExpression": {
+                "id": 232,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 612,
+                  "line": 43,
+                  "column": 29
+                },
+                "fullStart": 612,
+                "endPos": {
+                  "offset": 613,
+                  "line": 43,
+                  "column": 30
+                },
+                "fullEnd": 613,
+                "start": 612,
+                "end": 613,
+                "expression": {
+                  "id": 231,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 612,
+                    "line": 43,
+                    "column": 29
+                  },
+                  "fullStart": 612,
+                  "endPos": {
+                    "offset": 613,
+                    "line": 43,
+                    "column": 30
+                  },
+                  "fullEnd": 613,
+                  "start": 612,
+                  "end": 613,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 612,
+                      "line": 43,
+                      "column": 29
+                    },
+                    "endPos": {
+                      "offset": 613,
+                      "line": 43,
+                      "column": 30
+                    },
+                    "value": "b",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 612,
+                    "end": 613
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 234,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 614,
+                  "line": 43,
+                  "column": 31
+                },
+                "fullStart": 614,
+                "endPos": {
+                  "offset": 617,
+                  "line": 43,
+                  "column": 34
+                },
+                "fullEnd": 618,
+                "start": 614,
+                "end": 617,
+                "expression": {
+                  "id": 233,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 614,
+                    "line": 43,
+                    "column": 31
+                  },
+                  "fullStart": 614,
+                  "endPos": {
+                    "offset": 617,
+                    "line": 43,
+                    "column": 34
+                  },
+                  "fullEnd": 618,
+                  "start": 614,
+                  "end": 617,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 614,
+                      "line": 43,
+                      "column": 31
+                    },
+                    "endPos": {
+                      "offset": 617,
+                      "line": 43,
+                      "column": 34
+                    },
+                    "value": "id6",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 617,
+                          "line": 43,
+                          "column": 34
+                        },
+                        "endPos": {
+                          "offset": 618,
+                          "line": 43,
+                          "column": 35
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 617,
+                        "end": 618
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 614,
+                    "end": 617
+                  }
+                }
+              }
+            }
+          },
+          "args": [
+            {
+              "id": 241,
+              "kind": "<list-expression>",
+              "startPos": {
+                "offset": 618,
+                "line": 43,
+                "column": 35
+              },
+              "fullStart": 618,
+              "endPos": {
+                "offset": 639,
+                "line": 43,
+                "column": 56
+              },
+              "fullEnd": 640,
+              "start": 618,
+              "end": 639,
+              "listOpenBracket": {
+                "kind": "<lbracket>",
+                "startPos": {
+                  "offset": 618,
+                  "line": 43,
+                  "column": 35
+                },
+                "endPos": {
+                  "offset": 619,
+                  "line": 43,
+                  "column": 36
+                },
+                "value": "[",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 618,
+                "end": 619
+              },
+              "elementList": [
+                {
+                  "id": 240,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 619,
+                    "line": 43,
+                    "column": 36
+                  },
+                  "fullStart": 619,
+                  "endPos": {
+                    "offset": 638,
+                    "line": 43,
+                    "column": 55
+                  },
+                  "fullEnd": 638,
+                  "start": 619,
+                  "end": 638,
+                  "name": {
+                    "id": 237,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 619,
+                      "line": 43,
+                      "column": 36
+                    },
+                    "fullStart": 619,
+                    "endPos": {
+                      "offset": 624,
+                      "line": 43,
+                      "column": 41
+                    },
+                    "fullEnd": 624,
+                    "start": 619,
+                    "end": 624,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 619,
+                          "line": 43,
+                          "column": 36
+                        },
+                        "endPos": {
+                          "offset": 624,
+                          "line": 43,
+                          "column": 41
+                        },
+                        "value": "color",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 619,
+                        "end": 624
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 239,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 626,
+                      "line": 43,
+                      "column": 43
+                    },
+                    "fullStart": 626,
+                    "endPos": {
+                      "offset": 638,
+                      "line": 43,
+                      "column": 55
+                    },
+                    "fullEnd": 638,
+                    "start": 626,
+                    "end": 638,
+                    "expression": {
+                      "id": 238,
+                      "kind": "<literal>",
+                      "startPos": {
+                        "offset": 626,
+                        "line": 43,
+                        "column": 43
+                      },
+                      "fullStart": 626,
+                      "endPos": {
+                        "offset": 638,
+                        "line": 43,
+                        "column": 55
+                      },
+                      "fullEnd": 638,
+                      "start": 626,
+                      "end": 638,
+                      "literal": {
+                        "kind": "<color>",
+                        "startPos": {
+                          "offset": 626,
+                          "line": 43,
+                          "column": 43
+                        },
+                        "endPos": {
+                          "offset": 638,
+                          "line": 43,
+                          "column": 55
+                        },
+                        "value": "#not_a_color",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 626,
+                        "end": 638
+                      }
+                    }
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 624,
+                      "line": 43,
+                      "column": 41
+                    },
+                    "endPos": {
+                      "offset": 625,
+                      "line": 43,
+                      "column": 42
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 625,
+                          "line": 43,
+                          "column": 42
+                        },
+                        "endPos": {
+                          "offset": 626,
+                          "line": 43,
+                          "column": 43
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 625,
+                        "end": 626
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 624,
+                    "end": 625
+                  }
+                }
+              ],
+              "commaList": [],
+              "listCloseBracket": {
+                "kind": "<rbracket>",
+                "startPos": {
+                  "offset": 638,
+                  "line": 43,
+                  "column": 55
+                },
+                "endPos": {
+                  "offset": 639,
+                  "line": 43,
+                  "column": 56
+                },
+                "value": "]",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 639,
+                      "line": 43,
+                      "column": 56
+                    },
+                    "endPos": {
+                      "offset": 640,
+                      "line": 44,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 639,
+                    "end": 640
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 638,
+                "end": 639
+              }
+            }
+          ]
+        },
+        "parent": 264
+      },
+      {
+        "id": 263,
+        "kind": "<element-declaration>",
+        "startPos": {
+          "offset": 640,
+          "line": 44,
+          "column": 0
+        },
+        "fullStart": 640,
+        "endPos": {
+          "offset": 691,
+          "line": 44,
+          "column": 51
+        },
+        "fullEnd": 692,
+        "start": 640,
+        "end": 691,
+        "type": {
+          "kind": "<identifier>",
+          "startPos": {
+            "offset": 640,
+            "line": 44,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 643,
+            "line": 44,
+            "column": 3
+          },
+          "value": "Ref",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 643,
+                "line": 44,
+                "column": 3
+              },
+              "endPos": {
+                "offset": 644,
+                "line": 44,
+                "column": 4
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 643,
+              "end": 644
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 640,
+          "end": 643
+        },
+        "name": {
+          "id": 245,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 644,
+            "line": 44,
+            "column": 4
+          },
+          "fullStart": 644,
+          "endPos": {
+            "offset": 659,
+            "line": 44,
+            "column": 19
+          },
+          "fullEnd": 659,
+          "start": 644,
+          "end": 659,
+          "expression": {
+            "id": 244,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 644,
+              "line": 44,
+              "column": 4
+            },
+            "fullStart": 644,
+            "endPos": {
+              "offset": 659,
+              "line": 44,
+              "column": 19
+            },
+            "fullEnd": 659,
+            "start": 644,
+            "end": 659,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 644,
+                "line": 44,
+                "column": 4
+              },
+              "endPos": {
+                "offset": 659,
+                "line": 44,
+                "column": 19
+              },
+              "value": "error_shortref4",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 644,
+              "end": 659
+            }
+          }
+        },
+        "bodyColon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 659,
+            "line": 44,
+            "column": 19
+          },
+          "endPos": {
+            "offset": 660,
+            "line": 44,
+            "column": 20
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 660,
+                "line": 44,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 661,
+                "line": 44,
+                "column": 21
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 660,
+              "end": 661
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 659,
+          "end": 660
+        },
+        "body": {
+          "id": 262,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 661,
+            "line": 44,
+            "column": 21
+          },
+          "fullStart": 661,
+          "endPos": {
+            "offset": 691,
+            "line": 44,
+            "column": 51
+          },
+          "fullEnd": 692,
+          "start": 661,
+          "end": 691,
+          "callee": {
+            "id": 256,
+            "kind": "<infix-expression>",
+            "startPos": {
+              "offset": 661,
+              "line": 44,
+              "column": 21
+            },
+            "fullStart": 661,
+            "endPos": {
+              "offset": 674,
+              "line": 44,
+              "column": 34
+            },
+            "fullEnd": 675,
+            "start": 661,
+            "end": 674,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 667,
+                "line": 44,
+                "column": 27
+              },
+              "endPos": {
+                "offset": 668,
+                "line": 44,
+                "column": 28
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 668,
+                    "line": 44,
+                    "column": 28
+                  },
+                  "endPos": {
+                    "offset": 669,
+                    "line": 44,
+                    "column": 29
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 668,
+                  "end": 669
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 667,
+              "end": 668
+            },
+            "leftExpression": {
+              "id": 250,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 661,
+                "line": 44,
+                "column": 21
+              },
+              "fullStart": 661,
+              "endPos": {
+                "offset": 666,
+                "line": 44,
+                "column": 26
+              },
+              "fullEnd": 667,
+              "start": 661,
+              "end": 666,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 662,
+                  "line": 44,
+                  "column": 22
+                },
+                "endPos": {
+                  "offset": 663,
+                  "line": 44,
+                  "column": 23
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 662,
+                "end": 663
+              },
+              "leftExpression": {
+                "id": 247,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 661,
+                  "line": 44,
+                  "column": 21
+                },
+                "fullStart": 661,
+                "endPos": {
+                  "offset": 662,
+                  "line": 44,
+                  "column": 22
+                },
+                "fullEnd": 662,
+                "start": 661,
+                "end": 662,
+                "expression": {
+                  "id": 246,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 661,
+                    "line": 44,
+                    "column": 21
+                  },
+                  "fullStart": 661,
+                  "endPos": {
+                    "offset": 662,
+                    "line": 44,
+                    "column": 22
+                  },
+                  "fullEnd": 662,
+                  "start": 661,
+                  "end": 662,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 661,
+                      "line": 44,
+                      "column": 21
+                    },
+                    "endPos": {
+                      "offset": 662,
+                      "line": 44,
+                      "column": 22
+                    },
+                    "value": "c",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 661,
+                    "end": 662
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 249,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 663,
+                  "line": 44,
+                  "column": 23
+                },
+                "fullStart": 663,
+                "endPos": {
+                  "offset": 666,
+                  "line": 44,
+                  "column": 26
+                },
+                "fullEnd": 667,
+                "start": 663,
+                "end": 666,
+                "expression": {
+                  "id": 248,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 663,
+                    "line": 44,
+                    "column": 23
+                  },
+                  "fullStart": 663,
+                  "endPos": {
+                    "offset": 666,
+                    "line": 44,
+                    "column": 26
+                  },
+                  "fullEnd": 667,
+                  "start": 663,
+                  "end": 666,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 663,
+                      "line": 44,
+                      "column": 23
+                    },
+                    "endPos": {
+                      "offset": 666,
+                      "line": 44,
+                      "column": 26
+                    },
+                    "value": "id7",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 666,
+                          "line": 44,
+                          "column": 26
+                        },
+                        "endPos": {
+                          "offset": 667,
+                          "line": 44,
+                          "column": 27
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 666,
+                        "end": 667
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 663,
+                    "end": 666
+                  }
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 255,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 669,
+                "line": 44,
+                "column": 29
+              },
+              "fullStart": 669,
+              "endPos": {
+                "offset": 674,
+                "line": 44,
+                "column": 34
+              },
+              "fullEnd": 675,
+              "start": 669,
+              "end": 674,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 670,
+                  "line": 44,
+                  "column": 30
+                },
+                "endPos": {
+                  "offset": 671,
+                  "line": 44,
+                  "column": 31
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 670,
+                "end": 671
+              },
+              "leftExpression": {
+                "id": 252,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 669,
+                  "line": 44,
+                  "column": 29
+                },
+                "fullStart": 669,
+                "endPos": {
+                  "offset": 670,
+                  "line": 44,
+                  "column": 30
+                },
+                "fullEnd": 670,
+                "start": 669,
+                "end": 670,
+                "expression": {
+                  "id": 251,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 669,
+                    "line": 44,
+                    "column": 29
+                  },
+                  "fullStart": 669,
+                  "endPos": {
+                    "offset": 670,
+                    "line": 44,
+                    "column": 30
+                  },
+                  "fullEnd": 670,
+                  "start": 669,
+                  "end": 670,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 669,
+                      "line": 44,
+                      "column": 29
+                    },
+                    "endPos": {
+                      "offset": 670,
+                      "line": 44,
+                      "column": 30
+                    },
+                    "value": "b",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 669,
+                    "end": 670
+                  }
+                }
+              },
+              "rightExpression": {
+                "id": 254,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 671,
+                  "line": 44,
+                  "column": 31
+                },
+                "fullStart": 671,
+                "endPos": {
+                  "offset": 674,
+                  "line": 44,
+                  "column": 34
+                },
+                "fullEnd": 675,
+                "start": 671,
+                "end": 674,
+                "expression": {
+                  "id": 253,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 671,
+                    "line": 44,
+                    "column": 31
+                  },
+                  "fullStart": 671,
+                  "endPos": {
+                    "offset": 674,
+                    "line": 44,
+                    "column": 34
+                  },
+                  "fullEnd": 675,
+                  "start": 671,
+                  "end": 674,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 671,
+                      "line": 44,
+                      "column": 31
+                    },
+                    "endPos": {
+                      "offset": 674,
+                      "line": 44,
+                      "column": 34
+                    },
+                    "value": "id7",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 674,
+                          "line": 44,
+                          "column": 34
+                        },
+                        "endPos": {
+                          "offset": 675,
+                          "line": 44,
+                          "column": 35
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 674,
+                        "end": 675
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 671,
+                    "end": 674
+                  }
+                }
+              }
+            }
+          },
+          "args": [
+            {
+              "id": 261,
+              "kind": "<list-expression>",
+              "startPos": {
+                "offset": 675,
+                "line": 44,
+                "column": 35
+              },
+              "fullStart": 675,
+              "endPos": {
+                "offset": 691,
+                "line": 44,
+                "column": 51
+              },
+              "fullEnd": 692,
+              "start": 675,
+              "end": 691,
+              "listOpenBracket": {
+                "kind": "<lbracket>",
+                "startPos": {
+                  "offset": 675,
+                  "line": 44,
+                  "column": 35
+                },
+                "endPos": {
+                  "offset": 676,
+                  "line": 44,
+                  "column": 36
+                },
+                "value": "[",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 675,
+                "end": 676
+              },
+              "elementList": [
+                {
+                  "id": 260,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 676,
+                    "line": 44,
+                    "column": 36
+                  },
+                  "fullStart": 676,
+                  "endPos": {
+                    "offset": 690,
+                    "line": 44,
+                    "column": 50
+                  },
+                  "fullEnd": 690,
+                  "start": 676,
+                  "end": 690,
+                  "name": {
+                    "id": 257,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 676,
+                      "line": 44,
+                      "column": 36
+                    },
+                    "fullStart": 676,
+                    "endPos": {
+                      "offset": 681,
+                      "line": 44,
+                      "column": 41
+                    },
+                    "fullEnd": 681,
+                    "start": 676,
+                    "end": 681,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 676,
+                          "line": 44,
+                          "column": 36
+                        },
+                        "endPos": {
+                          "offset": 681,
+                          "line": 44,
+                          "column": 41
+                        },
+                        "value": "hello",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 676,
+                        "end": 681
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 259,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 683,
+                      "line": 44,
+                      "column": 43
+                    },
+                    "fullStart": 683,
+                    "endPos": {
+                      "offset": 690,
+                      "line": 44,
+                      "column": 50
+                    },
+                    "fullEnd": 690,
+                    "start": 683,
+                    "end": 690,
+                    "expression": {
+                      "id": 258,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 683,
+                        "line": 44,
+                        "column": 43
+                      },
+                      "fullStart": 683,
+                      "endPos": {
+                        "offset": 690,
+                        "line": 44,
+                        "column": 50
+                      },
+                      "fullEnd": 690,
+                      "start": 683,
+                      "end": 690,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 683,
+                          "line": 44,
+                          "column": 43
+                        },
+                        "endPos": {
+                          "offset": 690,
+                          "line": 44,
+                          "column": 50
+                        },
+                        "value": "goodbye",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 683,
+                        "end": 690
+                      }
+                    }
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 681,
+                      "line": 44,
+                      "column": 41
+                    },
+                    "endPos": {
+                      "offset": 682,
+                      "line": 44,
+                      "column": 42
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 682,
+                          "line": 44,
+                          "column": 42
+                        },
+                        "endPos": {
+                          "offset": 683,
+                          "line": 44,
+                          "column": 43
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 682,
+                        "end": 683
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 681,
+                    "end": 682
+                  }
+                }
+              ],
+              "commaList": [],
+              "listCloseBracket": {
+                "kind": "<rbracket>",
+                "startPos": {
+                  "offset": 690,
+                  "line": 44,
+                  "column": 50
+                },
+                "endPos": {
+                  "offset": 691,
+                  "line": 44,
+                  "column": 51
+                },
+                "value": "]",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 691,
+                      "line": 44,
+                      "column": 51
+                    },
+                    "endPos": {
+                      "offset": 692,
+                      "line": 45,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 691,
+                    "end": 692
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 690,
+                "end": 691
+              }
+            }
+          ]
+        },
+        "parent": 264
+      }
+    ],
+    "eof": {
+      "kind": "<eof>",
+      "startPos": {
+        "offset": 693,
+        "line": 46,
+        "column": 0
+      },
+      "endPos": {
+        "offset": 693,
+        "line": 46,
+        "column": 0
+      },
+      "value": "",
+      "leadingTrivia": [
+        {
+          "kind": "<newline>",
+          "startPos": {
+            "offset": 692,
+            "line": 45,
+            "column": 0
+          },
+          "endPos": {
+            "offset": 693,
+            "line": 46,
+            "column": 0
+          },
+          "value": "\n",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 692,
+          "end": 693
+        }
+      ],
+      "trailingTrivia": [],
+      "leadingInvalid": [],
+      "trailingInvalid": [],
+      "isInvalid": false,
+      "start": 693,
+      "end": 693
+    },
+    "symbol": {
+      "symbolTable": {
+        "Table:b": {
+          "references": [],
+          "id": 1,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 2,
+              "declaration": 11
+            },
+            "Column:c_id": {
+              "references": [],
+              "id": 3,
+              "declaration": 16
+            },
+            "Column:id2": {
+              "references": [],
+              "id": 4,
+              "declaration": 21
+            },
+            "Column:id3": {
+              "references": [],
+              "id": 5,
+              "declaration": 26
+            },
+            "Column:id4": {
+              "references": [],
+              "id": 6,
+              "declaration": 31
+            },
+            "Column:id5": {
+              "references": [],
+              "id": 7,
+              "declaration": 36
+            },
+            "Column:id6": {
+              "references": [],
+              "id": 8,
+              "declaration": 41
+            },
+            "Column:id7": {
+              "references": [],
+              "id": 9,
+              "declaration": 46
+            }
+          },
+          "declaration": 48
+        },
+        "Table:c": {
+          "references": [],
+          "id": 10,
+          "symbolTable": {
+            "Column:id": {
+              "references": [],
+              "id": 11,
+              "declaration": 55
+            },
+            "Column:b_id": {
+              "references": [],
+              "id": 12,
+              "declaration": 60
+            },
+            "Column:id2": {
+              "references": [],
+              "id": 13,
+              "declaration": 65
+            },
+            "Column:id3": {
+              "references": [],
+              "id": 14,
+              "declaration": 70
+            },
+            "Column:id4": {
+              "references": [],
+              "id": 15,
+              "declaration": 75
+            },
+            "Column:id5": {
+              "references": [],
+              "id": 16,
+              "declaration": 80
+            },
+            "Column:id6": {
+              "references": [],
+              "id": 17,
+              "declaration": 85
+            },
+            "Column:id7": {
+              "references": [],
+              "id": 18,
+              "declaration": 90
+            }
+          },
+          "declaration": 92
+        }
+      },
+      "id": 0,
+      "references": []
+    }
+  },
+  "errors": [
+    {
+      "code": 3006,
+      "diagnostic": "A Ref shouldn't have a setting list",
+      "nodeOrToken": {
+        "id": 147,
+        "kind": "<list-expression>",
+        "startPos": {
+          "offset": 382,
+          "line": 30,
+          "column": 15
+        },
+        "fullStart": 382,
+        "endPos": {
+          "offset": 398,
+          "line": 30,
+          "column": 31
+        },
+        "fullEnd": 399,
+        "start": 382,
+        "end": 398,
+        "listOpenBracket": {
+          "kind": "<lbracket>",
+          "startPos": {
+            "offset": 382,
+            "line": 30,
+            "column": 15
+          },
+          "endPos": {
+            "offset": 383,
+            "line": 30,
+            "column": 16
+          },
+          "value": "[",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 382,
+          "end": 383
+        },
+        "elementList": [
+          {
+            "id": 146,
+            "kind": "<attribute>",
+            "startPos": {
+              "offset": 383,
+              "line": 30,
+              "column": 16
+            },
+            "fullStart": 383,
+            "endPos": {
+              "offset": 397,
+              "line": 30,
+              "column": 30
+            },
+            "fullEnd": 397,
+            "start": 383,
+            "end": 397,
+            "name": {
+              "id": 143,
+              "kind": "<identifer-stream>",
+              "startPos": {
+                "offset": 383,
+                "line": 30,
+                "column": 16
+              },
+              "fullStart": 383,
+              "endPos": {
+                "offset": 388,
+                "line": 30,
+                "column": 21
+              },
+              "fullEnd": 388,
+              "start": 383,
+              "end": 388,
+              "identifiers": [
+                {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 383,
+                    "line": 30,
+                    "column": 16
+                  },
+                  "endPos": {
+                    "offset": 388,
+                    "line": 30,
+                    "column": 21
+                  },
+                  "value": "color",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 383,
+                  "end": 388
+                }
+              ]
+            },
+            "value": {
+              "id": 145,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 390,
+                "line": 30,
+                "column": 23
+              },
+              "fullStart": 390,
+              "endPos": {
+                "offset": 397,
+                "line": 30,
+                "column": 30
+              },
+              "fullEnd": 397,
+              "start": 390,
+              "end": 397,
+              "expression": {
+                "id": 144,
+                "kind": "<literal>",
+                "startPos": {
+                  "offset": 390,
+                  "line": 30,
+                  "column": 23
+                },
+                "fullStart": 390,
+                "endPos": {
+                  "offset": 397,
+                  "line": 30,
+                  "column": 30
+                },
+                "fullEnd": 397,
+                "start": 390,
+                "end": 397,
+                "literal": {
+                  "kind": "<color>",
+                  "startPos": {
+                    "offset": 390,
+                    "line": 30,
+                    "column": 23
+                  },
+                  "endPos": {
+                    "offset": 397,
+                    "line": 30,
+                    "column": 30
+                  },
+                  "value": "#123456",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 390,
+                  "end": 397
+                }
+              }
+            },
+            "colon": {
+              "kind": "<colon>",
+              "startPos": {
+                "offset": 388,
+                "line": 30,
+                "column": 21
+              },
+              "endPos": {
+                "offset": 389,
+                "line": 30,
+                "column": 22
+              },
+              "value": ":",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 389,
+                    "line": 30,
+                    "column": 22
+                  },
+                  "endPos": {
+                    "offset": 390,
+                    "line": 30,
+                    "column": 23
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 389,
+                  "end": 390
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 388,
+              "end": 389
+            }
+          }
+        ],
+        "commaList": [],
+        "listCloseBracket": {
+          "kind": "<rbracket>",
+          "startPos": {
+            "offset": 397,
+            "line": 30,
+            "column": 30
+          },
+          "endPos": {
+            "offset": 398,
+            "line": 30,
+            "column": 31
+          },
+          "value": "]",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 398,
+                "line": 30,
+                "column": 31
+              },
+              "endPos": {
+                "offset": 399,
+                "line": 30,
+                "column": 32
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 398,
+              "end": 399
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 397,
+          "end": 398
+        }
+      },
+      "start": 382,
+      "end": 398,
+      "name": "CompileError"
+    },
+    {
+      "code": 3037,
+      "diagnostic": "'color' must be a color literal",
+      "nodeOrToken": {
+        "id": 178,
+        "kind": "<attribute>",
+        "startPos": {
+          "offset": 454,
+          "line": 35,
+          "column": 17
+        },
+        "fullStart": 454,
+        "endPos": {
+          "offset": 473,
+          "line": 35,
+          "column": 36
+        },
+        "fullEnd": 473,
+        "start": 454,
+        "end": 473,
+        "name": {
+          "id": 175,
+          "kind": "<identifer-stream>",
+          "startPos": {
+            "offset": 454,
+            "line": 35,
+            "column": 17
+          },
+          "fullStart": 454,
+          "endPos": {
+            "offset": 459,
+            "line": 35,
+            "column": 22
+          },
+          "fullEnd": 459,
+          "start": 454,
+          "end": 459,
+          "identifiers": [
+            {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 454,
+                "line": 35,
+                "column": 17
+              },
+              "endPos": {
+                "offset": 459,
+                "line": 35,
+                "column": 22
+              },
+              "value": "color",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 454,
+              "end": 459
+            }
+          ]
+        },
+        "value": {
+          "id": 177,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 461,
+            "line": 35,
+            "column": 24
+          },
+          "fullStart": 461,
+          "endPos": {
+            "offset": 473,
+            "line": 35,
+            "column": 36
+          },
+          "fullEnd": 473,
+          "start": 461,
+          "end": 473,
+          "expression": {
+            "id": 176,
+            "kind": "<literal>",
+            "startPos": {
+              "offset": 461,
+              "line": 35,
+              "column": 24
+            },
+            "fullStart": 461,
+            "endPos": {
+              "offset": 473,
+              "line": 35,
+              "column": 36
+            },
+            "fullEnd": 473,
+            "start": 461,
+            "end": 473,
+            "literal": {
+              "kind": "<color>",
+              "startPos": {
+                "offset": 461,
+                "line": 35,
+                "column": 24
+              },
+              "endPos": {
+                "offset": 473,
+                "line": 35,
+                "column": 36
+              },
+              "value": "#not_a_color",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 461,
+              "end": 473
+            }
+          }
+        },
+        "colon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 459,
+            "line": 35,
+            "column": 22
+          },
+          "endPos": {
+            "offset": 460,
+            "line": 35,
+            "column": 23
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 460,
+                "line": 35,
+                "column": 23
+              },
+              "endPos": {
+                "offset": 461,
+                "line": 35,
+                "column": 24
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 460,
+              "end": 461
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 459,
+          "end": 460
+        }
+      },
+      "start": 454,
+      "end": 473,
+      "name": "CompileError"
+    },
+    {
+      "code": 3035,
+      "diagnostic": "Unknown ref setting 'hello'",
+      "nodeOrToken": {
+        "id": 199,
+        "kind": "<attribute>",
+        "startPos": {
+          "offset": 512,
+          "line": 39,
+          "column": 17
+        },
+        "fullStart": 512,
+        "endPos": {
+          "offset": 526,
+          "line": 39,
+          "column": 31
+        },
+        "fullEnd": 526,
+        "start": 512,
+        "end": 526,
+        "name": {
+          "id": 196,
+          "kind": "<identifer-stream>",
+          "startPos": {
+            "offset": 512,
+            "line": 39,
+            "column": 17
+          },
+          "fullStart": 512,
+          "endPos": {
+            "offset": 517,
+            "line": 39,
+            "column": 22
+          },
+          "fullEnd": 517,
+          "start": 512,
+          "end": 517,
+          "identifiers": [
+            {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 512,
+                "line": 39,
+                "column": 17
+              },
+              "endPos": {
+                "offset": 517,
+                "line": 39,
+                "column": 22
+              },
+              "value": "hello",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 512,
+              "end": 517
+            }
+          ]
+        },
+        "value": {
+          "id": 198,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 519,
+            "line": 39,
+            "column": 24
+          },
+          "fullStart": 519,
+          "endPos": {
+            "offset": 526,
+            "line": 39,
+            "column": 31
+          },
+          "fullEnd": 526,
+          "start": 519,
+          "end": 526,
+          "expression": {
+            "id": 197,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 519,
+              "line": 39,
+              "column": 24
+            },
+            "fullStart": 519,
+            "endPos": {
+              "offset": 526,
+              "line": 39,
+              "column": 31
+            },
+            "fullEnd": 526,
+            "start": 519,
+            "end": 526,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 519,
+                "line": 39,
+                "column": 24
+              },
+              "endPos": {
+                "offset": 526,
+                "line": 39,
+                "column": 31
+              },
+              "value": "goodbye",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 519,
+              "end": 526
+            }
+          }
+        },
+        "colon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 517,
+            "line": 39,
+            "column": 22
+          },
+          "endPos": {
+            "offset": 518,
+            "line": 39,
+            "column": 23
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 518,
+                "line": 39,
+                "column": 23
+              },
+              "endPos": {
+                "offset": 519,
+                "line": 39,
+                "column": 24
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 518,
+              "end": 519
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 517,
+          "end": 518
+        }
+      },
+      "start": 512,
+      "end": 526,
+      "name": "CompileError"
+    },
+    {
+      "code": 3006,
+      "diagnostic": "A Ref shouldn't have a setting list",
+      "nodeOrToken": {
+        "id": 210,
+        "kind": "<list-expression>",
+        "startPos": {
+          "offset": 551,
+          "line": 42,
+          "column": 20
+        },
+        "fullStart": 551,
+        "endPos": {
+          "offset": 567,
+          "line": 42,
+          "column": 36
+        },
+        "fullEnd": 567,
+        "start": 551,
+        "end": 567,
+        "listOpenBracket": {
+          "kind": "<lbracket>",
+          "startPos": {
+            "offset": 551,
+            "line": 42,
+            "column": 20
+          },
+          "endPos": {
+            "offset": 552,
+            "line": 42,
+            "column": 21
+          },
+          "value": "[",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 551,
+          "end": 552
+        },
+        "elementList": [
+          {
+            "id": 209,
+            "kind": "<attribute>",
+            "startPos": {
+              "offset": 552,
+              "line": 42,
+              "column": 21
+            },
+            "fullStart": 552,
+            "endPos": {
+              "offset": 566,
+              "line": 42,
+              "column": 35
+            },
+            "fullEnd": 566,
+            "start": 552,
+            "end": 566,
+            "name": {
+              "id": 206,
+              "kind": "<identifer-stream>",
+              "startPos": {
+                "offset": 552,
+                "line": 42,
+                "column": 21
+              },
+              "fullStart": 552,
+              "endPos": {
+                "offset": 557,
+                "line": 42,
+                "column": 26
+              },
+              "fullEnd": 557,
+              "start": 552,
+              "end": 557,
+              "identifiers": [
+                {
+                  "kind": "<identifier>",
+                  "startPos": {
+                    "offset": 552,
+                    "line": 42,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 557,
+                    "line": 42,
+                    "column": 26
+                  },
+                  "value": "color",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 552,
+                  "end": 557
+                }
+              ]
+            },
+            "value": {
+              "id": 208,
+              "kind": "<primary-expression>",
+              "startPos": {
+                "offset": 559,
+                "line": 42,
+                "column": 28
+              },
+              "fullStart": 559,
+              "endPos": {
+                "offset": 566,
+                "line": 42,
+                "column": 35
+              },
+              "fullEnd": 566,
+              "start": 559,
+              "end": 566,
+              "expression": {
+                "id": 207,
+                "kind": "<literal>",
+                "startPos": {
+                  "offset": 559,
+                  "line": 42,
+                  "column": 28
+                },
+                "fullStart": 559,
+                "endPos": {
+                  "offset": 566,
+                  "line": 42,
+                  "column": 35
+                },
+                "fullEnd": 566,
+                "start": 559,
+                "end": 566,
+                "literal": {
+                  "kind": "<color>",
+                  "startPos": {
+                    "offset": 559,
+                    "line": 42,
+                    "column": 28
+                  },
+                  "endPos": {
+                    "offset": 566,
+                    "line": 42,
+                    "column": 35
+                  },
+                  "value": "#123456",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 559,
+                  "end": 566
+                }
+              }
+            },
+            "colon": {
+              "kind": "<colon>",
+              "startPos": {
+                "offset": 557,
+                "line": 42,
+                "column": 26
+              },
+              "endPos": {
+                "offset": 558,
+                "line": 42,
+                "column": 27
+              },
+              "value": ":",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 558,
+                    "line": 42,
+                    "column": 27
+                  },
+                  "endPos": {
+                    "offset": 559,
+                    "line": 42,
+                    "column": 28
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 558,
+                  "end": 559
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 557,
+              "end": 558
+            }
+          }
+        ],
+        "commaList": [],
+        "listCloseBracket": {
+          "kind": "<rbracket>",
+          "startPos": {
+            "offset": 566,
+            "line": 42,
+            "column": 35
+          },
+          "endPos": {
+            "offset": 567,
+            "line": 42,
+            "column": 36
+          },
+          "value": "]",
+          "leadingTrivia": [],
+          "trailingTrivia": [],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 566,
+          "end": 567
+        }
+      },
+      "start": 551,
+      "end": 567,
+      "name": "CompileError"
+    },
+    {
+      "code": 3037,
+      "diagnostic": "'color' must be a color literal",
+      "nodeOrToken": {
+        "id": 240,
+        "kind": "<attribute>",
+        "startPos": {
+          "offset": 619,
+          "line": 43,
+          "column": 36
+        },
+        "fullStart": 619,
+        "endPos": {
+          "offset": 638,
+          "line": 43,
+          "column": 55
+        },
+        "fullEnd": 638,
+        "start": 619,
+        "end": 638,
+        "name": {
+          "id": 237,
+          "kind": "<identifer-stream>",
+          "startPos": {
+            "offset": 619,
+            "line": 43,
+            "column": 36
+          },
+          "fullStart": 619,
+          "endPos": {
+            "offset": 624,
+            "line": 43,
+            "column": 41
+          },
+          "fullEnd": 624,
+          "start": 619,
+          "end": 624,
+          "identifiers": [
+            {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 619,
+                "line": 43,
+                "column": 36
+              },
+              "endPos": {
+                "offset": 624,
+                "line": 43,
+                "column": 41
+              },
+              "value": "color",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 619,
+              "end": 624
+            }
+          ]
+        },
+        "value": {
+          "id": 239,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 626,
+            "line": 43,
+            "column": 43
+          },
+          "fullStart": 626,
+          "endPos": {
+            "offset": 638,
+            "line": 43,
+            "column": 55
+          },
+          "fullEnd": 638,
+          "start": 626,
+          "end": 638,
+          "expression": {
+            "id": 238,
+            "kind": "<literal>",
+            "startPos": {
+              "offset": 626,
+              "line": 43,
+              "column": 43
+            },
+            "fullStart": 626,
+            "endPos": {
+              "offset": 638,
+              "line": 43,
+              "column": 55
+            },
+            "fullEnd": 638,
+            "start": 626,
+            "end": 638,
+            "literal": {
+              "kind": "<color>",
+              "startPos": {
+                "offset": 626,
+                "line": 43,
+                "column": 43
+              },
+              "endPos": {
+                "offset": 638,
+                "line": 43,
+                "column": 55
+              },
+              "value": "#not_a_color",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 626,
+              "end": 638
+            }
+          }
+        },
+        "colon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 624,
+            "line": 43,
+            "column": 41
+          },
+          "endPos": {
+            "offset": 625,
+            "line": 43,
+            "column": 42
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 625,
+                "line": 43,
+                "column": 42
+              },
+              "endPos": {
+                "offset": 626,
+                "line": 43,
+                "column": 43
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 625,
+              "end": 626
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 624,
+          "end": 625
+        }
+      },
+      "start": 619,
+      "end": 638,
+      "name": "CompileError"
+    },
+    {
+      "code": 3035,
+      "diagnostic": "Unknown ref setting 'hello'",
+      "nodeOrToken": {
+        "id": 260,
+        "kind": "<attribute>",
+        "startPos": {
+          "offset": 676,
+          "line": 44,
+          "column": 36
+        },
+        "fullStart": 676,
+        "endPos": {
+          "offset": 690,
+          "line": 44,
+          "column": 50
+        },
+        "fullEnd": 690,
+        "start": 676,
+        "end": 690,
+        "name": {
+          "id": 257,
+          "kind": "<identifer-stream>",
+          "startPos": {
+            "offset": 676,
+            "line": 44,
+            "column": 36
+          },
+          "fullStart": 676,
+          "endPos": {
+            "offset": 681,
+            "line": 44,
+            "column": 41
+          },
+          "fullEnd": 681,
+          "start": 676,
+          "end": 681,
+          "identifiers": [
+            {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 676,
+                "line": 44,
+                "column": 36
+              },
+              "endPos": {
+                "offset": 681,
+                "line": 44,
+                "column": 41
+              },
+              "value": "hello",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 676,
+              "end": 681
+            }
+          ]
+        },
+        "value": {
+          "id": 259,
+          "kind": "<primary-expression>",
+          "startPos": {
+            "offset": 683,
+            "line": 44,
+            "column": 43
+          },
+          "fullStart": 683,
+          "endPos": {
+            "offset": 690,
+            "line": 44,
+            "column": 50
+          },
+          "fullEnd": 690,
+          "start": 683,
+          "end": 690,
+          "expression": {
+            "id": 258,
+            "kind": "<variable>",
+            "startPos": {
+              "offset": 683,
+              "line": 44,
+              "column": 43
+            },
+            "fullStart": 683,
+            "endPos": {
+              "offset": 690,
+              "line": 44,
+              "column": 50
+            },
+            "fullEnd": 690,
+            "start": 683,
+            "end": 690,
+            "variable": {
+              "kind": "<identifier>",
+              "startPos": {
+                "offset": 683,
+                "line": 44,
+                "column": 43
+              },
+              "endPos": {
+                "offset": 690,
+                "line": 44,
+                "column": 50
+              },
+              "value": "goodbye",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 683,
+              "end": 690
+            }
+          }
+        },
+        "colon": {
+          "kind": "<colon>",
+          "startPos": {
+            "offset": 681,
+            "line": 44,
+            "column": 41
+          },
+          "endPos": {
+            "offset": 682,
+            "line": 44,
+            "column": 42
+          },
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 682,
+                "line": 44,
+                "column": 42
+              },
+              "endPos": {
+                "offset": 683,
+                "line": 44,
+                "column": 43
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 682,
+              "end": 683
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 681,
+          "end": 682
+        }
+      },
+      "start": 676,
+      "end": 690,
+      "name": "CompileError"
+    }
+  ]
+}

--- a/packages/dbml-parse/tests/validator/output/ref_name_and_color_setting.out.json
+++ b/packages/dbml-parse/tests/validator/output/ref_name_and_color_setting.out.json
@@ -1805,7 +1805,7 @@
             "line": 11,
             "column": 13
           },
-          "fullEnd": 117,
+          "fullEnd": 116,
           "start": 107,
           "end": 116,
           "expression": {
@@ -1822,7 +1822,7 @@
               "line": 11,
               "column": 13
             },
-            "fullEnd": 117,
+            "fullEnd": 116,
             "start": 107,
             "end": 116,
             "variable": {
@@ -1839,29 +1839,7 @@
               },
               "value": "short_ref",
               "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 116,
-                    "line": 11,
-                    "column": 13
-                  },
-                  "endPos": {
-                    "offset": 117,
-                    "line": 11,
-                    "column": 14
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 116,
-                  "end": 117
-                }
-              ],
+              "trailingTrivia": [],
               "leadingInvalid": [],
               "trailingInvalid": [],
               "isInvalid": false,
@@ -1870,48 +1848,129 @@
             }
           }
         },
-        "attributeList": {
-          "id": 39,
-          "kind": "<list-expression>",
+        "bodyColon": {
+          "kind": "<colon>",
           "startPos": {
+            "offset": 116,
+            "line": 11,
+            "column": 13
+          },
+          "endPos": {
             "offset": 117,
             "line": 11,
             "column": 14
           },
-          "fullStart": 117,
-          "endPos": {
-            "offset": 133,
+          "value": ":",
+          "leadingTrivia": [],
+          "trailingTrivia": [
+            {
+              "kind": "<space>",
+              "startPos": {
+                "offset": 117,
+                "line": 11,
+                "column": 14
+              },
+              "endPos": {
+                "offset": 118,
+                "line": 11,
+                "column": 15
+              },
+              "value": " ",
+              "leadingTrivia": [],
+              "trailingTrivia": [],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 117,
+              "end": 118
+            }
+          ],
+          "leadingInvalid": [],
+          "trailingInvalid": [],
+          "isInvalid": false,
+          "start": 116,
+          "end": 117
+        },
+        "body": {
+          "id": 51,
+          "kind": "<function-application>",
+          "startPos": {
+            "offset": 118,
             "line": 11,
-            "column": 30
+            "column": 15
           },
-          "fullEnd": 133,
-          "start": 117,
-          "end": 133,
-          "listOpenBracket": {
-            "kind": "<lbracket>",
+          "fullStart": 118,
+          "endPos": {
+            "offset": 146,
+            "line": 11,
+            "column": 43
+          },
+          "fullEnd": 147,
+          "start": 118,
+          "end": 146,
+          "callee": {
+            "id": 45,
+            "kind": "<infix-expression>",
             "startPos": {
-              "offset": 117,
-              "line": 11,
-              "column": 14
-            },
-            "endPos": {
               "offset": 118,
               "line": 11,
               "column": 15
             },
-            "value": "[",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 117,
-            "end": 118
-          },
-          "elementList": [
-            {
-              "id": 38,
-              "kind": "<attribute>",
+            "fullStart": 118,
+            "endPos": {
+              "offset": 129,
+              "line": 11,
+              "column": 26
+            },
+            "fullEnd": 130,
+            "start": 118,
+            "end": 129,
+            "op": {
+              "kind": "<op>",
+              "startPos": {
+                "offset": 123,
+                "line": 11,
+                "column": 20
+              },
+              "endPos": {
+                "offset": 124,
+                "line": 11,
+                "column": 21
+              },
+              "value": "<",
+              "leadingTrivia": [],
+              "trailingTrivia": [
+                {
+                  "kind": "<space>",
+                  "startPos": {
+                    "offset": 124,
+                    "line": 11,
+                    "column": 21
+                  },
+                  "endPos": {
+                    "offset": 125,
+                    "line": 11,
+                    "column": 22
+                  },
+                  "value": " ",
+                  "leadingTrivia": [],
+                  "trailingTrivia": [],
+                  "leadingInvalid": [],
+                  "trailingInvalid": [],
+                  "isInvalid": false,
+                  "start": 124,
+                  "end": 125
+                }
+              ],
+              "leadingInvalid": [],
+              "trailingInvalid": [],
+              "isInvalid": false,
+              "start": 123,
+              "end": 124
+            },
+            "leftExpression": {
+              "id": 39,
+              "kind": "<infix-expression>",
               "startPos": {
                 "offset": 118,
                 "line": 11,
@@ -1919,16 +1978,37 @@
               },
               "fullStart": 118,
               "endPos": {
-                "offset": 132,
+                "offset": 122,
                 "line": 11,
-                "column": 29
+                "column": 19
               },
-              "fullEnd": 132,
+              "fullEnd": 123,
               "start": 118,
-              "end": 132,
-              "name": {
-                "id": 35,
-                "kind": "<identifer-stream>",
+              "end": 122,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 119,
+                  "line": 11,
+                  "column": 16
+                },
+                "endPos": {
+                  "offset": 120,
+                  "line": 11,
+                  "column": 17
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 119,
+                "end": 120
+              },
+              "leftExpression": {
+                "id": 36,
+                "kind": "<primary-expression>",
                 "startPos": {
                   "offset": 118,
                   "line": 11,
@@ -1936,15 +2016,31 @@
                 },
                 "fullStart": 118,
                 "endPos": {
-                  "offset": 123,
+                  "offset": 119,
                   "line": 11,
-                  "column": 20
+                  "column": 16
                 },
-                "fullEnd": 123,
+                "fullEnd": 119,
                 "start": 118,
-                "end": 123,
-                "identifiers": [
-                  {
+                "end": 119,
+                "expression": {
+                  "id": 35,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 118,
+                    "line": 11,
+                    "column": 15
+                  },
+                  "fullStart": 118,
+                  "endPos": {
+                    "offset": 119,
+                    "line": 11,
+                    "column": 16
+                  },
+                  "fullEnd": 119,
+                  "start": 118,
+                  "end": 119,
+                  "variable": {
                     "kind": "<identifier>",
                     "startPos": {
                       "offset": 118,
@@ -1952,23 +2048,141 @@
                       "column": 15
                     },
                     "endPos": {
-                      "offset": 123,
+                      "offset": 119,
                       "line": 11,
-                      "column": 20
+                      "column": 16
                     },
-                    "value": "color",
+                    "value": "b",
                     "leadingTrivia": [],
                     "trailingTrivia": [],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
                     "start": 118,
-                    "end": 123
+                    "end": 119
                   }
-                ]
+                }
               },
-              "value": {
-                "id": 37,
+              "rightExpression": {
+                "id": 38,
+                "kind": "<primary-expression>",
+                "startPos": {
+                  "offset": 120,
+                  "line": 11,
+                  "column": 17
+                },
+                "fullStart": 120,
+                "endPos": {
+                  "offset": 122,
+                  "line": 11,
+                  "column": 19
+                },
+                "fullEnd": 123,
+                "start": 120,
+                "end": 122,
+                "expression": {
+                  "id": 37,
+                  "kind": "<variable>",
+                  "startPos": {
+                    "offset": 120,
+                    "line": 11,
+                    "column": 17
+                  },
+                  "fullStart": 120,
+                  "endPos": {
+                    "offset": 122,
+                    "line": 11,
+                    "column": 19
+                  },
+                  "fullEnd": 123,
+                  "start": 120,
+                  "end": 122,
+                  "variable": {
+                    "kind": "<identifier>",
+                    "startPos": {
+                      "offset": 120,
+                      "line": 11,
+                      "column": 17
+                    },
+                    "endPos": {
+                      "offset": 122,
+                      "line": 11,
+                      "column": 19
+                    },
+                    "value": "id",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 122,
+                          "line": 11,
+                          "column": 19
+                        },
+                        "endPos": {
+                          "offset": 123,
+                          "line": 11,
+                          "column": 20
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 122,
+                        "end": 123
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 120,
+                    "end": 122
+                  }
+                }
+              }
+            },
+            "rightExpression": {
+              "id": 44,
+              "kind": "<infix-expression>",
+              "startPos": {
+                "offset": 125,
+                "line": 11,
+                "column": 22
+              },
+              "fullStart": 125,
+              "endPos": {
+                "offset": 129,
+                "line": 11,
+                "column": 26
+              },
+              "fullEnd": 130,
+              "start": 125,
+              "end": 129,
+              "op": {
+                "kind": "<op>",
+                "startPos": {
+                  "offset": 126,
+                  "line": 11,
+                  "column": 23
+                },
+                "endPos": {
+                  "offset": 127,
+                  "line": 11,
+                  "column": 24
+                },
+                "value": ".",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 126,
+                "end": 127
+              },
+              "leftExpression": {
+                "id": 41,
                 "kind": "<primary-expression>",
                 "startPos": {
                   "offset": 125,
@@ -1977,16 +2191,16 @@
                 },
                 "fullStart": 125,
                 "endPos": {
-                  "offset": 132,
+                  "offset": 126,
                   "line": 11,
-                  "column": 29
+                  "column": 23
                 },
-                "fullEnd": 132,
+                "fullEnd": 126,
                 "start": 125,
-                "end": 132,
+                "end": 126,
                 "expression": {
-                  "id": 36,
-                  "kind": "<literal>",
+                  "id": 40,
+                  "kind": "<variable>",
                   "startPos": {
                     "offset": 125,
                     "line": 11,
@@ -1994,482 +2208,24 @@
                   },
                   "fullStart": 125,
                   "endPos": {
-                    "offset": 132,
+                    "offset": 126,
                     "line": 11,
-                    "column": 29
+                    "column": 23
                   },
-                  "fullEnd": 132,
+                  "fullEnd": 126,
                   "start": 125,
-                  "end": 132,
-                  "literal": {
-                    "kind": "<color>",
+                  "end": 126,
+                  "variable": {
+                    "kind": "<identifier>",
                     "startPos": {
                       "offset": 125,
                       "line": 11,
                       "column": 22
                     },
                     "endPos": {
-                      "offset": 132,
+                      "offset": 126,
                       "line": 11,
-                      "column": 29
-                    },
-                    "value": "#aabbcc",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 125,
-                    "end": 132
-                  }
-                }
-              },
-              "colon": {
-                "kind": "<colon>",
-                "startPos": {
-                  "offset": 123,
-                  "line": 11,
-                  "column": 20
-                },
-                "endPos": {
-                  "offset": 124,
-                  "line": 11,
-                  "column": 21
-                },
-                "value": ":",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 124,
-                      "line": 11,
-                      "column": 21
-                    },
-                    "endPos": {
-                      "offset": 125,
-                      "line": 11,
-                      "column": 22
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 124,
-                    "end": 125
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 123,
-                "end": 124
-              }
-            }
-          ],
-          "commaList": [],
-          "listCloseBracket": {
-            "kind": "<rbracket>",
-            "startPos": {
-              "offset": 132,
-              "line": 11,
-              "column": 29
-            },
-            "endPos": {
-              "offset": 133,
-              "line": 11,
-              "column": 30
-            },
-            "value": "]",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 132,
-            "end": 133
-          }
-        },
-        "bodyColon": {
-          "kind": "<colon>",
-          "startPos": {
-            "offset": 133,
-            "line": 11,
-            "column": 30
-          },
-          "endPos": {
-            "offset": 134,
-            "line": 11,
-            "column": 31
-          },
-          "value": ":",
-          "leadingTrivia": [],
-          "trailingTrivia": [
-            {
-              "kind": "<space>",
-              "startPos": {
-                "offset": 134,
-                "line": 11,
-                "column": 31
-              },
-              "endPos": {
-                "offset": 135,
-                "line": 11,
-                "column": 32
-              },
-              "value": " ",
-              "leadingTrivia": [],
-              "trailingTrivia": [],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 134,
-              "end": 135
-            }
-          ],
-          "leadingInvalid": [],
-          "trailingInvalid": [],
-          "isInvalid": false,
-          "start": 133,
-          "end": 134
-        },
-        "body": {
-          "id": 51,
-          "kind": "<function-application>",
-          "startPos": {
-            "offset": 135,
-            "line": 11,
-            "column": 32
-          },
-          "fullStart": 135,
-          "endPos": {
-            "offset": 146,
-            "line": 11,
-            "column": 43
-          },
-          "fullEnd": 147,
-          "start": 135,
-          "end": 146,
-          "callee": {
-            "id": 50,
-            "kind": "<infix-expression>",
-            "startPos": {
-              "offset": 135,
-              "line": 11,
-              "column": 32
-            },
-            "fullStart": 135,
-            "endPos": {
-              "offset": 146,
-              "line": 11,
-              "column": 43
-            },
-            "fullEnd": 147,
-            "start": 135,
-            "end": 146,
-            "op": {
-              "kind": "<op>",
-              "startPos": {
-                "offset": 140,
-                "line": 11,
-                "column": 37
-              },
-              "endPos": {
-                "offset": 141,
-                "line": 11,
-                "column": 38
-              },
-              "value": "<",
-              "leadingTrivia": [],
-              "trailingTrivia": [
-                {
-                  "kind": "<space>",
-                  "startPos": {
-                    "offset": 141,
-                    "line": 11,
-                    "column": 38
-                  },
-                  "endPos": {
-                    "offset": 142,
-                    "line": 11,
-                    "column": 39
-                  },
-                  "value": " ",
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
-                  "leadingInvalid": [],
-                  "trailingInvalid": [],
-                  "isInvalid": false,
-                  "start": 141,
-                  "end": 142
-                }
-              ],
-              "leadingInvalid": [],
-              "trailingInvalid": [],
-              "isInvalid": false,
-              "start": 140,
-              "end": 141
-            },
-            "leftExpression": {
-              "id": 44,
-              "kind": "<infix-expression>",
-              "startPos": {
-                "offset": 135,
-                "line": 11,
-                "column": 32
-              },
-              "fullStart": 135,
-              "endPos": {
-                "offset": 139,
-                "line": 11,
-                "column": 36
-              },
-              "fullEnd": 140,
-              "start": 135,
-              "end": 139,
-              "op": {
-                "kind": "<op>",
-                "startPos": {
-                  "offset": 136,
-                  "line": 11,
-                  "column": 33
-                },
-                "endPos": {
-                  "offset": 137,
-                  "line": 11,
-                  "column": 34
-                },
-                "value": ".",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 136,
-                "end": 137
-              },
-              "leftExpression": {
-                "id": 41,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 135,
-                  "line": 11,
-                  "column": 32
-                },
-                "fullStart": 135,
-                "endPos": {
-                  "offset": 136,
-                  "line": 11,
-                  "column": 33
-                },
-                "fullEnd": 136,
-                "start": 135,
-                "end": 136,
-                "expression": {
-                  "id": 40,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 135,
-                    "line": 11,
-                    "column": 32
-                  },
-                  "fullStart": 135,
-                  "endPos": {
-                    "offset": 136,
-                    "line": 11,
-                    "column": 33
-                  },
-                  "fullEnd": 136,
-                  "start": 135,
-                  "end": 136,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 135,
-                      "line": 11,
-                      "column": 32
-                    },
-                    "endPos": {
-                      "offset": 136,
-                      "line": 11,
-                      "column": 33
-                    },
-                    "value": "b",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 135,
-                    "end": 136
-                  }
-                }
-              },
-              "rightExpression": {
-                "id": 43,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 137,
-                  "line": 11,
-                  "column": 34
-                },
-                "fullStart": 137,
-                "endPos": {
-                  "offset": 139,
-                  "line": 11,
-                  "column": 36
-                },
-                "fullEnd": 140,
-                "start": 137,
-                "end": 139,
-                "expression": {
-                  "id": 42,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 137,
-                    "line": 11,
-                    "column": 34
-                  },
-                  "fullStart": 137,
-                  "endPos": {
-                    "offset": 139,
-                    "line": 11,
-                    "column": 36
-                  },
-                  "fullEnd": 140,
-                  "start": 137,
-                  "end": 139,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 137,
-                      "line": 11,
-                      "column": 34
-                    },
-                    "endPos": {
-                      "offset": 139,
-                      "line": 11,
-                      "column": 36
-                    },
-                    "value": "id",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [
-                      {
-                        "kind": "<space>",
-                        "startPos": {
-                          "offset": 139,
-                          "line": 11,
-                          "column": 36
-                        },
-                        "endPos": {
-                          "offset": 140,
-                          "line": 11,
-                          "column": 37
-                        },
-                        "value": " ",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 139,
-                        "end": 140
-                      }
-                    ],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 137,
-                    "end": 139
-                  }
-                }
-              }
-            },
-            "rightExpression": {
-              "id": 49,
-              "kind": "<infix-expression>",
-              "startPos": {
-                "offset": 142,
-                "line": 11,
-                "column": 39
-              },
-              "fullStart": 142,
-              "endPos": {
-                "offset": 146,
-                "line": 11,
-                "column": 43
-              },
-              "fullEnd": 147,
-              "start": 142,
-              "end": 146,
-              "op": {
-                "kind": "<op>",
-                "startPos": {
-                  "offset": 143,
-                  "line": 11,
-                  "column": 40
-                },
-                "endPos": {
-                  "offset": 144,
-                  "line": 11,
-                  "column": 41
-                },
-                "value": ".",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 143,
-                "end": 144
-              },
-              "leftExpression": {
-                "id": 46,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 142,
-                  "line": 11,
-                  "column": 39
-                },
-                "fullStart": 142,
-                "endPos": {
-                  "offset": 143,
-                  "line": 11,
-                  "column": 40
-                },
-                "fullEnd": 143,
-                "start": 142,
-                "end": 143,
-                "expression": {
-                  "id": 45,
-                  "kind": "<variable>",
-                  "startPos": {
-                    "offset": 142,
-                    "line": 11,
-                    "column": 39
-                  },
-                  "fullStart": 142,
-                  "endPos": {
-                    "offset": 143,
-                    "line": 11,
-                    "column": 40
-                  },
-                  "fullEnd": 143,
-                  "start": 142,
-                  "end": 143,
-                  "variable": {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 142,
-                      "line": 11,
-                      "column": 39
-                    },
-                    "endPos": {
-                      "offset": 143,
-                      "line": 11,
-                      "column": 40
+                      "column": 23
                     },
                     "value": "c",
                     "leadingTrivia": [],
@@ -2477,93 +2233,338 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 142,
-                    "end": 143
+                    "start": 125,
+                    "end": 126
                   }
                 }
               },
               "rightExpression": {
-                "id": 48,
+                "id": 43,
                 "kind": "<primary-expression>",
                 "startPos": {
-                  "offset": 144,
+                  "offset": 127,
                   "line": 11,
-                  "column": 41
+                  "column": 24
                 },
-                "fullStart": 144,
+                "fullStart": 127,
                 "endPos": {
-                  "offset": 146,
+                  "offset": 129,
                   "line": 11,
-                  "column": 43
+                  "column": 26
                 },
-                "fullEnd": 147,
-                "start": 144,
-                "end": 146,
+                "fullEnd": 130,
+                "start": 127,
+                "end": 129,
                 "expression": {
-                  "id": 47,
+                  "id": 42,
                   "kind": "<variable>",
                   "startPos": {
-                    "offset": 144,
+                    "offset": 127,
                     "line": 11,
-                    "column": 41
+                    "column": 24
                   },
-                  "fullStart": 144,
+                  "fullStart": 127,
                   "endPos": {
-                    "offset": 146,
+                    "offset": 129,
                     "line": 11,
-                    "column": 43
+                    "column": 26
                   },
-                  "fullEnd": 147,
-                  "start": 144,
-                  "end": 146,
+                  "fullEnd": 130,
+                  "start": 127,
+                  "end": 129,
                   "variable": {
                     "kind": "<identifier>",
                     "startPos": {
-                      "offset": 144,
+                      "offset": 127,
                       "line": 11,
-                      "column": 41
+                      "column": 24
                     },
                     "endPos": {
-                      "offset": 146,
+                      "offset": 129,
                       "line": 11,
-                      "column": 43
+                      "column": 26
                     },
                     "value": "id",
                     "leadingTrivia": [],
                     "trailingTrivia": [
                       {
-                        "kind": "<newline>",
+                        "kind": "<space>",
                         "startPos": {
-                          "offset": 146,
+                          "offset": 129,
                           "line": 11,
-                          "column": 43
+                          "column": 26
                         },
                         "endPos": {
-                          "offset": 147,
-                          "line": 12,
-                          "column": 0
+                          "offset": 130,
+                          "line": 11,
+                          "column": 27
                         },
-                        "value": "\n",
+                        "value": " ",
                         "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 146,
-                        "end": 147
+                        "start": 129,
+                        "end": 130
                       }
                     ],
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 144,
-                    "end": 146
+                    "start": 127,
+                    "end": 129
                   }
                 }
               }
             }
           },
-          "args": []
+          "args": [
+            {
+              "id": 50,
+              "kind": "<list-expression>",
+              "startPos": {
+                "offset": 130,
+                "line": 11,
+                "column": 27
+              },
+              "fullStart": 130,
+              "endPos": {
+                "offset": 146,
+                "line": 11,
+                "column": 43
+              },
+              "fullEnd": 147,
+              "start": 130,
+              "end": 146,
+              "listOpenBracket": {
+                "kind": "<lbracket>",
+                "startPos": {
+                  "offset": 130,
+                  "line": 11,
+                  "column": 27
+                },
+                "endPos": {
+                  "offset": 131,
+                  "line": 11,
+                  "column": 28
+                },
+                "value": "[",
+                "leadingTrivia": [],
+                "trailingTrivia": [],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 130,
+                "end": 131
+              },
+              "elementList": [
+                {
+                  "id": 49,
+                  "kind": "<attribute>",
+                  "startPos": {
+                    "offset": 131,
+                    "line": 11,
+                    "column": 28
+                  },
+                  "fullStart": 131,
+                  "endPos": {
+                    "offset": 145,
+                    "line": 11,
+                    "column": 42
+                  },
+                  "fullEnd": 145,
+                  "start": 131,
+                  "end": 145,
+                  "name": {
+                    "id": 46,
+                    "kind": "<identifer-stream>",
+                    "startPos": {
+                      "offset": 131,
+                      "line": 11,
+                      "column": 28
+                    },
+                    "fullStart": 131,
+                    "endPos": {
+                      "offset": 136,
+                      "line": 11,
+                      "column": 33
+                    },
+                    "fullEnd": 136,
+                    "start": 131,
+                    "end": 136,
+                    "identifiers": [
+                      {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 131,
+                          "line": 11,
+                          "column": 28
+                        },
+                        "endPos": {
+                          "offset": 136,
+                          "line": 11,
+                          "column": 33
+                        },
+                        "value": "color",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 131,
+                        "end": 136
+                      }
+                    ]
+                  },
+                  "value": {
+                    "id": 48,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 138,
+                      "line": 11,
+                      "column": 35
+                    },
+                    "fullStart": 138,
+                    "endPos": {
+                      "offset": 145,
+                      "line": 11,
+                      "column": 42
+                    },
+                    "fullEnd": 145,
+                    "start": 138,
+                    "end": 145,
+                    "expression": {
+                      "id": 47,
+                      "kind": "<literal>",
+                      "startPos": {
+                        "offset": 138,
+                        "line": 11,
+                        "column": 35
+                      },
+                      "fullStart": 138,
+                      "endPos": {
+                        "offset": 145,
+                        "line": 11,
+                        "column": 42
+                      },
+                      "fullEnd": 145,
+                      "start": 138,
+                      "end": 145,
+                      "literal": {
+                        "kind": "<color>",
+                        "startPos": {
+                          "offset": 138,
+                          "line": 11,
+                          "column": 35
+                        },
+                        "endPos": {
+                          "offset": 145,
+                          "line": 11,
+                          "column": 42
+                        },
+                        "value": "#aabbcc",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 138,
+                        "end": 145
+                      }
+                    }
+                  },
+                  "colon": {
+                    "kind": "<colon>",
+                    "startPos": {
+                      "offset": 136,
+                      "line": 11,
+                      "column": 33
+                    },
+                    "endPos": {
+                      "offset": 137,
+                      "line": 11,
+                      "column": 34
+                    },
+                    "value": ":",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [
+                      {
+                        "kind": "<space>",
+                        "startPos": {
+                          "offset": 137,
+                          "line": 11,
+                          "column": 34
+                        },
+                        "endPos": {
+                          "offset": 138,
+                          "line": 11,
+                          "column": 35
+                        },
+                        "value": " ",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 137,
+                        "end": 138
+                      }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 136,
+                    "end": 137
+                  }
+                }
+              ],
+              "commaList": [],
+              "listCloseBracket": {
+                "kind": "<rbracket>",
+                "startPos": {
+                  "offset": 145,
+                  "line": 11,
+                  "column": 42
+                },
+                "endPos": {
+                  "offset": 146,
+                  "line": 11,
+                  "column": 43
+                },
+                "value": "]",
+                "leadingTrivia": [],
+                "trailingTrivia": [
+                  {
+                    "kind": "<newline>",
+                    "startPos": {
+                      "offset": 146,
+                      "line": 11,
+                      "column": 43
+                    },
+                    "endPos": {
+                      "offset": 147,
+                      "line": 12,
+                      "column": 0
+                    },
+                    "value": "\n",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 146,
+                    "end": 147
+                  }
+                ],
+                "leadingInvalid": [],
+                "trailingInvalid": [],
+                "isInvalid": false,
+                "start": 145,
+                "end": 146
+              }
+            }
+          ]
         },
         "parent": 74
       },
@@ -2770,9 +2771,9 @@
             }
           }
         },
-        "attributeList": {
-          "id": 59,
-          "kind": "<list-expression>",
+        "body": {
+          "id": 72,
+          "kind": "<block-expression>",
           "startPos": {
             "offset": 174,
             "line": 14,
@@ -2780,15 +2781,15 @@
           },
           "fullStart": 174,
           "endPos": {
-            "offset": 190,
-            "line": 14,
-            "column": 29
+            "offset": 210,
+            "line": 16,
+            "column": 1
           },
-          "fullEnd": 191,
+          "fullEnd": 210,
           "start": 174,
-          "end": 190,
-          "listOpenBracket": {
-            "kind": "<lbracket>",
+          "end": 210,
+          "blockOpenBrace": {
+            "kind": "<lbrace>",
             "startPos": {
               "offset": 174,
               "line": 14,
@@ -2799,262 +2800,18 @@
               "line": 14,
               "column": 14
             },
-            "value": "[",
-            "leadingTrivia": [],
-            "trailingTrivia": [],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 174,
-            "end": 175
-          },
-          "elementList": [
-            {
-              "id": 58,
-              "kind": "<attribute>",
-              "startPos": {
-                "offset": 175,
-                "line": 14,
-                "column": 14
-              },
-              "fullStart": 175,
-              "endPos": {
-                "offset": 189,
-                "line": 14,
-                "column": 28
-              },
-              "fullEnd": 189,
-              "start": 175,
-              "end": 189,
-              "name": {
-                "id": 55,
-                "kind": "<identifer-stream>",
-                "startPos": {
-                  "offset": 175,
-                  "line": 14,
-                  "column": 14
-                },
-                "fullStart": 175,
-                "endPos": {
-                  "offset": 180,
-                  "line": 14,
-                  "column": 19
-                },
-                "fullEnd": 180,
-                "start": 175,
-                "end": 180,
-                "identifiers": [
-                  {
-                    "kind": "<identifier>",
-                    "startPos": {
-                      "offset": 175,
-                      "line": 14,
-                      "column": 14
-                    },
-                    "endPos": {
-                      "offset": 180,
-                      "line": 14,
-                      "column": 19
-                    },
-                    "value": "color",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 175,
-                    "end": 180
-                  }
-                ]
-              },
-              "value": {
-                "id": 57,
-                "kind": "<primary-expression>",
-                "startPos": {
-                  "offset": 182,
-                  "line": 14,
-                  "column": 21
-                },
-                "fullStart": 182,
-                "endPos": {
-                  "offset": 189,
-                  "line": 14,
-                  "column": 28
-                },
-                "fullEnd": 189,
-                "start": 182,
-                "end": 189,
-                "expression": {
-                  "id": 56,
-                  "kind": "<literal>",
-                  "startPos": {
-                    "offset": 182,
-                    "line": 14,
-                    "column": 21
-                  },
-                  "fullStart": 182,
-                  "endPos": {
-                    "offset": 189,
-                    "line": 14,
-                    "column": 28
-                  },
-                  "fullEnd": 189,
-                  "start": 182,
-                  "end": 189,
-                  "literal": {
-                    "kind": "<color>",
-                    "startPos": {
-                      "offset": 182,
-                      "line": 14,
-                      "column": 21
-                    },
-                    "endPos": {
-                      "offset": 189,
-                      "line": 14,
-                      "column": 28
-                    },
-                    "value": "#123456",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 182,
-                    "end": 189
-                  }
-                }
-              },
-              "colon": {
-                "kind": "<colon>",
-                "startPos": {
-                  "offset": 180,
-                  "line": 14,
-                  "column": 19
-                },
-                "endPos": {
-                  "offset": 181,
-                  "line": 14,
-                  "column": 20
-                },
-                "value": ":",
-                "leadingTrivia": [],
-                "trailingTrivia": [
-                  {
-                    "kind": "<space>",
-                    "startPos": {
-                      "offset": 181,
-                      "line": 14,
-                      "column": 20
-                    },
-                    "endPos": {
-                      "offset": 182,
-                      "line": 14,
-                      "column": 21
-                    },
-                    "value": " ",
-                    "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 181,
-                    "end": 182
-                  }
-                ],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 180,
-                "end": 181
-              }
-            }
-          ],
-          "commaList": [],
-          "listCloseBracket": {
-            "kind": "<rbracket>",
-            "startPos": {
-              "offset": 189,
-              "line": 14,
-              "column": 28
-            },
-            "endPos": {
-              "offset": 190,
-              "line": 14,
-              "column": 29
-            },
-            "value": "]",
-            "leadingTrivia": [],
-            "trailingTrivia": [
-              {
-                "kind": "<space>",
-                "startPos": {
-                  "offset": 190,
-                  "line": 14,
-                  "column": 29
-                },
-                "endPos": {
-                  "offset": 191,
-                  "line": 14,
-                  "column": 30
-                },
-                "value": " ",
-                "leadingTrivia": [],
-                "trailingTrivia": [],
-                "leadingInvalid": [],
-                "trailingInvalid": [],
-                "isInvalid": false,
-                "start": 190,
-                "end": 191
-              }
-            ],
-            "leadingInvalid": [],
-            "trailingInvalid": [],
-            "isInvalid": false,
-            "start": 189,
-            "end": 190
-          }
-        },
-        "body": {
-          "id": 72,
-          "kind": "<block-expression>",
-          "startPos": {
-            "offset": 191,
-            "line": 14,
-            "column": 30
-          },
-          "fullStart": 191,
-          "endPos": {
-            "offset": 210,
-            "line": 16,
-            "column": 1
-          },
-          "fullEnd": 210,
-          "start": 191,
-          "end": 210,
-          "blockOpenBrace": {
-            "kind": "<lbrace>",
-            "startPos": {
-              "offset": 191,
-              "line": 14,
-              "column": 30
-            },
-            "endPos": {
-              "offset": 192,
-              "line": 14,
-              "column": 31
-            },
             "value": "{",
             "leadingTrivia": [],
             "trailingTrivia": [
               {
                 "kind": "<newline>",
                 "startPos": {
-                  "offset": 192,
+                  "offset": 175,
                   "line": 14,
-                  "column": 31
+                  "column": 14
                 },
                 "endPos": {
-                  "offset": 193,
+                  "offset": 176,
                   "line": 15,
                   "column": 0
                 },
@@ -3064,60 +2821,60 @@
                 "leadingInvalid": [],
                 "trailingInvalid": [],
                 "isInvalid": false,
-                "start": 192,
-                "end": 193
+                "start": 175,
+                "end": 176
               }
             ],
             "leadingInvalid": [],
             "trailingInvalid": [],
             "isInvalid": false,
-            "start": 191,
-            "end": 192
+            "start": 174,
+            "end": 175
           },
           "body": [
             {
               "id": 71,
               "kind": "<function-application>",
               "startPos": {
-                "offset": 195,
+                "offset": 178,
                 "line": 15,
                 "column": 2
               },
-              "fullStart": 193,
+              "fullStart": 176,
               "endPos": {
                 "offset": 208,
                 "line": 15,
-                "column": 15
+                "column": 32
               },
               "fullEnd": 209,
-              "start": 195,
+              "start": 178,
               "end": 208,
               "callee": {
-                "id": 70,
+                "id": 65,
                 "kind": "<infix-expression>",
                 "startPos": {
-                  "offset": 195,
+                  "offset": 178,
                   "line": 15,
                   "column": 2
                 },
-                "fullStart": 193,
+                "fullStart": 176,
                 "endPos": {
-                  "offset": 208,
+                  "offset": 191,
                   "line": 15,
                   "column": 15
                 },
-                "fullEnd": 209,
-                "start": 195,
-                "end": 208,
+                "fullEnd": 192,
+                "start": 178,
+                "end": 191,
                 "op": {
                   "kind": "<op>",
                   "startPos": {
-                    "offset": 200,
+                    "offset": 183,
                     "line": 15,
                     "column": 7
                   },
                   "endPos": {
-                    "offset": 201,
+                    "offset": 184,
                     "line": 15,
                     "column": 8
                   },
@@ -3127,12 +2884,12 @@
                     {
                       "kind": "<space>",
                       "startPos": {
-                        "offset": 201,
+                        "offset": 184,
                         "line": 15,
                         "column": 8
                       },
                       "endPos": {
-                        "offset": 202,
+                        "offset": 185,
                         "line": 15,
                         "column": 9
                       },
@@ -3142,42 +2899,42 @@
                       "leadingInvalid": [],
                       "trailingInvalid": [],
                       "isInvalid": false,
-                      "start": 201,
-                      "end": 202
+                      "start": 184,
+                      "end": 185
                     }
                   ],
                   "leadingInvalid": [],
                   "trailingInvalid": [],
                   "isInvalid": false,
-                  "start": 200,
-                  "end": 201
+                  "start": 183,
+                  "end": 184
                 },
                 "leftExpression": {
-                  "id": 64,
+                  "id": 59,
                   "kind": "<infix-expression>",
                   "startPos": {
-                    "offset": 195,
+                    "offset": 178,
                     "line": 15,
                     "column": 2
                   },
-                  "fullStart": 193,
+                  "fullStart": 176,
                   "endPos": {
-                    "offset": 199,
+                    "offset": 182,
                     "line": 15,
                     "column": 6
                   },
-                  "fullEnd": 200,
-                  "start": 195,
-                  "end": 199,
+                  "fullEnd": 183,
+                  "start": 178,
+                  "end": 182,
                   "op": {
                     "kind": "<op>",
                     "startPos": {
-                      "offset": 196,
+                      "offset": 179,
                       "line": 15,
                       "column": 3
                     },
                     "endPos": {
-                      "offset": 197,
+                      "offset": 180,
                       "line": 15,
                       "column": 4
                     },
@@ -3187,52 +2944,52 @@
                     "leadingInvalid": [],
                     "trailingInvalid": [],
                     "isInvalid": false,
-                    "start": 196,
-                    "end": 197
+                    "start": 179,
+                    "end": 180
                   },
                   "leftExpression": {
-                    "id": 61,
+                    "id": 56,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 195,
+                      "offset": 178,
                       "line": 15,
                       "column": 2
                     },
-                    "fullStart": 193,
+                    "fullStart": 176,
                     "endPos": {
-                      "offset": 196,
+                      "offset": 179,
                       "line": 15,
                       "column": 3
                     },
-                    "fullEnd": 196,
-                    "start": 195,
-                    "end": 196,
+                    "fullEnd": 179,
+                    "start": 178,
+                    "end": 179,
                     "expression": {
-                      "id": 60,
+                      "id": 55,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 195,
+                        "offset": 178,
                         "line": 15,
                         "column": 2
                       },
-                      "fullStart": 193,
+                      "fullStart": 176,
                       "endPos": {
-                        "offset": 196,
+                        "offset": 179,
                         "line": 15,
                         "column": 3
                       },
-                      "fullEnd": 196,
-                      "start": 195,
-                      "end": 196,
+                      "fullEnd": 179,
+                      "start": 178,
+                      "end": 179,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 195,
+                          "offset": 178,
                           "line": 15,
                           "column": 2
                         },
                         "endPos": {
-                          "offset": 196,
+                          "offset": 179,
                           "line": 15,
                           "column": 3
                         },
@@ -3241,12 +2998,12 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 193,
+                              "offset": 176,
                               "line": 15,
                               "column": 0
                             },
                             "endPos": {
-                              "offset": 194,
+                              "offset": 177,
                               "line": 15,
                               "column": 1
                             },
@@ -3256,18 +3013,18 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 193,
-                            "end": 194
+                            "start": 176,
+                            "end": 177
                           },
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 194,
+                              "offset": 177,
                               "line": 15,
                               "column": 1
                             },
                             "endPos": {
-                              "offset": 195,
+                              "offset": 178,
                               "line": 15,
                               "column": 2
                             },
@@ -3277,62 +3034,62 @@
                             "leadingInvalid": [],
                             "trailingInvalid": [],
                             "isInvalid": false,
-                            "start": 194,
-                            "end": 195
+                            "start": 177,
+                            "end": 178
                           }
                         ],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 195,
-                        "end": 196
+                        "start": 178,
+                        "end": 179
                       }
                     }
                   },
                   "rightExpression": {
-                    "id": 63,
+                    "id": 58,
                     "kind": "<primary-expression>",
                     "startPos": {
-                      "offset": 197,
+                      "offset": 180,
                       "line": 15,
                       "column": 4
                     },
-                    "fullStart": 197,
+                    "fullStart": 180,
                     "endPos": {
-                      "offset": 199,
+                      "offset": 182,
                       "line": 15,
                       "column": 6
                     },
-                    "fullEnd": 200,
-                    "start": 197,
-                    "end": 199,
+                    "fullEnd": 183,
+                    "start": 180,
+                    "end": 182,
                     "expression": {
-                      "id": 62,
+                      "id": 57,
                       "kind": "<variable>",
                       "startPos": {
-                        "offset": 197,
+                        "offset": 180,
                         "line": 15,
                         "column": 4
                       },
-                      "fullStart": 197,
+                      "fullStart": 180,
                       "endPos": {
-                        "offset": 199,
+                        "offset": 182,
                         "line": 15,
                         "column": 6
                       },
-                      "fullEnd": 200,
-                      "start": 197,
-                      "end": 199,
+                      "fullEnd": 183,
+                      "start": 180,
+                      "end": 182,
                       "variable": {
                         "kind": "<identifier>",
                         "startPos": {
-                          "offset": 197,
+                          "offset": 180,
                           "line": 15,
                           "column": 4
                         },
                         "endPos": {
-                          "offset": 199,
+                          "offset": 182,
                           "line": 15,
                           "column": 6
                         },
@@ -3342,14 +3099,391 @@
                           {
                             "kind": "<space>",
                             "startPos": {
-                              "offset": 199,
+                              "offset": 182,
                               "line": 15,
                               "column": 6
                             },
                             "endPos": {
-                              "offset": 200,
+                              "offset": 183,
                               "line": 15,
                               "column": 7
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 182,
+                            "end": 183
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 180,
+                        "end": 182
+                      }
+                    }
+                  }
+                },
+                "rightExpression": {
+                  "id": 64,
+                  "kind": "<infix-expression>",
+                  "startPos": {
+                    "offset": 185,
+                    "line": 15,
+                    "column": 9
+                  },
+                  "fullStart": 185,
+                  "endPos": {
+                    "offset": 191,
+                    "line": 15,
+                    "column": 15
+                  },
+                  "fullEnd": 192,
+                  "start": 185,
+                  "end": 191,
+                  "op": {
+                    "kind": "<op>",
+                    "startPos": {
+                      "offset": 186,
+                      "line": 15,
+                      "column": 10
+                    },
+                    "endPos": {
+                      "offset": 187,
+                      "line": 15,
+                      "column": 11
+                    },
+                    "value": ".",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 186,
+                    "end": 187
+                  },
+                  "leftExpression": {
+                    "id": 61,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 185,
+                      "line": 15,
+                      "column": 9
+                    },
+                    "fullStart": 185,
+                    "endPos": {
+                      "offset": 186,
+                      "line": 15,
+                      "column": 10
+                    },
+                    "fullEnd": 186,
+                    "start": 185,
+                    "end": 186,
+                    "expression": {
+                      "id": 60,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 185,
+                        "line": 15,
+                        "column": 9
+                      },
+                      "fullStart": 185,
+                      "endPos": {
+                        "offset": 186,
+                        "line": 15,
+                        "column": 10
+                      },
+                      "fullEnd": 186,
+                      "start": 185,
+                      "end": 186,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 185,
+                          "line": 15,
+                          "column": 9
+                        },
+                        "endPos": {
+                          "offset": 186,
+                          "line": 15,
+                          "column": 10
+                        },
+                        "value": "b",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 185,
+                        "end": 186
+                      }
+                    }
+                  },
+                  "rightExpression": {
+                    "id": 63,
+                    "kind": "<primary-expression>",
+                    "startPos": {
+                      "offset": 187,
+                      "line": 15,
+                      "column": 11
+                    },
+                    "fullStart": 187,
+                    "endPos": {
+                      "offset": 191,
+                      "line": 15,
+                      "column": 15
+                    },
+                    "fullEnd": 192,
+                    "start": 187,
+                    "end": 191,
+                    "expression": {
+                      "id": 62,
+                      "kind": "<variable>",
+                      "startPos": {
+                        "offset": 187,
+                        "line": 15,
+                        "column": 11
+                      },
+                      "fullStart": 187,
+                      "endPos": {
+                        "offset": 191,
+                        "line": 15,
+                        "column": 15
+                      },
+                      "fullEnd": 192,
+                      "start": 187,
+                      "end": 191,
+                      "variable": {
+                        "kind": "<identifier>",
+                        "startPos": {
+                          "offset": 187,
+                          "line": 15,
+                          "column": 11
+                        },
+                        "endPos": {
+                          "offset": 191,
+                          "line": 15,
+                          "column": 15
+                        },
+                        "value": "c_id",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 191,
+                              "line": 15,
+                              "column": 15
+                            },
+                            "endPos": {
+                              "offset": 192,
+                              "line": 15,
+                              "column": 16
+                            },
+                            "value": " ",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 191,
+                            "end": 192
+                          }
+                        ],
+                        "leadingInvalid": [],
+                        "trailingInvalid": [],
+                        "isInvalid": false,
+                        "start": 187,
+                        "end": 191
+                      }
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "id": 70,
+                  "kind": "<list-expression>",
+                  "startPos": {
+                    "offset": 192,
+                    "line": 15,
+                    "column": 16
+                  },
+                  "fullStart": 192,
+                  "endPos": {
+                    "offset": 208,
+                    "line": 15,
+                    "column": 32
+                  },
+                  "fullEnd": 209,
+                  "start": 192,
+                  "end": 208,
+                  "listOpenBracket": {
+                    "kind": "<lbracket>",
+                    "startPos": {
+                      "offset": 192,
+                      "line": 15,
+                      "column": 16
+                    },
+                    "endPos": {
+                      "offset": 193,
+                      "line": 15,
+                      "column": 17
+                    },
+                    "value": "[",
+                    "leadingTrivia": [],
+                    "trailingTrivia": [],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 192,
+                    "end": 193
+                  },
+                  "elementList": [
+                    {
+                      "id": 69,
+                      "kind": "<attribute>",
+                      "startPos": {
+                        "offset": 193,
+                        "line": 15,
+                        "column": 17
+                      },
+                      "fullStart": 193,
+                      "endPos": {
+                        "offset": 207,
+                        "line": 15,
+                        "column": 31
+                      },
+                      "fullEnd": 207,
+                      "start": 193,
+                      "end": 207,
+                      "name": {
+                        "id": 66,
+                        "kind": "<identifer-stream>",
+                        "startPos": {
+                          "offset": 193,
+                          "line": 15,
+                          "column": 17
+                        },
+                        "fullStart": 193,
+                        "endPos": {
+                          "offset": 198,
+                          "line": 15,
+                          "column": 22
+                        },
+                        "fullEnd": 198,
+                        "start": 193,
+                        "end": 198,
+                        "identifiers": [
+                          {
+                            "kind": "<identifier>",
+                            "startPos": {
+                              "offset": 193,
+                              "line": 15,
+                              "column": 17
+                            },
+                            "endPos": {
+                              "offset": 198,
+                              "line": 15,
+                              "column": 22
+                            },
+                            "value": "color",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 193,
+                            "end": 198
+                          }
+                        ]
+                      },
+                      "value": {
+                        "id": 68,
+                        "kind": "<primary-expression>",
+                        "startPos": {
+                          "offset": 200,
+                          "line": 15,
+                          "column": 24
+                        },
+                        "fullStart": 200,
+                        "endPos": {
+                          "offset": 207,
+                          "line": 15,
+                          "column": 31
+                        },
+                        "fullEnd": 207,
+                        "start": 200,
+                        "end": 207,
+                        "expression": {
+                          "id": 67,
+                          "kind": "<literal>",
+                          "startPos": {
+                            "offset": 200,
+                            "line": 15,
+                            "column": 24
+                          },
+                          "fullStart": 200,
+                          "endPos": {
+                            "offset": 207,
+                            "line": 15,
+                            "column": 31
+                          },
+                          "fullEnd": 207,
+                          "start": 200,
+                          "end": 207,
+                          "literal": {
+                            "kind": "<color>",
+                            "startPos": {
+                              "offset": 200,
+                              "line": 15,
+                              "column": 24
+                            },
+                            "endPos": {
+                              "offset": 207,
+                              "line": 15,
+                              "column": 31
+                            },
+                            "value": "#123456",
+                            "leadingTrivia": [],
+                            "trailingTrivia": [],
+                            "leadingInvalid": [],
+                            "trailingInvalid": [],
+                            "isInvalid": false,
+                            "start": 200,
+                            "end": 207
+                          }
+                        }
+                      },
+                      "colon": {
+                        "kind": "<colon>",
+                        "startPos": {
+                          "offset": 198,
+                          "line": 15,
+                          "column": 22
+                        },
+                        "endPos": {
+                          "offset": 199,
+                          "line": 15,
+                          "column": 23
+                        },
+                        "value": ":",
+                        "leadingTrivia": [],
+                        "trailingTrivia": [
+                          {
+                            "kind": "<space>",
+                            "startPos": {
+                              "offset": 199,
+                              "line": 15,
+                              "column": 23
+                            },
+                            "endPos": {
+                              "offset": 200,
+                              "line": 15,
+                              "column": 24
                             },
                             "value": " ",
                             "leadingTrivia": [],
@@ -3364,189 +3498,57 @@
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 197,
+                        "start": 198,
                         "end": 199
                       }
                     }
-                  }
-                },
-                "rightExpression": {
-                  "id": 69,
-                  "kind": "<infix-expression>",
-                  "startPos": {
-                    "offset": 202,
-                    "line": 15,
-                    "column": 9
-                  },
-                  "fullStart": 202,
-                  "endPos": {
-                    "offset": 208,
-                    "line": 15,
-                    "column": 15
-                  },
-                  "fullEnd": 209,
-                  "start": 202,
-                  "end": 208,
-                  "op": {
-                    "kind": "<op>",
+                  ],
+                  "commaList": [],
+                  "listCloseBracket": {
+                    "kind": "<rbracket>",
                     "startPos": {
-                      "offset": 203,
+                      "offset": 207,
                       "line": 15,
-                      "column": 10
+                      "column": 31
                     },
                     "endPos": {
-                      "offset": 204,
+                      "offset": 208,
                       "line": 15,
-                      "column": 11
+                      "column": 32
                     },
-                    "value": ".",
+                    "value": "]",
                     "leadingTrivia": [],
-                    "trailingTrivia": [],
-                    "leadingInvalid": [],
-                    "trailingInvalid": [],
-                    "isInvalid": false,
-                    "start": 203,
-                    "end": 204
-                  },
-                  "leftExpression": {
-                    "id": 66,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 202,
-                      "line": 15,
-                      "column": 9
-                    },
-                    "fullStart": 202,
-                    "endPos": {
-                      "offset": 203,
-                      "line": 15,
-                      "column": 10
-                    },
-                    "fullEnd": 203,
-                    "start": 202,
-                    "end": 203,
-                    "expression": {
-                      "id": 65,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 202,
-                        "line": 15,
-                        "column": 9
-                      },
-                      "fullStart": 202,
-                      "endPos": {
-                        "offset": 203,
-                        "line": 15,
-                        "column": 10
-                      },
-                      "fullEnd": 203,
-                      "start": 202,
-                      "end": 203,
-                      "variable": {
-                        "kind": "<identifier>",
+                    "trailingTrivia": [
+                      {
+                        "kind": "<newline>",
                         "startPos": {
-                          "offset": 202,
+                          "offset": 208,
                           "line": 15,
-                          "column": 9
+                          "column": 32
                         },
                         "endPos": {
-                          "offset": 203,
-                          "line": 15,
-                          "column": 10
+                          "offset": 209,
+                          "line": 16,
+                          "column": 0
                         },
-                        "value": "b",
+                        "value": "\n",
                         "leadingTrivia": [],
                         "trailingTrivia": [],
                         "leadingInvalid": [],
                         "trailingInvalid": [],
                         "isInvalid": false,
-                        "start": 202,
-                        "end": 203
+                        "start": 208,
+                        "end": 209
                       }
-                    }
-                  },
-                  "rightExpression": {
-                    "id": 68,
-                    "kind": "<primary-expression>",
-                    "startPos": {
-                      "offset": 204,
-                      "line": 15,
-                      "column": 11
-                    },
-                    "fullStart": 204,
-                    "endPos": {
-                      "offset": 208,
-                      "line": 15,
-                      "column": 15
-                    },
-                    "fullEnd": 209,
-                    "start": 204,
-                    "end": 208,
-                    "expression": {
-                      "id": 67,
-                      "kind": "<variable>",
-                      "startPos": {
-                        "offset": 204,
-                        "line": 15,
-                        "column": 11
-                      },
-                      "fullStart": 204,
-                      "endPos": {
-                        "offset": 208,
-                        "line": 15,
-                        "column": 15
-                      },
-                      "fullEnd": 209,
-                      "start": 204,
-                      "end": 208,
-                      "variable": {
-                        "kind": "<identifier>",
-                        "startPos": {
-                          "offset": 204,
-                          "line": 15,
-                          "column": 11
-                        },
-                        "endPos": {
-                          "offset": 208,
-                          "line": 15,
-                          "column": 15
-                        },
-                        "value": "c_id",
-                        "leadingTrivia": [],
-                        "trailingTrivia": [
-                          {
-                            "kind": "<newline>",
-                            "startPos": {
-                              "offset": 208,
-                              "line": 15,
-                              "column": 15
-                            },
-                            "endPos": {
-                              "offset": 209,
-                              "line": 16,
-                              "column": 0
-                            },
-                            "value": "\n",
-                            "leadingTrivia": [],
-                            "trailingTrivia": [],
-                            "leadingInvalid": [],
-                            "trailingInvalid": [],
-                            "isInvalid": false,
-                            "start": 208,
-                            "end": 209
-                          }
-                        ],
-                        "leadingInvalid": [],
-                        "trailingInvalid": [],
-                        "isInvalid": false,
-                        "start": 204,
-                        "end": 208
-                      }
-                    }
+                    ],
+                    "leadingInvalid": [],
+                    "trailingInvalid": [],
+                    "isInvalid": false,
+                    "start": 207,
+                    "end": 208
                   }
                 }
-              },
-              "args": []
+              ]
             }
           ],
           "blockCloseBrace": {


### PR DESCRIPTION
## Summary
* Revert some changes from https://github.com/holistics/dbml/pull/678
* Move Ref color setting validation from ElementDeclarationNode setting list to sub fields setting list. New ref's color setting syntax:
```
// Short form
Ref short_ref: b.id < c.id [color: #aabbcc]

// Long form
Ref long_ref {
  c.id < b.c_id [color: #123456]
}
```
## Issue
(issue link here)

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review