### PR TITLE
Fix not handling column type with arguments in TablePartial

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.13.2",
+  "version": "3.13.3-alpha.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/cli",
-  "version": "3.13.2",
+  "version": "3.13.3-alpha.0",
   "description": "",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -26,8 +26,8 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.21.0",
-    "@dbml/connector": "^3.13.2",
-    "@dbml/core": "^3.13.2",
+    "@dbml/connector": "^3.13.3-alpha.0",
+    "@dbml/core": "^3.13.3-alpha.0",
     "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/cli",
-  "version": "3.13.3-alpha.0",
+  "version": "3.13.3-alpha.1",
   "description": "",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -26,8 +26,8 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.21.0",
-    "@dbml/connector": "^3.13.3-alpha.0",
-    "@dbml/core": "^3.13.3-alpha.0",
+    "@dbml/connector": "^3.13.3-alpha.1",
+    "@dbml/core": "^3.13.3-alpha.1",
     "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",

--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/connector",
-  "version": "3.13.3-alpha.0",
+  "version": "3.13.3-alpha.1",
   "description": "This package was created to fetch the schema JSON from many kind of databases.",
   "author": "huy.phung.sw@gmail.com",
   "license": "MIT",

--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/connector",
-  "version": "3.13.2",
+  "version": "3.13.3-alpha.0",
   "description": "This package was created to fetch the schema JSON from many kind of databases.",
   "author": "huy.phung.sw@gmail.com",
   "license": "MIT",

--- a/packages/dbml-core/__tests__/normalized_model/table_partial.in.dbml
+++ b/packages/dbml-core/__tests__/normalized_model/table_partial.in.dbml
@@ -54,3 +54,13 @@ Table users {
   ~test
   ~test2
 }
+
+TablePartial testColWithTypeHaveArgs {
+  callExpColInTest1 int(4) [note: 'simple column with call expression as type']
+  callExpColInTest2 decimal(10, 2) [default: 0.1, note: 'column with type that have arguments and default value being a float number']
+}
+
+Table testColWithTypeHaveArgs {
+  id int
+  ~testColWithTypeHaveArgs
+}

--- a/packages/dbml-core/__tests__/normalized_model/table_partial.out.json
+++ b/packages/dbml-core/__tests__/normalized_model/table_partial.out.json
@@ -18,7 +18,8 @@
       "note": "Default Public Schema",
       "tableIds": [
         1,
-        3
+        3,
+        4
       ],
       "enumIds": [],
       "tableGroupIds": [],
@@ -222,6 +223,39 @@
       ],
       "schemaId": 1,
       "groupId": null
+    },
+    "4": {
+      "id": 4,
+      "name": "testColWithTypeHaveArgs",
+      "alias": null,
+      "note": null,
+      "partials": [
+        {
+          "order": 1,
+          "token": {
+            "start": {
+              "offset": 1133,
+              "line": 65,
+              "column": 3
+            },
+            "end": {
+              "offset": 1157,
+              "line": 65,
+              "column": 27
+            }
+          },
+          "name": "testColWithTypeHaveArgs",
+          "id": 7
+        }
+      ],
+      "fieldIds": [
+        14,
+        15,
+        16
+      ],
+      "indexIds": [],
+      "schemaId": 1,
+      "groupId": null
     }
   },
   "endpoints": {
@@ -285,45 +319,45 @@
       "unique": true,
       "pk": false,
       "note": null,
+      "injectedPartialId": 6,
       "columnIds": [
         1
       ],
-      "tableId": 3,
-      "injectedPartialId": 6
+      "tableId": 3
     },
     "2": {
       "id": 2,
       "unique": false,
       "pk": true,
       "note": null,
+      "injectedPartialId": 6,
       "columnIds": [
         2
       ],
-      "tableId": 3,
-      "injectedPartialId": 6
+      "tableId": 3
     },
     "3": {
       "id": 3,
       "unique": true,
       "pk": false,
       "note": null,
+      "injectedPartialId": 6,
       "columnIds": [
         3,
         4
       ],
-      "tableId": 3,
-      "injectedPartialId": 6
+      "tableId": 3
     },
     "4": {
       "id": 4,
       "unique": true,
       "pk": false,
       "note": null,
+      "injectedPartialId": 3,
       "columnIds": [
         5
       ],
-      "tableId": 3,
-      "injectedPartialId": 3
+      "tableId": 3
     }
   },
   "indexColumns": {
@@ -589,6 +623,59 @@
       "injectedPartialId": 1,
       "endpointIds": [],
       "tableId": 3,
+      "enumId": null
+    },
+    "14": {
+      "id": 14,
+      "name": "id",
+      "type": {
+        "schemaName": null,
+        "type_name": "int",
+        "args": null
+      },
+      "unique": false,
+      "pk": false,
+      "note": null,
+      "endpointIds": [],
+      "tableId": 4,
+      "enumId": null
+    },
+    "15": {
+      "id": 15,
+      "name": "callExpColInTest1",
+      "type": {
+        "schemaName": null,
+        "type_name": "int(4)",
+        "args": "4"
+      },
+      "unique": false,
+      "pk": false,
+      "note": "simple column with call expression as type",
+      "increment": false,
+      "injectedPartialId": 7,
+      "endpointIds": [],
+      "tableId": 4,
+      "enumId": null
+    },
+    "16": {
+      "id": 16,
+      "name": "callExpColInTest2",
+      "type": {
+        "schemaName": null,
+        "type_name": "decimal(10,2)",
+        "args": "10,2"
+      },
+      "unique": false,
+      "pk": false,
+      "note": "column with type that have arguments and default value being a float number",
+      "dbdefault": {
+        "type": "number",
+        "value": 0.1
+      },
+      "increment": false,
+      "injectedPartialId": 7,
+      "endpointIds": [],
+      "tableId": 4,
       "enumId": null
     }
   },
