### PR TITLE
Hotfix: Infinite loop when running use-then-create-table mssql in dbml

### DIFF
--- a/packages/dbml-parse/__tests__/examples/parser/use.test.ts
+++ b/packages/dbml-parse/__tests__/examples/parser/use.test.ts
@@ -87,9 +87,9 @@ describe('[example] use declaration parsing', () => {
       expect(r.getValue().ast.uses).toHaveLength(1);
     });
 
-    test('missing specifiers: 8 errors, continues parsing elements', () => {
+    test('missing specifiers: 6 errors, continues parsing elements', () => {
       const r = parse(`use from './schema'\nTable posts { id int }`);
-      expect(r.getErrors()).toHaveLength(8);
+      expect(r.getErrors()).toHaveLength(6);
       expect(r.getErrors()[0].diagnostic).toBe("Expect an opening brace '{'");
       expect(r.getValue().ast.body.length).toBeGreaterThanOrEqual(1);
     });

--- a/packages/dbml-parse/__tests__/snapshots/infinite_loops/infinite_loops.test.ts
+++ b/packages/dbml-parse/__tests__/snapshots/infinite_loops/infinite_loops.test.ts
@@ -1,0 +1,30 @@
+import {
+  readFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  describe, it,
+} from 'vitest';
+import {
+  scanTestNames,
+} from '@tests/utils';
+import { DEFAULT_ENTRY } from '@/constants';
+import Compiler from '@/compiler';
+import { MemoryProjectLayout } from '@/compiler/projectLayout/layout';
+
+const TIMEOUT_MS = 10_000;
+
+describe('[snapshot] infinite_loops', () => {
+  const testNames = scanTestNames(path.resolve(__dirname, './input/'));
+
+  testNames.forEach((testName) => {
+    it(testName, () => {
+      const program = readFileSync(path.resolve(__dirname, `./input/${testName}.in.dbml`), 'utf-8');
+
+      const layout = new MemoryProjectLayout();
+      layout.setSource(DEFAULT_ENTRY, program);
+      const compiler = new Compiler(layout);
+      compiler.interpretFile(DEFAULT_ENTRY);
+    }, TIMEOUT_MS);
+  });
+});

--- a/packages/dbml-parse/__tests__/snapshots/infinite_loops/input/mssql_use_then_create.in.dbml
+++ b/packages/dbml-parse/__tests__/snapshots/infinite_loops/input/mssql_use_then_create.in.dbml
@@ -1,0 +1,10 @@
+// Anonymized version of the diagram that caused the infinite loop
+// Check this PR for more context: https://github.com/holistics/dbml/pull/912
+
+USE [SampleDB]
+GO
+
+CREATE TABLE [app].[products](
+    [product_name] [nvarchar](255) NULL,
+)
+GO

--- a/packages/dbml-parse/src/core/parser/parser.ts
+++ b/packages/dbml-parse/src/core/parser/parser.ts
@@ -187,8 +187,10 @@ export default class Parser {
     this.tokens = tokens;
   }
 
-  parse (): Report<{ ast: ProgramNode;
-    tokens: SyntaxToken[]; }> {
+  parse (): Report<{
+    ast: ProgramNode;
+    tokens: SyntaxToken[];
+  }> {
     const body = this.program();
     const eof = this.advance();
     const program = this.nodeFactory.create(ProgramNode, {
@@ -400,10 +402,7 @@ export default class Parser {
       if (!(e instanceof PartialParsingError)) {
         throw e;
       }
-      if (!this.canHandle(e)) {
-        throw new PartialParsingError(e.token, buildNode(), e.handlerContext);
-      }
-      this.synchronizeUseSpecifier();
+      throw new PartialParsingError(e.token, buildNode(), e.handlerContext); // Let use specifier list handle this
     }
 
     if (
@@ -418,10 +417,7 @@ export default class Parser {
         if (e.partialNode instanceof SyntaxNode) {
           args.name = e.partialNode;
         }
-        if (!this.canHandle(e)) {
-          throw new PartialParsingError(e.token, buildNode(), e.handlerContext);
-        }
-        this.synchronizeUseSpecifier();
+        throw new PartialParsingError(e.token, buildNode(), e.handlerContext); // Let use specifier list handle this
       }
     } else if (args.importKind) {
       this.logError(this.peek(), CompileErrorCode.UNEXPECTED_TOKEN, 'Expect an element name');
@@ -449,26 +445,11 @@ export default class Parser {
         if (!this.canHandle(e)) {
           throw new PartialParsingError(e.token, buildNode(), e.handlerContext);
         }
-        this.synchronizeUseSpecifier();
       }
     }
 
     return buildNode();
   }
-
-  private synchronizeUseSpecifier = () => {
-    while (!this.isAtEnd()) {
-      const token = this.peek();
-      if (
-        this.check(SyntaxTokenKind.RBRACE)
-        || isAtStartOfLine(this.previous(), token)
-      ) {
-        break;
-      }
-      markInvalid(token);
-      this.advance();
-    }
-  };
 
   private synchronizeProgram = () => {
     const invalidToken = this.peek();

--- a/packages/dbml-parse/src/core/parser/parser.ts
+++ b/packages/dbml-parse/src/core/parser/parser.ts
@@ -58,6 +58,15 @@ class PartialParsingError<T extends SyntaxNode> {
   }
 }
 
+// Parser architecture:
+// - Recursive descent parser: Each node in AST maps to a private "parse method" in the parser
+//   Example: ProgramNode -> Parser.program
+//            UseSpecifierNode -> Parser.useSpecifier
+// - Panic mode recovery strategy: A "parse method" when encounters an invalid syntax:
+//   1. Determine whether it can handle this syntax error: `this.canHandle(e)`
+//   2. If it can't, throw a new PartialParsingError with the partially built node
+//   3. If it can, call `synchronizeParseMethod`
+//      INVARIANT: `synchronizeParseMethod` must ensure in most cases that it consumes at least one Lexer token, else, we risk infinite loops. Only do this when you know what you're doing, but avoid doing so.
 export default class Parser {
   private tokens: SyntaxToken[];
 
@@ -386,6 +395,11 @@ export default class Parser {
     }
   };
 
+  // Parse a use specifier
+  // use { table t } from './t.dbml'
+  //       ^^^^^^^
+  //       use specifier
+  // It cannot handle any syntax errors, expect useSpecifierList to handle syntax errors it throws
   private useSpecifier (): UseSpecifierNode {
     const args: {
       importKind?: SyntaxToken;


### PR DESCRIPTION
## Summary
- Problem: There's an infinite loop in the parser triggered by an MSSQL syntax appearing inside DBML (e.g `USE [db] GO CREATE TABLE [schema].[table](...)`)
- Root cause: The `synchronizeUseSpecifier` error recovery loop could spin indefinitely when tokens didn't match its exit conditions (`}` or start-of-line). This is because it isn't ensured to always consume AT LEAST 1 token. So the loop can happen like: Parse -> Error -> Recover (does not consume any token) -> Parse the invalid token again -> ...
- Solution: Remove the `synchronizeUseSpecifier`, just throw the error to `useSpecifierList` for it to handle

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Lint Checks Passed
- [ ] Unit Tests Passed
- [ ] Coverage Tests Passed
- [ ] Integration Tests Passed
- [ ] Code Review
