### PR TITLE
BigQuery ADC (Application Default Credentials) support

### DIFF
--- a/packages/dbml-connector/src/connectors/bigqueryConnector.ts
+++ b/packages/dbml-connector/src/connectors/bigqueryConnector.ts
@@ -21,14 +21,18 @@ import {
   TableConstraintsDictionary,
 } from './types';
 
-async function connectBigQuery(credential: BigQueryCredentials): Promise<BigQuery> {
-  const client = new BigQuery({
-    projectId: credential.projectId,
-    credentials: {
-      private_key: credential.credentials.privateKey,
-      client_email: credential.credentials.clientEmail,
-    },
-  });
+async function connectBigQuery (credential: BigQueryCredentials): Promise<BigQuery> {
+  const client = credential?.credentials?.clientEmail && credential?.credentials?.privateKey
+    ? new BigQuery({
+      projectId: credential.projectId,
+      credentials: {
+        client_email: credential.credentials.clientEmail,
+        private_key: credential.credentials.privateKey,
+      },
+    })
+    : new BigQuery({
+      projectId: credential.projectId,
+    });
 
   try {
     const query = `SELECT CURRENT_DATE() as today`;

--- a/packages/dbml-connector/src/connectors/types.ts
+++ b/packages/dbml-connector/src/connectors/types.ts
@@ -101,7 +101,7 @@ interface DatabaseSchema {
 
 interface BigQueryCredentials {
   projectId: string,
-  credentials: {
+  credentials?: {
     clientEmail: string,
     privateKey: string,
   },

--- a/packages/dbml-connector/src/connectors/types.ts
+++ b/packages/dbml-connector/src/connectors/types.ts
@@ -100,7 +100,7 @@ interface DatabaseSchema {
 }
 
 interface BigQueryCredentials {
-  projectId: string,
+  projectId?: string,
   credentials?: {
     clientEmail: string,
     privateKey: string,


### PR DESCRIPTION
## Summary
This PR introduces support for Application Default Credentials (ADC) and Workload Identity Federation (WIF) in the BigQuery connector for @dbml/cli.
- Previously, the connector only accepted service account JSON keys, which required creating and managing long-lived credentials.
- With this change, if no explicit credentials are passed, the connector will fall back to ADC provided by the @google-cloud/bigquery SDK.
- This allows developers to use gcloud auth application-default login, service account impersonation, or Workload Identity Federation (e.g., GitHub Actions → GCP) without generating JSON keys.

➡️ This makes the tool safer to use in CI/CD pipelines and easier to integrate in environments where service account key files are discouraged.

## Issue
N/A

## Lasting Changes (Technical)

- Modified bigqueryConnector.ts to detect when no client_email / private_key are present and fall back to a simple `const client = new BigQuery();` instantiation.
- This enables ADC/WIF support, reusing the environment’s GCP credentials.
- Maintains backward compatibility with existing JSON key–based authentication.
- No new libraries introduced (still uses @google-cloud/bigquery).

## Checklist

Please check directly on the box once each of these are done

- [ x] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review