### PR TITLE
MSSQL: fix cannot parse varchar(max) and double precision

### DIFF
--- a/packages/dbml-core/__tests__/parser/mssql-parse/input/default_tables.in.sql
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/input/default_tables.in.sql
@@ -4,8 +4,7 @@ CREATE TABLE [products] (
   [merchant_id] int NOT NULL,
   [price] float DEFAULT (123.12),
   [status] varchar(255) DEFAULT (NULL),
-  [created_at] varchar(255) DEFAULT (now()),
-  [stock] boolean DEFAULT ('true'),
-  [expiration] date DEFAULT (current_date())
+  [created_at] date DEFAULT GETDATE(),
+  [expiration] date DEFAULT GETDATE()
 )
 GO

--- a/packages/dbml-core/__tests__/parser/mssql-parse/input/wrapped_type.in.sql
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/input/wrapped_type.in.sql
@@ -1,0 +1,6 @@
+CREATE TABLE [products] (
+  [name] [varchar](MAX) DEFAULT 'Tea',
+  [status] [varchar](255) DEFAULT (NULL),
+  [price] double precision
+)
+GO

--- a/packages/dbml-core/__tests__/parser/mssql-parse/output/default_tables.out.json
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/output/default_tables.out.json
@@ -58,25 +58,14 @@
         },
         {
           "type": {
-            "type_name": "varchar(255)",
+            "type_name": "date",
             "schemaName": null
           },
           "dbdefault": {
             "type": "expression",
-            "value": "now()"
+            "value": "GETDATE()"
           },
           "name": "created_at"
-        },
-        {
-          "type": {
-            "type_name": "boolean",
-            "schemaName": null
-          },
-          "dbdefault": {
-            "type": "string",
-            "value": "true"
-          },
-          "name": "stock"
         },
         {
           "type": {
@@ -85,7 +74,7 @@
           },
           "dbdefault": {
             "type": "expression",
-            "value": "current_date()"
+            "value": "GETDATE()"
           },
           "name": "expiration"
         }

--- a/packages/dbml-core/__tests__/parser/mssql-parse/output/wrapped_type.out.json
+++ b/packages/dbml-core/__tests__/parser/mssql-parse/output/wrapped_type.out.json
@@ -1,0 +1,38 @@
+{
+  "tables": [
+    {
+      "name": "products",
+      "fields": [
+        {
+          "type": {
+            "type_name": "varchar(MAX)",
+            "schemaName": null
+          },
+          "dbdefault": {
+            "type": "string",
+            "value": "Tea"
+          },
+          "name": "name"
+        },
+        {
+          "type": {
+            "type_name": "varchar(255)",
+            "schemaName": null
+          },
+          "dbdefault": {
+            "type": "boolean",
+            "value": "NULL"
+          },
+          "name": "status"
+        },
+        {
+          "type": {
+            "type_name": "double precision",
+            "schemaName": null
+          },
+          "name": "price"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fix:
  - Cannot parse varchar(max) like data type
  - Cannot parse double precision
  - Fix eslint for `MssqlASTGen`

## Issue
https://github.com/holistics/dbml/issues/712

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [x] Code Review