### PR TITLE
fix: export dbml to oracle - export default value before inline constraint

### DIFF
--- a/packages/dbml-core/__tests__/exporter/oracle_exporter/input/column_constraints.in.dbml
+++ b/packages/dbml-core/__tests__/exporter/oracle_exporter/input/column_constraints.in.dbml
@@ -1,0 +1,28 @@
+Table "employees" {
+  "employee_id" number [pk, increment]
+  "email" varchar2(100) [unique, not null]
+  "first_name" nvarchar2(50) [not null, default: 'Unknown']
+  "last_name" nvarchar2(50) [not null]
+  "middle_name" varchar2(50) [default: '']
+  "department" varchar2(30) [unique, default: 'General', not null]
+  "years_of_service" integer [default: 0, not null]
+  "employee_rank" number(2) [unique, not null, default: 1]
+  "hire_date" date [not null, default: `SYSDATE`]
+  "last_review_date" timestamp [default: `current_timestamp`]
+  "termination_date" date
+  "birth_date" date [not null]
+  "is_active" number(1) [default: 1, not null]
+  "is_manager" number(1) [default: 0]
+  "notes" clob
+  "profile_data" nclob [default: '{}']
+}
+
+Table "projects" {
+  "project_id" int [pk, increment]
+  "project_code" varchar2(20) [unique, not null]
+  "project_name" nvarchar2(100) [not null, default: 'Unnamed Project']
+  "start_date" date [not null, default: `SYSDATE`]
+  "end_date" date
+  "status" varchar2(20) [default: 'PLANNED', not null]
+  "priority" integer [default: 999, unique]
+}

--- a/packages/dbml-core/__tests__/exporter/oracle_exporter/output/column_constraints.out.sql
+++ b/packages/dbml-core/__tests__/exporter/oracle_exporter/output/column_constraints.out.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "employees" (
+  "employee_id" number GENERATED AS IDENTITY PRIMARY KEY,
+  "email" varchar2(100) UNIQUE NOT NULL,
+  "first_name" nvarchar2(50) DEFAULT 'Unknown' NOT NULL,
+  "last_name" nvarchar2(50) NOT NULL,
+  "middle_name" varchar2(50) DEFAULT '',
+  "department" varchar2(30) DEFAULT 'General' UNIQUE NOT NULL,
+  "years_of_service" integer DEFAULT 0 NOT NULL,
+  "employee_rank" number(2) DEFAULT 1 UNIQUE NOT NULL,
+  "hire_date" date DEFAULT SYSDATE NOT NULL,
+  "last_review_date" timestamp DEFAULT current_timestamp,
+  "termination_date" date,
+  "birth_date" date NOT NULL,
+  "is_active" number(1) DEFAULT 1 NOT NULL,
+  "is_manager" number(1) DEFAULT 0,
+  "notes" clob,
+  "profile_data" nclob DEFAULT '{}'
+);
+
+CREATE TABLE "projects" (
+  "project_id" int GENERATED AS IDENTITY PRIMARY KEY,
+  "project_code" varchar2(20) UNIQUE NOT NULL,
+  "project_name" nvarchar2(100) DEFAULT 'Unnamed Project' NOT NULL,
+  "start_date" date DEFAULT SYSDATE NOT NULL,
+  "end_date" date,
+  "status" varchar2(20) DEFAULT 'PLANNED' NOT NULL,
+  "priority" integer DEFAULT 999 UNIQUE
+);

--- a/packages/dbml-core/src/export/OracleExporter.js
+++ b/packages/dbml-core/src/export/OracleExporter.js
@@ -74,6 +74,17 @@ class OracleExporter {
         cloneField.not_null = false;
       }
 
+      // default value must be placed before the inline constraint expression
+      // See column definition syntax https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__CEGEDHJE
+      // See constraint syntax https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/constraint.html#GUID-1055EA97-BA6F-4764-A15F-1024FD5B6DFE__CJAEDFIB
+      if (cloneField.dbdefault) {
+        if (cloneField.dbdefault.type === 'string') {
+          line += ` DEFAULT '${cloneField.dbdefault.value}'`;
+        } else {
+          line += ` DEFAULT ${cloneField.dbdefault.value}`;
+        }
+      }
+
       if (cloneField.unique) {
         line += ' UNIQUE';
       }
@@ -83,14 +94,6 @@ class OracleExporter {
 
       if (cloneField.not_null) {
         line += ' NOT NULL';
-      }
-
-      if (cloneField.dbdefault) {
-        if (cloneField.dbdefault.type === 'string') {
-          line += ` DEFAULT '${cloneField.dbdefault.value}'`;
-        } else {
-          line += ` DEFAULT ${cloneField.dbdefault.value}`;
-        }
       }
 
       return line;


### PR DESCRIPTION
## Summary
- Oracle exporter: Export default value before inline constraint (`unique`, `not null`, `primary key`)

## Issue
https://github.com/holistics/dbml/issues/756

## Lasting Changes (Technical)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] Integration Tests Passed
- [ ] Code Review