### PR TITLE
fix: make dbml compiler can be undefined in parser.d.ts

### DIFF
--- a/packages/dbml-core/types/parse/Parser.d.ts
+++ b/packages/dbml-core/types/parse/Parser.d.ts
@@ -18,7 +18,7 @@ declare class Parser {
     static parsePostgresToJSON(str: string): RawDatabase;
     static parsePostgresToJSONv2(str: string): RawDatabase;
     static parseDBMLToJSON(str: string): RawDatabase;
-    static parseDBMLToJSONv2(str: string, dbmlCompiler: Compiler): RawDatabase;
+    static parseDBMLToJSONv2(str: string, dbmlCompiler?: Compiler): RawDatabase;
     static parseSchemaRbToJSON(str: string): RawDatabase;
     static parseMSSQLToJSON(str: string): RawDatabase;
     static parseSnowflakeToJSON(str: string): RawDatabase;


### PR DESCRIPTION
## Summary
- Correct type of `Parser.parseDBMLToJSONv2`: `static parseDBMLToJSONv2(str: string, dbmlCompiler?: Compiler): RawDatabase;`

## Issue
https://github.com/holistics/dbml/issues/685

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review