### PR TITLE
Fix flaky db2dbml/mssql test cause by inconsistent table ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     services:
       postgres:
         image: postgres:15-bullseye

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -215,6 +215,7 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
   const tablesAndFieldsSql = `
     WITH tables_and_fields AS (
       SELECT
+        t.object_id AS table_id,
         s.name AS table_schema,
         t.name AS table_name,
         t.create_date as table_create_date,
@@ -280,7 +281,6 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
         constraints_with_nulls
     )
     SELECT
-      object_id,
       table_schema,
       table_name,
       column_name,
@@ -307,7 +307,7 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
       ${buildSchemaQuery('table_schema', schemas)}
     ORDER BY
       table_schema,
-      object_id,
+      table_id,
       column_id;
   `;
 

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -307,6 +307,7 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
       ${buildSchemaQuery('table_schema', schemas)}
     ORDER BY
       table_schema,
+      table_create_date,
       table_id,
       column_id;
   `;

--- a/packages/dbml-connector/src/connectors/mssqlConnector.ts
+++ b/packages/dbml-connector/src/connectors/mssqlConnector.ts
@@ -280,6 +280,7 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
         constraints_with_nulls
     )
     SELECT
+      object_id,
       table_schema,
       table_name,
       column_name,
@@ -306,7 +307,7 @@ const generateTablesFieldsAndEnums = async (client: sql.ConnectionPool, schemas:
       ${buildSchemaQuery('table_schema', schemas)}
     ORDER BY
       table_schema,
-      table_create_date,
+      object_id,
       column_id;
   `;
 


### PR DESCRIPTION
## Summary
* Order table with same create_date by object_id instead of table create date in mssql connector
* Upgrade tests ci node version to 22

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [x] Integration Tests Passed
- [ ] Code Review