@@ -1088,6 +1175,96 @@
           "unique": true
         }
       ]
+    },
+    "7": {
+      "id": 7,
+      "name": "testColWithTypeHaveArgs",
+      "note": null,
+      "fields": [
+        {
+          "name": "callExpColInTest1",
+          "type": {
+            "schemaName": null,
+            "type_name": "int(4)",
+            "args": "4"
+          },
+          "token": {
+            "start": {
+              "offset": 874,
+              "line": 59,
+              "column": 3
+            },
+            "end": {
+              "offset": 951,
+              "line": 59,
+              "column": 80
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "increment": false,
+          "unique": false,
+          "note": {
+            "value": "simple column with call expression as type",
+            "token": {
+              "start": {
+                "offset": 900,
+                "line": 59,
+                "column": 29
+              },
+              "end": {
+                "offset": 950,
+                "line": 59,
+                "column": 79
+              }
+            }
+          }
+        },
+        {
+          "name": "callExpColInTest2",
+          "type": {
+            "schemaName": null,
+            "type_name": "decimal(10,2)",
+            "args": "10,2"
+          },
+          "token": {
+            "start": {
+              "offset": 954,
+              "line": 60,
+              "column": 3
+            },
+            "end": {
+              "offset": 1086,
+              "line": 60,
+              "column": 135
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "increment": false,
+          "unique": false,
+          "dbdefault": {
+            "type": "number",
+            "value": 0.1
+          },
+          "note": {
+            "value": "column with type that have arguments and default value being a float number",
+            "token": {
+              "start": {
+                "offset": 1002,
+                "line": 60,
+                "column": 51
+              },
+              "end": {
+                "offset": 1085,
+                "line": 60,
+                "column": 134
+              }
+            }
+          }
+        }
+      ],
+      "indexes": []
     }
   }
 }

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/core",
-  "version": "3.13.3-alpha.0",
+  "version": "3.13.3-alpha.1",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@dbml/parse": "^3.13.3-alpha.0",
+    "@dbml/parse": "^3.13.3-alpha.1",
     "antlr4": "^4.13.1",
     "lodash": "^4.17.15",
     "parsimmon": "^1.13.0",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/core",
-  "version": "3.13.2",
+  "version": "3.13.3-alpha.0",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@dbml/parse": "^3.13.2",
+    "@dbml/parse": "^3.13.3-alpha.0",
     "antlr4": "^4.13.1",
     "lodash": "^4.17.15",
     "parsimmon": "^1.13.0",

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/parse",
-  "version": "3.13.3-alpha.0",
+  "version": "3.13.3-alpha.1",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/parse",
-  "version": "3.13.2",
+  "version": "3.13.3-alpha.0",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-parse/tests/interpreter/input/index_table_partial.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/index_table_partial.in.dbml
@@ -1,0 +1,24 @@
+TablePartial user_partial {
+  full_name varchar
+  email varchar [unique]
+  gender varchar
+  date_of_birth varchar
+  created_at varchar
+  country_code int 
+  active boolean [not null]
+
+  indexes {
+    (id) [unique, note: 'index note']
+    full_name [name: "User Name"]
+    (email,created_at) [type: hash]
+    `now()`
+    (active, `lower(full_name)`)
+    (`getdate()`, `upper(gender)`)
+    (`reverse(country_code)`)
+  }
+}
+
+Table users {
+  id int [pk]
+  ~user_partial
+}

--- a/packages/dbml-parse/tests/interpreter/input/referential_actions.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/referential_actions.in.dbml
@@ -1,5 +1,13 @@
-Table "orders" {
+TablePartial increment_id {
   "id" int [pk, increment]
+}
+
+TablePartial name {
+  "name" varchar(255)
+}
+
+Table "orders" {
+  ~increment_id
   "user_id" int [unique, not null]
   "status" orders_status_enum
   "created_at" varchar(255)
@@ -14,7 +22,7 @@ Table "order_items" {
 
 Table "products" {
   "id" int
-  "name" varchar(255)
+  ~name
   "price" decimal(10,4)
   "created_at" datetime [default: `now()`]
 
@@ -24,8 +32,8 @@ Table "products" {
 }
 
 Table "users" {
-  "id" int [pk, increment]
-  "name" varchar(255)
+  ~increment_id
+  ~name
   "email" varchar(255) [unique]
   "date_of_birth" datetime
   "created_at" datetime [default: `now()`]
@@ -34,7 +42,7 @@ Table "users" {
 
 Table "countries" {
   "code" int [pk]
-  "name" varchar(255)
+  ~name
   "continent_name" varchar(255)
 }
 

--- a/packages/dbml-parse/tests/interpreter/input/table_partial.in.dbml
+++ b/packages/dbml-parse/tests/interpreter/input/table_partial.in.dbml
@@ -31,7 +31,7 @@ Table "user" {
 Table "country" [note: 'name is required'] {
   ~id
   ~sameHeaderColor
-  "name" string [not null]
+  "name" char(255) [not null]
 }
 
 Table "product" [headerColor: #17DACC, note: 'product must have price'] {
@@ -52,7 +52,7 @@ Table "merchant" [headerColor: #08DAFF, note: 'merchants sell a lot'] {
 Table "customer" {
   note: 'a customer is a user?'
   "email" string [ref: - user.email, note: 'the ref of this column should be bound and interpret successfully']
-  }
+}
 
 Ref:"user"."id" < "merchant"."user_id"
 

--- a/packages/dbml-parse/tests/interpreter/output/index_table_partial.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/index_table_partial.out.json
@@ -1,0 +1,553 @@
+{
+  "schemas": [],
+  "tables": [
+    {
+      "name": "users",
+      "schemaName": null,
+      "alias": null,
+      "fields": [
+        {
+          "name": "id",
+          "type": {
+            "schemaName": null,
+            "type_name": "int",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 437,
+              "line": 22,
+              "column": 3
+            },
+            "end": {
+              "offset": 448,
+              "line": 22,
+              "column": 14
+            }
+          },
+          "inline_refs": [],
+          "pk": true,
+          "increment": false,
+          "unique": false
+        }
+      ],
+      "token": {
+        "start": {
+          "offset": 421,
+          "line": 21,
+          "column": 1
+        },
+        "end": {
+          "offset": 466,
+          "line": 24,
+          "column": 2
+        }
+      },
+      "indexes": [],
+      "partials": [
+        {
+          "order": 1,
+          "token": {
+            "start": {
+              "offset": 451,
+              "line": 23,
+              "column": 3
+            },
+            "end": {
+              "offset": 464,
+              "line": 23,
+              "column": 16
+            }
+          },
+          "name": "user_partial"
+        }
+      ]
+    }
+  ],
+  "notes": [],
+  "refs": [],
+  "enums": [],
+  "tableGroups": [],
+  "aliases": [],
+  "project": {},
+  "tablePartials": [
+    {
+      "name": "user_partial",
+      "fields": [
+        {
+          "name": "full_name",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 30,
+              "line": 2,
+              "column": 3
+            },
+            "end": {
+              "offset": 47,
+              "line": 2,
+              "column": 20
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "email",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 50,
+              "line": 3,
+              "column": 3
+            },
+            "end": {
+              "offset": 72,
+              "line": 3,
+              "column": 25
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "increment": false,
+          "unique": true
+        },
+        {
+          "name": "gender",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 75,
+              "line": 4,
+              "column": 3
+            },
+            "end": {
+              "offset": 89,
+              "line": 4,
+              "column": 17
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "date_of_birth",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 92,
+              "line": 5,
+              "column": 3
+            },
+            "end": {
+              "offset": 113,
+              "line": 5,
+              "column": 24
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "created_at",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 116,
+              "line": 6,
+              "column": 3
+            },
+            "end": {
+              "offset": 134,
+              "line": 6,
+              "column": 21
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "country_code",
+          "type": {
+            "schemaName": null,
+            "type_name": "int",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 137,
+              "line": 7,
+              "column": 3
+            },
+            "end": {
+              "offset": 153,
+              "line": 7,
+              "column": 19
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        },
+        {
+          "name": "active",
+          "type": {
+            "schemaName": null,
+            "type_name": "boolean",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 157,
+              "line": 8,
+              "column": 3
+            },
+            "end": {
+              "offset": 182,
+              "line": 8,
+              "column": 28
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "increment": false,
+          "unique": false,
+          "not_null": true
+        }
+      ],
+      "token": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 419,
+          "line": 19,
+          "column": 2
+        }
+      },
+      "indexes": [
+        {
+          "columns": [
+            {
+              "value": "id",
+              "type": "column",
+              "token": {
+                "start": {
+                  "offset": 201,
+                  "line": 11,
+                  "column": 6
+                },
+                "end": {
+                  "offset": 203,
+                  "line": 11,
+                  "column": 8
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 200,
+              "line": 11,
+              "column": 5
+            },
+            "end": {
+              "offset": 233,
+              "line": 11,
+              "column": 38
+            }
+          },
+          "pk": false,
+          "unique": true,
+          "note": {
+            "value": "index note",
+            "token": {
+              "start": {
+                "offset": 214,
+                "line": 11,
+                "column": 19
+              },
+              "end": {
+                "offset": 232,
+                "line": 11,
+                "column": 37
+              }
+            }
+          }
+        },
+        {
+          "columns": [
+            {
+              "value": "full_name",
+              "type": "column",
+              "token": {
+                "start": {
+                  "offset": 238,
+                  "line": 12,
+                  "column": 5
+                },
+                "end": {
+                  "offset": 247,
+                  "line": 12,
+                  "column": 14
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 238,
+              "line": 12,
+              "column": 5
+            },
+            "end": {
+              "offset": 267,
+              "line": 12,
+              "column": 34
+            }
+          },
+          "pk": false,
+          "unique": false,
+          "name": "User Name"
+        },
+        {
+          "columns": [
+            {
+              "value": "email",
+              "type": "column",
+              "token": {
+                "start": {
+                  "offset": 273,
+                  "line": 13,
+                  "column": 6
+                },
+                "end": {
+                  "offset": 278,
+                  "line": 13,
+                  "column": 11
+                }
+              }
+            },
+            {
+              "value": "created_at",
+              "type": "column",
+              "token": {
+                "start": {
+                  "offset": 279,
+                  "line": 13,
+                  "column": 12
+                },
+                "end": {
+                  "offset": 289,
+                  "line": 13,
+                  "column": 22
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 272,
+              "line": 13,
+              "column": 5
+            },
+            "end": {
+              "offset": 303,
+              "line": 13,
+              "column": 36
+            }
+          },
+          "pk": false,
+          "unique": false,
+          "type": "hash"
+        },
+        {
+          "columns": [
+            {
+              "value": "now()",
+              "type": "expression",
+              "token": {
+                "start": {
+                  "offset": 308,
+                  "line": 14,
+                  "column": 5
+                },
+                "end": {
+                  "offset": 315,
+                  "line": 14,
+                  "column": 12
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 308,
+              "line": 14,
+              "column": 5
+            },
+            "end": {
+              "offset": 315,
+              "line": 14,
+              "column": 12
+            }
+          }
+        },
+        {
+          "columns": [
+            {
+              "value": "lower(full_name)",
+              "type": "expression",
+              "token": {
+                "start": {
+                  "offset": 329,
+                  "line": 15,
+                  "column": 14
+                },
+                "end": {
+                  "offset": 347,
+                  "line": 15,
+                  "column": 32
+                }
+              }
+            },
+            {
+              "value": "active",
+              "type": "column",
+              "token": {
+                "start": {
+                  "offset": 321,
+                  "line": 15,
+                  "column": 6
+                },
+                "end": {
+                  "offset": 327,
+                  "line": 15,
+                  "column": 12
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 320,
+              "line": 15,
+              "column": 5
+            },
+            "end": {
+              "offset": 348,
+              "line": 15,
+              "column": 33
+            }
+          }
+        },
+        {
+          "columns": [
+            {
+              "value": "getdate()",
+              "type": "expression",
+              "token": {
+                "start": {
+                  "offset": 354,
+                  "line": 16,
+                  "column": 6
+                },
+                "end": {
+                  "offset": 365,
+                  "line": 16,
+                  "column": 17
+                }
+              }
+            },
+            {
+              "value": "upper(gender)",
+              "type": "expression",
+              "token": {
+                "start": {
+                  "offset": 367,
+                  "line": 16,
+                  "column": 19
+                },
+                "end": {
+                  "offset": 382,
+                  "line": 16,
+                  "column": 34
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 353,
+              "line": 16,
+              "column": 5
+            },
+            "end": {
+              "offset": 383,
+              "line": 16,
+              "column": 35
+            }
+          }
+        },
+        {
+          "columns": [
+            {
+              "value": "reverse(country_code)",
+              "type": "expression",
+              "token": {
+                "start": {
+                  "offset": 389,
+                  "line": 17,
+                  "column": 6
+                },
+                "end": {
+                  "offset": 412,
+                  "line": 17,
+                  "column": 29
+                }
+              }
+            }
+          ],
+          "token": {
+            "start": {
+              "offset": 388,
+              "line": 17,
+              "column": 5
+            },
+            "end": {
+              "offset": 413,
+              "line": 17,
+              "column": 30
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/referential_actions.out.json
@@ -7,30 +7,6 @@
       "alias": null,
       "fields": [
         {
-          "name": "id",
-          "type": {
-            "schemaName": null,
-            "type_name": "int",
-            "args": null
-          },
-          "token": {
-            "start": {
-              "offset": 19,
-              "line": 2,
-              "column": 3
-            },
-            "end": {
-              "offset": 43,
-              "line": 2,
-              "column": 27
-            }
-          },
-          "inline_refs": [],
-          "pk": true,
-          "increment": true,
-          "unique": false
-        },
-        {
           "name": "user_id",
           "type": {
             "schemaName": null,
@@ -39,13 +15,13 @@
           },
           "token": {
             "start": {
-              "offset": 46,
-              "line": 3,
+              "offset": 138,
+              "line": 11,
               "column": 3
             },
             "end": {
-              "offset": 78,
-              "line": 3,
+              "offset": 170,
+              "line": 11,
               "column": 35
             }
           },
@@ -64,13 +40,13 @@
           },
           "token": {
             "start": {
-              "offset": 81,
-              "line": 4,
+              "offset": 173,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "offset": 108,
-              "line": 4,
+              "offset": 200,
+              "line": 12,
               "column": 30
             }
           },
@@ -87,13 +63,13 @@
           },
           "token": {
             "start": {
-              "offset": 111,
-              "line": 5,
+              "offset": 203,
+              "line": 13,
               "column": 3
             },
             "end": {
-              "offset": 136,
-              "line": 5,
+              "offset": 228,
+              "line": 13,
               "column": 28
             }
           },
@@ -104,18 +80,35 @@
       ],
       "token": {
         "start": {
-          "offset": 0,
-          "line": 1,
+          "offset": 103,
+          "line": 9,
           "column": 1
         },
         "end": {
-          "offset": 138,
-          "line": 6,
+          "offset": 230,
+          "line": 14,
           "column": 2
         }
       },
       "indexes": [],
-      "partials": []
+      "partials": [
+        {
+          "order": 0,
+          "token": {
+            "start": {
+              "offset": 122,
+              "line": 10,
+              "column": 3
+            },
+            "end": {
+              "offset": 135,
+              "line": 10,
+              "column": 16
+            }
+          },
+          "name": "increment_id"
+        }
+      ]
     },
     {
       "name": "order_items",
@@ -131,13 +124,13 @@
           },
           "token": {
             "start": {
-              "offset": 164,
-              "line": 9,
+              "offset": 256,
+              "line": 17,
               "column": 3
             },
             "end": {
-              "offset": 178,
-              "line": 9,
+              "offset": 270,
+              "line": 17,
               "column": 17
             }
           },
@@ -154,13 +147,13 @@
           },
           "token": {
             "start": {
-              "offset": 181,
-              "line": 10,
+              "offset": 273,
+              "line": 18,
               "column": 3
             },
             "end": {
-              "offset": 197,
-              "line": 10,
+              "offset": 289,
+              "line": 18,
               "column": 19
             }
           },
@@ -177,13 +170,13 @@
           },
           "token": {
             "start": {
-              "offset": 200,
-              "line": 11,
+              "offset": 292,
+              "line": 19,
               "column": 3
             },
             "end": {
-              "offset": 227,
-              "line": 11,
+              "offset": 319,
+              "line": 19,
               "column": 30
             }
           },
@@ -200,13 +193,13 @@
           },
           "token": {
             "start": {
-              "offset": 230,
-              "line": 12,
+              "offset": 322,
+              "line": 20,
               "column": 3
             },
             "end": {
-              "offset": 257,
-              "line": 12,
+              "offset": 349,
+              "line": 20,
               "column": 30
             }
           },
@@ -222,13 +215,13 @@
       ],
       "token": {
         "start": {
-          "offset": 140,
-          "line": 8,
+          "offset": 232,
+          "line": 16,
           "column": 1
         },
         "end": {
-          "offset": 259,
-          "line": 13,
+          "offset": 351,
+          "line": 21,
           "column": 2
         }
       },
@@ -249,37 +242,14 @@
           },
           "token": {
             "start": {
-              "offset": 282,
-              "line": 16,
+              "offset": 374,
+              "line": 24,
               "column": 3
             },
             "end": {
-              "offset": 290,
-              "line": 16,
+              "offset": 382,
+              "line": 24,
               "column": 11
-            }
-          },
-          "inline_refs": [],
-          "pk": false,
-          "unique": false
-        },
-        {
-          "name": "name",
-          "type": {
-            "schemaName": null,
-            "type_name": "varchar(255)",
-            "args": "255"
-          },
-          "token": {
-            "start": {
-              "offset": 293,
-              "line": 17,
-              "column": 3
-            },
-            "end": {
-              "offset": 312,
-              "line": 17,
-              "column": 22
             }
           },
           "inline_refs": [],
@@ -295,13 +265,13 @@
           },
           "token": {
             "start": {
-              "offset": 315,
-              "line": 18,
+              "offset": 393,
+              "line": 26,
               "column": 3
             },
             "end": {
-              "offset": 336,
-              "line": 18,
+              "offset": 414,
+              "line": 26,
               "column": 24
             }
           },
@@ -318,13 +288,13 @@
           },
           "token": {
             "start": {
-              "offset": 339,
-              "line": 19,
+              "offset": 417,
+              "line": 27,
               "column": 3
             },
             "end": {
-              "offset": 379,
-              "line": 19,
+              "offset": 457,
+              "line": 27,
               "column": 43
             }
           },
@@ -340,13 +310,13 @@
       ],
       "token": {
         "start": {
-          "offset": 261,
-          "line": 15,
+          "offset": 353,
+          "line": 23,
           "column": 1
         },
         "end": {
-          "offset": 418,
-          "line": 24,
+          "offset": 496,
+          "line": 32,
           "column": 2
         }
       },
@@ -358,13 +328,13 @@
               "type": "column",
               "token": {
                 "start": {
-                  "offset": 398,
-                  "line": 22,
+                  "offset": 476,
+                  "line": 30,
                   "column": 6
                 },
                 "end": {
-                  "offset": 400,
-                  "line": 22,
+                  "offset": 478,
+                  "line": 30,
                   "column": 8
                 }
               }
@@ -374,13 +344,13 @@
               "type": "column",
               "token": {
                 "start": {
-                  "offset": 402,
-                  "line": 22,
+                  "offset": 480,
+                  "line": 30,
                   "column": 10
                 },
                 "end": {
-                  "offset": 406,
-                  "line": 22,
+                  "offset": 484,
+                  "line": 30,
                   "column": 14
                 }
               }
@@ -388,13 +358,13 @@
           ],
           "token": {
             "start": {
-              "offset": 397,
-              "line": 22,
+              "offset": 475,
+              "line": 30,
               "column": 5
             },
             "end": {
-              "offset": 412,
-              "line": 22,
+              "offset": 490,
+              "line": 30,
               "column": 20
             }
           },
@@ -402,60 +372,30 @@
           "unique": false
         }
       ],
-      "partials": []
+      "partials": [
+        {
+          "order": 1,
+          "token": {
+            "start": {
+              "offset": 385,
+              "line": 25,
+              "column": 3
+            },
+            "end": {
+              "offset": 390,
+              "line": 25,
+              "column": 8
+            }
+          },
+          "name": "name"
+        }
+      ]
     },
     {
       "name": "users",
       "schemaName": null,
       "alias": null,
       "fields": [
-        {
-          "name": "id",
-          "type": {
-            "schemaName": null,
-            "type_name": "int",
-            "args": null
-          },
-          "token": {
-            "start": {
-              "offset": 438,
-              "line": 27,
-              "column": 3
-            },
-            "end": {
-              "offset": 462,
-              "line": 27,
-              "column": 27
-            }
-          },
-          "inline_refs": [],
-          "pk": true,
-          "increment": true,
-          "unique": false
-        },
-        {
-          "name": "name",
-          "type": {
-            "schemaName": null,
-            "type_name": "varchar(255)",
-            "args": "255"
-          },
-          "token": {
-            "start": {
-              "offset": 465,
-              "line": 28,
-              "column": 3
-            },
-            "end": {
-              "offset": 484,
-              "line": 28,
-              "column": 22
-            }
-          },
-          "inline_refs": [],
-          "pk": false,
-          "unique": false
-        },
         {
           "name": "email",
           "type": {
@@ -465,13 +405,13 @@
           },
           "token": {
             "start": {
-              "offset": 487,
-              "line": 29,
+              "offset": 540,
+              "line": 37,
               "column": 3
             },
             "end": {
-              "offset": 516,
-              "line": 29,
+              "offset": 569,
+              "line": 37,
               "column": 32
             }
           },
@@ -489,13 +429,13 @@
           },
           "token": {
             "start": {
-              "offset": 519,
-              "line": 30,
+              "offset": 572,
+              "line": 38,
               "column": 3
             },
             "end": {
-              "offset": 543,
-              "line": 30,
+              "offset": 596,
+              "line": 38,
               "column": 27
             }
           },
@@ -512,13 +452,13 @@
           },
           "token": {
             "start": {
-              "offset": 546,
-              "line": 31,
+              "offset": 599,
+              "line": 39,
               "column": 3
             },
             "end": {
-              "offset": 586,
-              "line": 31,
+              "offset": 639,
+              "line": 39,
               "column": 43
             }
           },
@@ -540,13 +480,13 @@
           },
           "token": {
             "start": {
-              "offset": 589,
-              "line": 32,
+              "offset": 642,
+              "line": 40,
               "column": 3
             },
             "end": {
-              "offset": 618,
-              "line": 32,
+              "offset": 671,
+              "line": 40,
               "column": 32
             }
           },
@@ -559,18 +499,51 @@
       ],
       "token": {
         "start": {
-          "offset": 420,
-          "line": 26,
+          "offset": 498,
+          "line": 34,
           "column": 1
         },
         "end": {
-          "offset": 620,
-          "line": 33,
+          "offset": 673,
+          "line": 41,
           "column": 2
         }
       },
       "indexes": [],
-      "partials": []
+      "partials": [
+        {
+          "order": 0,
+          "token": {
+            "start": {
+              "offset": 516,
+              "line": 35,
+              "column": 3
+            },
+            "end": {
+              "offset": 529,
+              "line": 35,
+              "column": 16
+            }
+          },
+          "name": "increment_id"
+        },
+        {
+          "order": 1,
+          "token": {
+            "start": {
+              "offset": 532,
+              "line": 36,
+              "column": 3
+            },
+            "end": {
+              "offset": 537,
+              "line": 36,
+              "column": 8
+            }
+          },
+          "name": "name"
+        }
+      ]
     },
     {
       "name": "countries",
@@ -586,42 +559,19 @@
           },
           "token": {
             "start": {
-              "offset": 644,
-              "line": 36,
+              "offset": 697,
+              "line": 44,
               "column": 3
             },
             "end": {
-              "offset": 659,
-              "line": 36,
+              "offset": 712,
+              "line": 44,
               "column": 18
             }
           },
           "inline_refs": [],
           "pk": true,
           "increment": false,
-          "unique": false
-        },
-        {
-          "name": "name",
-          "type": {
-            "schemaName": null,
-            "type_name": "varchar(255)",
-            "args": "255"
-          },
-          "token": {
-            "start": {
-              "offset": 662,
-              "line": 37,
-              "column": 3
-            },
-            "end": {
-              "offset": 681,
-              "line": 37,
-              "column": 22
-            }
-          },
-          "inline_refs": [],
-          "pk": false,
           "unique": false
         },
         {
@@ -633,13 +583,13 @@
           },
           "token": {
             "start": {
-              "offset": 684,
-              "line": 38,
+              "offset": 723,
+              "line": 46,
               "column": 3
             },
             "end": {
-              "offset": 713,
-              "line": 38,
+              "offset": 752,
+              "line": 46,
               "column": 32
             }
           },
@@ -650,18 +600,35 @@
       ],
       "token": {
         "start": {
-          "offset": 622,
-          "line": 35,
+          "offset": 675,
+          "line": 43,
           "column": 1
         },
         "end": {
-          "offset": 715,
-          "line": 39,
+          "offset": 754,
+          "line": 47,
           "column": 2
         }
       },
       "indexes": [],
-      "partials": []
+      "partials": [
+        {
+          "order": 1,
+          "token": {
+            "start": {
+              "offset": 715,
+              "line": 45,
+              "column": 3
+            },
+            "end": {
+              "offset": 720,
+              "line": 45,
+              "column": 8
+            }
+          },
+          "name": "name"
+        }
+      ]
     }
   ],
   "notes": [],
@@ -669,13 +636,13 @@
     {
       "token": {
         "start": {
-          "offset": 717,
-          "line": 41,
+          "offset": 756,
+          "line": 49,
           "column": 1
         },
         "end": {
-          "offset": 773,
-          "line": 41,
+          "offset": 812,
+          "line": 49,
           "column": 57
         }
       },
@@ -692,13 +659,13 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 721,
-              "line": 41,
+              "offset": 760,
+              "line": 49,
               "column": 5
             },
             "end": {
-              "offset": 733,
-              "line": 41,
+              "offset": 772,
+              "line": 49,
               "column": 17
             }
           }
@@ -712,13 +679,13 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 736,
-              "line": 41,
+              "offset": 775,
+              "line": 49,
               "column": 20
             },
             "end": {
-              "offset": 754,
-              "line": 41,
+              "offset": 793,
+              "line": 49,
               "column": 38
             }
           }
@@ -728,13 +695,13 @@
     {
       "token": {
         "start": {
-          "offset": 775,
-          "line": 43,
+          "offset": 814,
+          "line": 51,
           "column": 1
         },
         "end": {
-          "offset": 837,
-          "line": 43,
+          "offset": 876,
+          "line": 51,
           "column": 63
         }
       },
@@ -751,13 +718,13 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 779,
-              "line": 43,
+              "offset": 818,
+              "line": 51,
               "column": 5
             },
             "end": {
-              "offset": 792,
-              "line": 43,
+              "offset": 831,
+              "line": 51,
               "column": 18
             }
           }
@@ -771,13 +738,13 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 795,
-              "line": 43,
+              "offset": 834,
+              "line": 51,
               "column": 21
             },
             "end": {
-              "offset": 819,
-              "line": 43,
+              "offset": 858,
+              "line": 51,
               "column": 45
             }
           }
@@ -787,13 +754,13 @@
     {
       "token": {
         "start": {
-          "offset": 839,
-          "line": 45,
+          "offset": 878,
+          "line": 53,
           "column": 1
         },
         "end": {
-          "offset": 934,
-          "line": 45,
+          "offset": 973,
+          "line": 53,
           "column": 96
         }
       },
@@ -811,13 +778,13 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 843,
-              "line": 45,
+              "offset": 882,
+              "line": 53,
               "column": 5
             },
             "end": {
-              "offset": 868,
-              "line": 45,
+              "offset": 907,
+              "line": 53,
               "column": 30
             }
           }
@@ -832,13 +799,13 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 871,
-              "line": 45,
+              "offset": 910,
+              "line": 53,
               "column": 33
             },
             "end": {
-              "offset": 915,
-              "line": 45,
+              "offset": 954,
+              "line": 53,
               "column": 77
             }
           }
