### PR TITLE
fix: remove `lodash-es` from external config and update lodash import to have better tree shaking

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.13.8",
+  "version": "3.13.9-alpha.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/cli",
-  "version": "3.13.8",
+  "version": "3.13.9-alpha.0",
   "description": "",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -26,8 +26,8 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.21.0",
-    "@dbml/connector": "^3.13.8",
-    "@dbml/core": "^3.13.8",
+    "@dbml/connector": "^3.13.9-alpha.0",
+    "@dbml/core": "^3.13.9-alpha.0",
     "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",

--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/connector",
-  "version": "3.13.8",
+  "version": "3.13.9-alpha.0",
   "description": "This package was created to fetch the schema JSON from many kind of databases.",
   "author": "huy.phung.sw@gmail.com",
   "license": "MIT",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/core",
-  "version": "3.13.8",
+  "version": "3.13.9-alpha.0",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@dbml/parse": "^3.13.8",
+    "@dbml/parse": "^3.13.9-alpha.0",
     "antlr4": "^4.13.1",
     "lodash": "^4.17.15",
     "parsimmon": "^1.13.0",

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/parse",
-  "version": "3.13.8",
+  "version": "3.13.9-alpha.0",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-parse/src/lib/analyzer/binder/elementBinder/elementBinder.ts
+++ b/packages/dbml-parse/src/lib/analyzer/binder/elementBinder/elementBinder.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last } from 'lodash';
 import { isTupleOfVariables } from '../../validator/utils';
 import {
   BlockExpressionNode,
@@ -108,7 +108,7 @@ export default abstract class ElementBinder {
 
   private bindSubfield (sub: FunctionApplicationNode) {
     const args = [sub.callee, ...sub.args];
-    const maybeSettingList = _.last(args);
+    const maybeSettingList = last(args);
     if (maybeSettingList instanceof ListExpressionNode) {
       args.pop();
       this.bindSettingList(maybeSettingList, this.subfield.settingList);

--- a/packages/dbml-parse/src/lib/analyzer/utils.ts
+++ b/packages/dbml-parse/src/lib/analyzer/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last } from 'lodash';
 import { None, Option, Some } from '../option';
 import {
   ElementDeclarationNode,
@@ -97,7 +97,7 @@ export function destructureComplexTuple(
   const variables: string[] = [];
   let tupleElements: string[] | undefined;
 
-  if (!isExpressionAVariableNode(_.last(fragments))) {
+  if (!isExpressionAVariableNode(last(fragments))) {
     const topFragment = fragments.pop()!;
     if (isTupleOfVariables(topFragment)) {
       tupleElements = topFragment.elementList.map((e) =>

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/enum.ts
@@ -1,3 +1,4 @@
+import { last, partition } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, ListExpressionNode, SyntaxNode } from '../../../parser/nodes';
@@ -7,7 +8,6 @@ import { ElementValidator } from '../types';
 import { aggregateSettingList, isValidName, pickValidator, registerSchemaStack } from '../utils';
 import { createEnumFieldSymbolIndex, createEnumSymbolIndex } from '../../../analyzer/symbol/symbolIndex';
 import { destructureComplexVariable, extractVarNameFromPrimaryVariable } from '../../../analyzer/utils';
-import _ from 'lodash';
 import SymbolTable from '../../../analyzer/symbol/symbolTable';
 import { EnumFieldSymbol, EnumSymbol } from '../../../analyzer/symbol/symbols';
 
@@ -89,7 +89,7 @@ export default class EnumValidator implements ElementValidator {
       return this.validateFields([body]);
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [...this.validateFields(fields as FunctionApplicationNode[]), ...this.validateSubElements(subs as ElementDeclarationNode[])]
   }
 
@@ -106,8 +106,8 @@ export default class EnumValidator implements ElementValidator {
       }
       
       const args = [...field.args];
-      if (_.last(args) instanceof ListExpressionNode) {
-        errors.push(...this.validateFieldSettings(_.last(args) as ListExpressionNode));
+      if (last(args) instanceof ListExpressionNode) {
+        errors.push(...this.validateFieldSettings(last(args) as ListExpressionNode));
         args.pop();
       } else if (args[0] instanceof ListExpressionNode) {
         errors.push(...this.validateFieldSettings(args[0]));

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/indexes.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/indexes.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last, partition } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import {
@@ -87,7 +87,7 @@ export default class IndexesValidator implements ElementValidator {
       return [new CompileError(CompileErrorCode.UNEXPECTED_SIMPLE_BODY, 'An Indexes must have a complex body', body)];
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [...this.validateFields(fields as FunctionApplicationNode[]), ...this.validateSubElements(subs as ElementDeclarationNode[])]
   }
 
@@ -99,7 +99,7 @@ export default class IndexesValidator implements ElementValidator {
 
       const errors: CompileError[] = [];
       const args = [field.callee, ...field.args];
-      if (_.last(args) instanceof ListExpressionNode) {
+      if (last(args) instanceof ListExpressionNode) {
         errors.push(...this.validateFieldSetting(args.pop() as ListExpressionNode));
       }
 

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/note.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/note.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import _ from 'lodash';
+import { partition } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import {
@@ -112,7 +112,7 @@ export default class NoteValidator implements ElementValidator {
       return this.validateFields([body]);
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [...this.validateFields(fields as FunctionApplicationNode[]), ...this.validateSubElements(subs as ElementDeclarationNode[])];
   }
 

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/project.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/project.ts
@@ -1,10 +1,10 @@
+import { partition } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, ListExpressionNode, SyntaxNode } from '../../../parser/nodes';
 import { SyntaxToken } from '../../../lexer/tokens';
 import { ElementValidator } from '../types';
 import { isSimpleName, pickValidator } from '../utils';
-import _ from 'lodash';
 import SymbolTable from '../../../analyzer/symbol/symbolTable';
 
 export default class ProjectValidator implements ElementValidator {
@@ -66,7 +66,7 @@ export default class ProjectValidator implements ElementValidator {
       return [new CompileError(CompileErrorCode.UNEXPECTED_SIMPLE_BODY, 'A Project\'s body must be a block', body)];
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [
       ...fields.map((field) => new CompileError(CompileErrorCode.INVALID_PROJECT_FIELD, 'A Project can not have inline fields', field)),
       ...this.validateSubElements(subs as ElementDeclarationNode[])

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/ref.ts
@@ -1,3 +1,4 @@
+import { partition, last } from 'lodash';
 import { SyntaxToken, SyntaxTokenKind } from '../../../lexer/tokens';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
@@ -8,10 +9,8 @@ import {
 } from '../../../parser/utils';
 import { ElementValidator } from '../types';
 import { aggregateSettingList, isSimpleName, isValidColor, pickValidator } from '../utils';
-import _ from 'lodash';
-import { getElementKind, isBinaryRelationship, isEqualTupleOperands } from '../../../analyzer/utils';
+import { isBinaryRelationship, isEqualTupleOperands } from '../../../analyzer/utils';
 import SymbolTable from '../../../analyzer/symbol/symbolTable';
-import { ElementKind } from '../../../analyzer/types';
 
 export default class RefValidator implements ElementValidator {
   private declarationNode: ElementDeclarationNode & { type: SyntaxToken; };
@@ -71,7 +70,7 @@ export default class RefValidator implements ElementValidator {
       return this.validateFields([body]);
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [...this.validateFields(fields as FunctionApplicationNode[]), ...this.validateSubElements(subs as ElementDeclarationNode[])]
   }
 
@@ -95,8 +94,8 @@ export default class RefValidator implements ElementValidator {
       }
 
       const args = [...field.args];
-      if (_.last(args) instanceof ListExpressionNode) {
-        const errs = this.validateFieldSettings(_.last(args) as ListExpressionNode);
+      if (last(args) instanceof ListExpressionNode) {
+        const errs = this.validateFieldSettings(last(args) as ListExpressionNode);
         errors.push(...errs);
         args.pop();
       } else if (args[0] instanceof ListExpressionNode) {

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/table.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/table.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import _, { forIn } from 'lodash';
+import { last, forIn } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import {
@@ -275,7 +275,7 @@ export default class TableValidator implements ElementValidator {
     }
 
     let settingList: ListExpressionNode | undefined;
-    if (_.last(parts) instanceof ListExpressionNode) {
+    if (last(parts) instanceof ListExpressionNode) {
       settingList = parts.pop() as ListExpressionNode;
     }
 

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/tableGroup.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/tableGroup.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import _ from 'lodash';
+import { forIn, partition } from 'lodash';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import {
   isSimpleName, pickValidator, registerSchemaStack, aggregateSettingList, isValidColor
@@ -102,7 +102,7 @@ export default class TableGroupValidator implements ElementValidator {
     const errors = aggReport.getErrors();
     const settingMap = aggReport.getValue();
 
-    _.forIn(settingMap, (attrs, name) => {
+    forIn(settingMap, (attrs, name) => {
       switch (name) {
         case 'color':
           if (attrs.length > 1) {
@@ -163,7 +163,7 @@ export default class TableGroupValidator implements ElementValidator {
       )];
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [
       ...this.validateFields(fields as FunctionApplicationNode[]),
       ...this.validateSubElements(subs as ElementDeclarationNode[]),

--- a/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/tablePartial.ts
+++ b/packages/dbml-parse/src/lib/analyzer/validator/elementValidators/tablePartial.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import _, { forIn, last } from 'lodash';
+import { partition, forIn, last } from 'lodash';
 import SymbolFactory from '../../symbol/factory';
 import { CompileError, CompileErrorCode } from '../../../errors';
 import {
@@ -165,7 +165,7 @@ export default class TablePartialValidator implements ElementValidator {
       return [new CompileError(CompileErrorCode.UNEXPECTED_SIMPLE_BODY, 'A TablePartial\'s body must be a block', body)];
     }
 
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
     return [
       ...this.validateFields(fields as FunctionApplicationNode[]),
       ...this.validateSubElements(subs as ElementDeclarationNode[]),
@@ -233,7 +233,7 @@ export default class TablePartialValidator implements ElementValidator {
     if (parts.length === 0) return [];
 
     let settingList: ListExpressionNode | undefined;
-    if (_.last(parts) instanceof ListExpressionNode) {
+    if (last(parts) instanceof ListExpressionNode) {
       settingList = parts.pop() as ListExpressionNode;
     }
 

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/sticky_note.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/sticky_note.ts
@@ -1,9 +1,9 @@
+import { partition, get } from 'lodash';
 import { ElementInterpreter, InterpreterDatabase, Note } from '../types';
 import { BlockExpressionNode, ElementDeclarationNode, FunctionApplicationNode, ListExpressionNode, SyntaxNode } from '../../parser/nodes';
 import { extractColor, extractElementName, getTokenPosition, normalizeNoteContent } from '../utils';
 import { CompileError, CompileErrorCode } from '../../errors';
 import { aggregateSettingList } from '../../analyzer/validator/utils';
-import _ from 'lodash';
 
 export class StickyNoteInterpreter implements ElementInterpreter {
   private declarationNode: ElementDeclarationNode;
@@ -46,7 +46,7 @@ export class StickyNoteInterpreter implements ElementInterpreter {
   }
 
   private interpretBody(body: BlockExpressionNode): CompileError[] {
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode);
 
     if (fields.length !== 1 || subs.length > 0) {
       return [
@@ -59,7 +59,7 @@ export class StickyNoteInterpreter implements ElementInterpreter {
 
 
   private interpretNote(note: FunctionApplicationNode): CompileError[] {
-    const noteContent = _.get(note, 'callee.expression.literal.value', '');
+    const noteContent = get(note, 'callee.expression.literal.value', '');
 
     this.note.content = normalizeNoteContent(noteContent);
     return [];

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/table.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { partition, last } from 'lodash';
 import {
   Column, ElementInterpreter, Index, InlineRef,
   InterpreterDatabase, Table, TablePartialInjection,
@@ -126,7 +126,7 @@ export class TableInterpreter implements ElementInterpreter {
   }
 
   private interpretBody (body: BlockExpressionNode): CompileError[] {
-    const [fields, subs] = _.partition(body.body, (e) => e instanceof FunctionApplicationNode || e instanceof PartialInjectionNode);
+    const [fields, subs] = partition(body.body, (e) => e instanceof FunctionApplicationNode || e instanceof PartialInjectionNode);
     return [
       ...this.interpretFields(fields as (FunctionApplicationNode | PartialInjectionNode)[]),
       ...this.interpretSubElements(subs as ElementDeclarationNode[]),
@@ -203,7 +203,7 @@ export class TableInterpreter implements ElementInterpreter {
     column.inline_refs = [];
 
     const settings = field.args.slice(1);
-    if (_.last(settings) instanceof ListExpressionNode) {
+    if (last(settings) instanceof ListExpressionNode) {
       const settingMap = aggregateSettingList(settings.pop() as ListExpressionNode).getValue();
       column.pk = !!settingMap[SettingName.PK]?.length || !!settingMap[SettingName.PKey]?.length;
       column.increment = !!settingMap[SettingName.Increment]?.length;
@@ -299,7 +299,7 @@ export class TableInterpreter implements ElementInterpreter {
       const indexField = _indexField as FunctionApplicationNode;
       index.token = getTokenPosition(indexField);
       const args = [indexField.callee!, ...indexField.args];
-      if (_.last(args) instanceof ListExpressionNode) {
+      if (last(args) instanceof ListExpressionNode) {
         const settingMap = aggregateSettingList(args.pop() as ListExpressionNode).getValue();
         index.pk = !!settingMap[SettingName.PK]?.length;
         index.unique = !!settingMap[SettingName.Unique]?.length;

--- a/packages/dbml-parse/src/lib/interpreter/elementInterpreter/tablePartial.ts
+++ b/packages/dbml-parse/src/lib/interpreter/elementInterpreter/tablePartial.ts
@@ -1,4 +1,4 @@
-import _, { head, partition } from 'lodash';
+import { last, head, partition } from 'lodash';
 import {
   Column, ElementInterpreter, Index, InlineRef,
   InterpreterDatabase, TablePartial,
@@ -138,7 +138,7 @@ export class TablePartialInterpreter implements ElementInterpreter {
     column.inline_refs = [];
 
     const settings = field.args.slice(1);
-    if (_.last(settings) instanceof ListExpressionNode) {
+    if (last(settings) instanceof ListExpressionNode) {
       const settingMap = aggregateSettingList(settings.pop() as ListExpressionNode).getValue();
       column.pk = !!settingMap[SettingName.PK]?.length || !!settingMap[SettingName.PKey]?.length;
       column.increment = !!settingMap[SettingName.Increment]?.length;
@@ -223,7 +223,7 @@ export class TablePartialInterpreter implements ElementInterpreter {
       const indexField = _indexField as FunctionApplicationNode;
       index.token = getTokenPosition(indexField);
       const args = [indexField.callee!, ...indexField.args];
-      if (_.last(args) instanceof ListExpressionNode) {
+      if (last(args) instanceof ListExpressionNode) {
         const settingMap = aggregateSettingList(args.pop() as ListExpressionNode).getValue();
         index.pk = !!settingMap[SettingName.PK]?.length;
         index.unique = !!settingMap[SettingName.Unique]?.length;

--- a/packages/dbml-parse/src/lib/interpreter/utils.ts
+++ b/packages/dbml-parse/src/lib/interpreter/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { zip } from 'lodash';
 import { ColumnSymbol } from '../analyzer/symbol/symbols';
 import {
   destructureComplexTuple, destructureComplexVariable, destructureMemberAccessExpression, extractQuotedStringToken,
@@ -6,7 +6,7 @@ import {
 } from '../analyzer/utils';
 import {
   ArrayNode, CallExpressionNode, FunctionExpressionNode, LiteralNode,
-  PrefixExpressionNode, PrimaryExpressionNode, SyntaxNode, TupleExpressionNode,
+  PrimaryExpressionNode, SyntaxNode, TupleExpressionNode,
 } from '../parser/nodes';
 import {
   ColumnType, RelationCardinality, Table, TokenPosition,
@@ -14,7 +14,6 @@ import {
 import { SyntaxTokenKind } from '../lexer/tokens';
 import { isExpressionAnIdentifierNode, isExpressionAQuotedString } from '../parser/utils';
 import { isExpressionANumber } from '../analyzer/validator/utils';
-import { NUMERIC_LITERAL_PREFIX } from '../../constants';
 import Report from '../report';
 import { CompileError, CompileErrorCode } from '../errors';
 import { getNumberTextFromExpression, parseNumber } from '../utils';
@@ -125,7 +124,7 @@ export function isSameEndpoint (sym1: ColumnSymbol | ColumnSymbol[], sym2: Colum
   if (Array.isArray(sym1)) {
     const firstIds = sym1.map(({ id }) => id).sort();
     const secondIds = (sym2 as ColumnSymbol[]).map(({ id }) => id).sort();
-    return _.zip(firstIds, secondIds).every(([first, second]) => first === second);
+    return zip(firstIds, secondIds).every(([first, second]) => first === second);
   }
 
   const firstId = sym1.id;

--- a/packages/dbml-parse/src/lib/parser/contextStack.ts
+++ b/packages/dbml-parse/src/lib/parser/contextStack.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last } from 'lodash';
 import { SyntaxToken, SyntaxTokenKind } from '../lexer/tokens';
 
 export const enum ParsingContext {
@@ -45,7 +45,7 @@ export class ParsingContextStack {
   }
 
   top(): ParsingContext | undefined {
-    return _.last(this.stack);
+    return last(this.stack);
   }
 
   isWithinGroupExpressionContext(): boolean {

--- a/packages/dbml-parse/src/lib/parser/nodes.ts
+++ b/packages/dbml-parse/src/lib/parser/nodes.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { flatten, zip } from 'lodash';
 import { SyntaxToken, SyntaxTokenKind } from '../lexer/tokens';
 import { NodeSymbol } from '../analyzer/symbol/symbols';
 import { Position } from '../types';
@@ -533,7 +533,7 @@ function interleave(
   const [e1] = arr1;
   const [e2] = arr2;
 
-  return (e1.start < e2.start ? _.flatten(_.zip(arr1, arr2)) : _.flatten(_.zip(arr2, arr1))).filter(
+  return (e1.start < e2.start ? flatten(zip(arr1, arr2)) : flatten(zip(arr2, arr1))).filter(
     (e) => e !== null,
   ) as (SyntaxNode | SyntaxToken)[];
 }

--- a/packages/dbml-parse/src/lib/parser/parser.ts
+++ b/packages/dbml-parse/src/lib/parser/parser.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable no-loop-func */
-import _ from 'lodash';
+import { last } from 'lodash';
 import {
   convertFuncAppToElem,
   isAsKeyword,
@@ -76,7 +76,7 @@ export default class Parser {
 
   private advance(): SyntaxToken {
     if (this.isAtEnd()) {
-      return _.last(this.tokens)!; // The EOF
+      return last(this.tokens)!; // The EOF
     }
 
     // eslint-disable-next-line no-plusplus
@@ -85,7 +85,7 @@ export default class Parser {
 
   private peek(lookahead: number = 0): SyntaxToken {
     if (lookahead + this.current >= this.tokens.length) {
-      return _.last(this.tokens)!; // The EOF
+      return last(this.tokens)!; // The EOF
     }
 
     return this.tokens[this.current + lookahead];

--- a/packages/dbml-parse/src/lib/parser/utils.ts
+++ b/packages/dbml-parse/src/lib/parser/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { last } from 'lodash';
 import { SyntaxToken, SyntaxTokenKind } from '../lexer/tokens';
 import { None, Option, Some } from '../option';
 import { alternateLists } from '../utils';
@@ -46,7 +46,7 @@ export function convertFuncAppToElem (
     return new None();
   }
 
-  const attributeList = _.last(cpArgs) instanceof ListExpressionNode
+  const attributeList = last(cpArgs) instanceof ListExpressionNode
     ? (cpArgs.pop() as ListExpressionNode)
     : undefined;
 

--- a/packages/dbml-parse/vite.config.ts
+++ b/packages/dbml-parse/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['monaco-editor-core', 'lodash-es'],
+      // Note: Don't externalize `lodash-es` since using Node lower than 22.12.0 cannot import it in `cjs` format
+      external: ['monaco-editor-core'],
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Remove `lodash-es` from build config to fix import issue related to `@dbml/parse` package for node versions lower than 22.12.0
- Update lodash import to have better tree shaking

## Issue
(issue link here)

## Lasting Changes (Technical)
- config(vite): Remove `lodash-es` from rollup's external config
- Update lodash's imports to only import required methods instead of the whole package to reduce bundle size

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review