### PR TITLE
Doc: fix wrong double quote character

### DIFF
--- a/dbml-homepage/docs/docs.md
+++ b/dbml-homepage/docs/docs.md
@@ -173,7 +173,7 @@ The list of column settings you can use:
 - `default: some_value`: set a default value of the column, please refer to the 'Default Value' section below
 - `increment`: mark the column as auto-increment
 
-**Note:** You can use a workaround for un-supported settings by adding the setting name into the column type name, such as `id “bigint unsigned” [pk]`
+**Note:** You can use a workaround for un-supported settings by adding the setting name into the column type name, such as `id "bigint unsigned" [pk]`
 
 ### Default Value
 
@@ -295,11 +295,11 @@ Table schema2.table2 {
 :::note
 * When defining one-to-one relationships, ensure columns are listed in the correct order:
   * With long & short form, the second column will be treated as a foreign key.
-  
-    E.g: `users.id - user_infos.user_id`, *user_infos.user_id* will be the foreign key.
-  * With inline form, the column that have the `ref` definition will be treated as a foreign key. 
 
-    E.g: 
+    E.g: `users.id - user_infos.user_id`, *user_infos.user_id* will be the foreign key.
+  * With inline form, the column that have the `ref` definition will be treated as a foreign key.
+
+    E.g:
     ```text
     Table user_infos {
       user_id integer [ref: - users.id]


### PR DESCRIPTION
## Summary
Fix the wrong double quote character in the public doc that is not recognized in the parser

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review