@@ -848,13 +815,13 @@
     {
       "token": {
         "start": {
-          "offset": 936,
-          "line": 47,
+          "offset": 975,
+          "line": 55,
           "column": 1
         },
         "end": {
-          "offset": 1003,
-          "line": 47,
+          "offset": 1042,
+          "line": 55,
           "column": 68
         }
       },
@@ -871,13 +838,13 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 940,
-              "line": 47,
+              "offset": 979,
+              "line": 55,
               "column": 5
             },
             "end": {
-              "offset": 958,
-              "line": 47,
+              "offset": 997,
+              "line": 55,
               "column": 23
             }
           }
@@ -891,13 +858,13 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 961,
-              "line": 47,
+              "offset": 1000,
+              "line": 55,
               "column": 26
             },
             "end": {
-              "offset": 983,
-              "line": 47,
+              "offset": 1022,
+              "line": 55,
               "column": 48
             }
           }
@@ -909,5 +876,89 @@
   "tableGroups": [],
   "aliases": [],
   "project": {},
-  "tablePartials": []
+  "tablePartials": [
+    {
+      "name": "increment_id",
+      "fields": [
+        {
+          "name": "id",
+          "type": {
+            "schemaName": null,
+            "type_name": "int",
+            "args": null
+          },
+          "token": {
+            "start": {
+              "offset": 30,
+              "line": 2,
+              "column": 3
+            },
+            "end": {
+              "offset": 54,
+              "line": 2,
+              "column": 27
+            }
+          },
+          "inline_refs": [],
+          "pk": true,
+          "increment": true,
+          "unique": false
+        }
+      ],
+      "token": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 56,
+          "line": 3,
+          "column": 2
+        }
+      },
+      "indexes": []
+    },
+    {
+      "name": "name",
+      "fields": [
+        {
+          "name": "name",
+          "type": {
+            "schemaName": null,
+            "type_name": "varchar(255)",
+            "args": "255"
+          },
+          "token": {
+            "start": {
+              "offset": 80,
+              "line": 6,
+              "column": 3
+            },
+            "end": {
+              "offset": 99,
+              "line": 6,
+              "column": 22
+            }
+          },
+          "inline_refs": [],
+          "pk": false,
+          "unique": false
+        }
+      ],
+      "token": {
+        "start": {
+          "offset": 58,
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "offset": 101,
+          "line": 7,
+          "column": 2
+        }
+      },
+      "indexes": []
+    }
+  ]
 }

