### PR TITLE
misc: add table partials sections to public doc ToC

### DIFF
--- a/dbml-homepage/docs/docs.md
+++ b/dbml-homepage/docs/docs.md
@@ -32,6 +32,9 @@ outlines the full syntax documentations of DBML.
 - [TableGroup](#tablegroup)
     - [TableGroup Notes](#tablegroup-notes-1)
     - [TableGroup Settings](#tablegroup-settings)
+- [Table Partial](#table-partial)
+  - [Conflict Resolution order](#conflict-resolution-order)
+  - [Table Partial example usage](#table-partial-example-usage)
 - [Multi-line String](#multi-line-string)
 - [Comments](#comments)
 - [Syntax Consistency](#syntax-consistency)
@@ -580,7 +583,7 @@ When there're multiple conflicting columns or settings with identical names due 
 1. Local Table Definition: If a definition exists within the local table, it takes precedence.
 2. Last Partial Referenced: If no local definition is found, the definition from the last partial (in dbml source) containing the conflicting name is used.
 
-### Example usage
+### Table Partial example usage
 
 ```text
 TablePartial base_template [headerColor: #ff0000] {


### PR DESCRIPTION
## Summary
* add table partials sections to syntax doc Table of Content

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review