### PR TITLE
misc(dbml-parse): upgrade lodash-es to v4.18.1

### DIFF
--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.18.1",
     "mssql": "^11.0.1",
     "mysql2": "^3.11.0",
     "oracledb": "^6.10.0",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@dbml/parse": "^7.1.1",
     "antlr4": "^4.13.1",
-    "lodash": "^4.17.15",
+    "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "luxon": "^3.4.4",
     "parsimmon": "^1.13.0",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -49,7 +49,7 @@
     "@dbml/parse": "^7.1.1",
     "antlr4": "^4.13.1",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
+    "lodash-es": "^4.18.1",
     "luxon": "^3.4.4",
     "parsimmon": "^1.13.0",
     "pluralize": "^8.0.0"

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -39,7 +39,7 @@
     "monaco-editor-core": "^0.44.0"
   },
   "dependencies": {
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.18.1",
     "luxon": "^3.7.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6844,6 +6844,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash-es@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6899,6 +6899,11 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.15:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
 log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz"


### PR DESCRIPTION
## Summary
- Bump `lodash-es` in `dbml/parse`, `dbml/core`, `dbml/connector` to v4.18.1 to fix vulnerable issues
- Bump `lodash` in `dbml/core` to v4.18.1 to fix vulnerable issues

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Lint Checks Passed
- [ ] Unit Tests Passed
- [ ] Coverage Tests Passed
- [ ] Integration Tests Passed
- [ ] Code Review