--- a/packages/dbml-parse/tests/interpreter/output/table_partial.out.json
+++ b/packages/dbml-parse/tests/interpreter/output/table_partial.out.json
@@ -153,8 +153,8 @@
           "name": "name",
           "type": {
             "schemaName": null,
-            "type_name": "string",
-            "args": null
+            "type_name": "char(255)",
+            "args": "255"
           },
           "token": {
             "start": {
@@ -163,9 +163,9 @@
               "column": 3
             },
             "end": {
-              "offset": 630,
+              "offset": 633,
               "line": 34,
-              "column": 27
+              "column": 30
             }
           },
           "inline_refs": [],
@@ -182,7 +182,7 @@
           "column": 1
         },
         "end": {
-          "offset": 632,
+          "offset": 635,
           "line": 35,
           "column": 2
         }
@@ -252,12 +252,12 @@
           },
           "token": {
             "start": {
-              "offset": 716,
+              "offset": 719,
               "line": 39,
               "column": 3
             },
             "end": {
-              "offset": 729,
+              "offset": 732,
               "line": 39,
               "column": 16
             }
@@ -275,12 +275,12 @@
           },
           "token": {
             "start": {
-              "offset": 732,
+              "offset": 735,
               "line": 40,
               "column": 3
             },
             "end": {
-              "offset": 758,
+              "offset": 761,
               "line": 40,
               "column": 29
             }
@@ -294,12 +294,12 @@
       ],
       "token": {
         "start": {
-          "offset": 634,
+          "offset": 637,
           "line": 37,
           "column": 1
         },
         "end": {
-          "offset": 779,
+          "offset": 782,
           "line": 42,
           "column": 2
         }
@@ -310,12 +310,12 @@
           "order": 0,
           "token": {
             "start": {
-              "offset": 710,
+              "offset": 713,
               "line": 38,
               "column": 3
             },
             "end": {
-              "offset": 713,
+              "offset": 716,
               "line": 38,
               "column": 6
             }
@@ -326,12 +326,12 @@
           "order": 3,
           "token": {
             "start": {
-              "offset": 761,
+              "offset": 764,
               "line": 41,
               "column": 3
             },
             "end": {
-              "offset": 777,
+              "offset": 780,
               "line": 41,
               "column": 19
             }
@@ -344,12 +344,12 @@
         "value": "product must have price",
         "token": {
           "start": {
-            "offset": 673,
+            "offset": 676,
             "line": 37,
             "column": 40
           },
           "end": {
-            "offset": 704,
+            "offset": 707,
             "line": 37,
             "column": 71
           }
@@ -370,12 +370,12 @@
           },
           "token": {
             "start": {
-              "offset": 861,
+              "offset": 864,
               "line": 46,
               "column": 3
             },
             "end": {
-              "offset": 874,
+              "offset": 877,
               "line": 46,
               "column": 16
             }
@@ -393,12 +393,12 @@
           },
           "token": {
             "start": {
-              "offset": 877,
+              "offset": 880,
               "line": 47,
               "column": 3
             },
             "end": {
-              "offset": 893,
+              "offset": 896,
               "line": 47,
               "column": 19
             }
@@ -416,12 +416,12 @@
           },
           "token": {
             "start": {
-              "offset": 915,
+              "offset": 918,
               "line": 49,
               "column": 3
             },
             "end": {
-              "offset": 931,
+              "offset": 934,
               "line": 49,
               "column": 19
             }
@@ -433,12 +433,12 @@
       ],
       "token": {
         "start": {
-          "offset": 781,
+          "offset": 784,
           "line": 44,
           "column": 1
         },
         "end": {
-          "offset": 933,
+          "offset": 936,
           "line": 50,
           "column": 2
         }
@@ -449,12 +449,12 @@
           "order": 0,
           "token": {
             "start": {
-              "offset": 855,
+              "offset": 858,
               "line": 45,
               "column": 3
             },
             "end": {
-              "offset": 858,
+              "offset": 861,
               "line": 45,
               "column": 6
             }
@@ -465,12 +465,12 @@
           "order": 3,
           "token": {
             "start": {
-              "offset": 896,
+              "offset": 899,
               "line": 48,
               "column": 3
             },
             "end": {
-              "offset": 912,
+              "offset": 915,
               "line": 48,
               "column": 19
             }
@@ -483,12 +483,12 @@
         "value": "merchants sell a lot",
         "token": {
           "start": {
-            "offset": 821,
+            "offset": 824,
             "line": 44,
             "column": 41
           },
           "end": {
-            "offset": 849,
+            "offset": 852,
             "line": 44,
             "column": 69
           }
@@ -509,12 +509,12 @@
           },
           "token": {
             "start": {
-              "offset": 988,
+              "offset": 991,
               "line": 54,
               "column": 3
             },
             "end": {
-              "offset": 1097,
+              "offset": 1100,
               "line": 54,
               "column": 112
             }
@@ -529,12 +529,12 @@
               "relation": "-",
               "token": {
                 "start": {
-                  "offset": 1004,
+                  "offset": 1007,
                   "line": 54,
                   "column": 19
                 },
                 "end": {
-                  "offset": 1021,
+                  "offset": 1024,
                   "line": 54,
                   "column": 36
                 }
@@ -548,12 +548,12 @@
             "value": "the ref of this column should be bound and interpret successfully",
             "token": {
               "start": {
-                "offset": 1023,
+                "offset": 1026,
                 "line": 54,
                 "column": 38
               },
               "end": {
-                "offset": 1096,
+                "offset": 1099,
                 "line": 54,
                 "column": 111
               }
@@ -563,14 +563,14 @@
       ],
       "token": {
         "start": {
-          "offset": 935,
+          "offset": 938,
           "line": 52,
           "column": 1
         },
         "end": {
-          "offset": 1101,
+          "offset": 1102,
           "line": 55,
-          "column": 4
+          "column": 2
         }
       },
       "indexes": [],
@@ -579,12 +579,12 @@
         "value": "a customer is a user?",
         "token": {
           "start": {
-            "offset": 956,
+            "offset": 959,
             "line": 53,
             "column": 3
           },
           "end": {
-            "offset": 985,
+            "offset": 988,
             "line": 53,
             "column": 32
           }
@@ -599,12 +599,12 @@
       "schemaName": null,
       "token": {
         "start": {
-          "offset": 1004,
+          "offset": 1007,
           "line": 54,
           "column": 19
         },
         "end": {
-          "offset": 1021,
+          "offset": 1024,
           "line": 54,
           "column": 36
         }
@@ -619,12 +619,12 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 1004,
+              "offset": 1007,
               "line": 54,
               "column": 19
             },
             "end": {
-              "offset": 1021,
+              "offset": 1024,
               "line": 54,
               "column": 36
             }
@@ -638,12 +638,12 @@
           ],
           "token": {
             "start": {
-              "offset": 988,
+              "offset": 991,
               "line": 54,
               "column": 3
             },
             "end": {
-              "offset": 1097,
+              "offset": 1100,
               "line": 54,
               "column": 112
             }
@@ -655,12 +655,12 @@
     {
       "token": {
         "start": {
-          "offset": 1103,
+          "offset": 1104,
           "line": 57,
           "column": 1
         },
         "end": {
-          "offset": 1141,
+          "offset": 1142,
           "line": 57,
           "column": 39
         }
@@ -677,12 +677,12 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 1107,
+              "offset": 1108,
               "line": 57,
               "column": 5
             },
             "end": {
-              "offset": 1118,
+              "offset": 1119,
               "line": 57,
               "column": 16
             }
@@ -697,12 +697,12 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1121,
+              "offset": 1122,
               "line": 57,
               "column": 19
             },
             "end": {
-              "offset": 1141,
+              "offset": 1142,
               "line": 57,
               "column": 39
             }
@@ -713,12 +713,12 @@
     {
       "token": {
         "start": {
-          "offset": 1143,
+          "offset": 1144,
           "line": 59,
           "column": 1
         },
         "end": {
-          "offset": 1187,
+          "offset": 1188,
           "line": 59,
           "column": 45
         }
@@ -735,12 +735,12 @@
           "relation": "1",
           "token": {
             "start": {
-              "offset": 1147,
+              "offset": 1148,
               "line": 59,
               "column": 5
             },
             "end": {
-              "offset": 1161,
+              "offset": 1162,
               "line": 59,
               "column": 19
             }
@@ -755,12 +755,12 @@
           "relation": "*",
           "token": {
             "start": {
-              "offset": 1164,
+              "offset": 1165,
               "line": 59,
               "column": 22
             },
             "end": {
-              "offset": 1187,
+              "offset": 1188,
               "line": 59,
               "column": 45
             }


### PR DESCRIPTION
## Summary
* Fix TablePartial not handling column type that have arguments (fix DBX-5987)
![image](https://github.com/user-attachments/assets/f047bf66-0c96-4091-b6ac-4d8bd2512cd6)
  * `function processColumnType` in TablePartial extracted the name from the original typeNode, which is `CallExpressionNode` for column type with arguments
  * It should have extracted the callee of the call expression instead

* Fix ESLint for
  * `interpreter/elementInterpreter/table.ts`
  * `interpreter/elementInterpreter/tablePartial.ts`
  * `interpreter/utils.ts`

## Issue
(issue link here)

## Lasting Changes (Technical)

* Moved `function processDefaultValue` and `function processColumnType` from `table.ts` and `tablePartial.ts` to `utils.ts` as those 2 files use the same helper functions

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review