### PR TITLE
DBX-6972 Fix silent errors when an autoincrement/default PK composite component do not have a value + Refactor

### DIFF
--- a/dbml-playground/package.json
+++ b/dbml-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/playground",
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "description": "Interactive playground for debugging and visualizing the DBML parser pipeline",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@dbml/core": "^8.4.0-alpha.0",
-    "@dbml/parse": "^8.4.0-alpha.0",
+    "@dbml/core": "^8.4.0-alpha.1",
+    "@dbml/parse": "^8.4.0-alpha.1",
     "@phosphor-icons/vue": "^2.2.0",
     "floating-vue": "^5.2.2",
     "lodash-es": "^4.17.21",

--- a/dbml-playground/package.json
+++ b/dbml-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbml/playground",
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "description": "Interactive playground for debugging and visualizing the DBML parser pipeline",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@dbml/core": "^8.3.1",
-    "@dbml/parse": "^8.3.1",
+    "@dbml/core": "^8.4.0-alpha.0",
+    "@dbml/parse": "^8.4.0-alpha.0",
     "@phosphor-icons/vue": "^2.2.0",
     "floating-vue": "^5.2.2",
     "lodash-es": "^4.17.21",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/cli",
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "description": "",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.21.0",
-    "@dbml/connector": "^8.4.0-alpha.0",
-    "@dbml/core": "^8.4.0-alpha.0",
-    "@dbml/parse": "^8.4.0-alpha.0",
+    "@dbml/connector": "^8.4.0-alpha.1",
+    "@dbml/core": "^8.4.0-alpha.1",
+    "@dbml/parse": "^8.4.0-alpha.1",
     "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",

--- a/packages/dbml-cli/package.json
+++ b/packages/dbml-cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/cli",
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "description": "",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.21.0",
-    "@dbml/connector": "^8.3.1",
-    "@dbml/core": "^8.3.1",
-    "@dbml/parse": "^8.3.1",
+    "@dbml/connector": "^8.4.0-alpha.0",
+    "@dbml/core": "^8.4.0-alpha.0",
+    "@dbml/parse": "^8.4.0-alpha.0",
     "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",

--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/connector",
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "description": "This package was created to fetch the schema JSON from many kind of databases.",
   "author": "huy.phung.sw@gmail.com",
   "license": "MIT",

--- a/packages/dbml-connector/package.json
+++ b/packages/dbml-connector/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/connector",
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "description": "This package was created to fetch the schema JSON from many kind of databases.",
   "author": "huy.phung.sw@gmail.com",
   "license": "MIT",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/core",
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -46,7 +46,7 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
-    "@dbml/parse": "^8.3.1",
+    "@dbml/parse": "^8.4.0-alpha.0",
     "antlr4": "^4.13.1",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",

--- a/packages/dbml-core/package.json
+++ b/packages/dbml-core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/core",
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "description": "> TODO: description",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",
@@ -46,7 +46,7 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
-    "@dbml/parse": "^8.4.0-alpha.0",
+    "@dbml/parse": "^8.4.0-alpha.1",
     "antlr4": "^4.13.1",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",

--- a/packages/dbml-parse/__tests__/examples/interpreter/record/increment.test.ts
+++ b/packages/dbml-parse/__tests__/examples/interpreter/record/increment.test.ts
@@ -170,7 +170,7 @@ describe('[example - record] auto-increment and serial type constraints', () => 
     });
   });
 
-  test('should detect duplicate pk for non-null values with increment', () => {
+  test('should skip duplicate pk check for increment column', () => {
     const source = `
       Table users {
         id int [pk, increment]
@@ -185,9 +185,8 @@ describe('[example - record] auto-increment and serial type constraints', () => 
     const result = interpret(source);
     const warnings = result.getWarnings();
 
-    expect(warnings.length).toBe(2);
-    expect(warnings[0].diagnostic).toBe('Duplicate PK: users.id = 1');
-    expect(warnings[1].diagnostic).toBe('Duplicate PK: users.id = 1');
+    // Auto-increment PK skips duplicate check entirely
+    expect(warnings.length).toBe(0);
   });
 
   test('should detect duplicate pk with not null + dbdefault', () => {

--- a/packages/dbml-parse/__tests__/examples/interpreter/record/pk.test.ts
+++ b/packages/dbml-parse/__tests__/examples/interpreter/record/pk.test.ts
@@ -284,6 +284,72 @@ describe('[example - record] simple primary key constraints', () => {
     expect(warnings[0].diagnostic).toBe('NULL in PK: users.id cannot be NULL');
   });
 
+  test('should not crash when composite PK has unspecified increment column with null in specified column', () => {
+    const source = `
+      Table users {
+        id int [increment]
+        tenant_id int
+
+        indexes {
+          (id, tenant_id) [pk]
+        }
+      }
+      records users(tenant_id) {
+        null
+        1
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].diagnostic).toContain('NULL');
+  });
+
+  test('should not crash when composite PK has unspecified default column with null in specified column', () => {
+    const source = `
+      Table orders {
+        id int [default: 0]
+        code int
+
+        indexes {
+          (id, code) [pk]
+        }
+      }
+      records orders(code) {
+        null
+        1
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].diagnostic).toContain('NULL');
+  });
+
+  test('should not crash when composite PK has unspecified increment column with duplicates in specified column', () => {
+    const source = `
+      Table users {
+        id int [increment]
+        tenant_id int
+
+        indexes {
+          (id, tenant_id) [pk]
+        }
+      }
+      records users(tenant_id) {
+        1
+        1
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].diagnostic).toContain('Duplicate');
+  });
+
   test('should validate PK alias syntax (primary key)', () => {
     const source = `
       Table users {

--- a/packages/dbml-parse/__tests__/examples/interpreter/record/pk.test.ts
+++ b/packages/dbml-parse/__tests__/examples/interpreter/record/pk.test.ts
@@ -284,6 +284,44 @@ describe('[example - record] simple primary key constraints', () => {
     expect(warnings[0].diagnostic).toBe('NULL in PK: users.id cannot be NULL');
   });
 
+  test('should not crash when simple PK with default is unspecified and records have duplicates', () => {
+    const source = `
+      Table items {
+        id int [pk, default: 0]
+        name varchar
+      }
+      records items(name) {
+        "Alice"
+        "Bob"
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    // id defaults to 0 for both rows, so both have PK = 0 - duplicates
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].diagnostic).toContain('Duplicate PK');
+    expect(warnings[0].diagnostic).toContain('= 0');
+  });
+
+  test('should not crash when simple PK with increment is unspecified', () => {
+    const source = `
+      Table items {
+        id int [pk, increment]
+        name varchar
+      }
+      records items(name) {
+        "Alice"
+        "Bob"
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    // id is auto-increment, each row gets a unique PK - no warnings
+    expect(warnings.length).toBe(0);
+  });
+
   test('should not crash when composite PK has unspecified increment column with null in specified column', () => {
     const source = `
       Table users {
@@ -346,8 +384,32 @@ describe('[example - record] simple primary key constraints', () => {
     const result = interpret(source);
     const warnings = result.getWarnings();
 
+    // id is auto-increment, so each row gets a unique (id, tenant_id) pair - no warnings
+    expect(warnings.length).toBe(0);
+  });
+
+  test('should not crash when composite PK has unspecified default column with duplicates in specified column', () => {
+    const source = `
+      Table orders {
+        id int [default: 0]
+        code int
+
+        indexes {
+          (id, code) [pk]
+        }
+      }
+      records orders(code) {
+        1
+        1
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    // id defaults to 0 for both rows, so (0, 1) and (0, 1) are duplicates
     expect(warnings.length).toBeGreaterThanOrEqual(1);
     expect(warnings[0].diagnostic).toContain('Duplicate');
+    expect(warnings[0].diagnostic).toContain('(0, 1)');
   });
 
   test('should validate PK alias syntax (primary key)', () => {

--- a/packages/dbml-parse/__tests__/examples/interpreter/record/unique.test.ts
+++ b/packages/dbml-parse/__tests__/examples/interpreter/record/unique.test.ts
@@ -460,4 +460,24 @@ describe('[example - record] simple unique constraints', () => {
     expect(errors[1].code).toBe(CompileErrorCode.DUPLICATE_RECORDS_FOR_TABLE);
     expect(errors[1].diagnostic).toBe("Duplicate Records blocks for the same Table 'users' - A Table can only have one Records block");
   });
+
+  test('should not crash when unique column with default is omitted and records have duplicates', () => {
+    const source = `
+      Table items {
+        code int [unique, default: 0]
+        name varchar
+      }
+      records items(name) {
+        "Alice"
+        "Bob"
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+
+    // code defaults to 0 for both rows, so both have UNIQUE code = 0 - duplicates
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].diagnostic).toContain('Duplicate UNIQUE');
+    expect(warnings[0].diagnostic).toContain('= 0');
+  });
 });

--- a/packages/dbml-parse/eslint.config.ts
+++ b/packages/dbml-parse/eslint.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(
       ignores: [
         'node_modules/*',
         'dist/*',
+        'dist-profile/*',
         'vite.config.ts',
         'vite.profile.config.ts',
         'eslint.config.ts',

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/parse",
-  "version": "8.3.1",
+  "version": "8.4.0-alpha.0",
   "description": "DBML parser v2",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-parse/package.json
+++ b/packages/dbml-parse/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@dbml/parse",
-  "version": "8.4.0-alpha.0",
+  "version": "8.4.0-alpha.1",
   "description": "DBML parser v2",
   "author": "Holistics <dev@holistics.io>",
   "license": "Apache-2.0",

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
@@ -1,4 +1,4 @@
-import { flatMap, isEmpty } from 'lodash-es';
+import { compact, flatMap, isEmpty, keyBy } from 'lodash-es';
 import type Compiler from '@/compiler/index';
 import type { CompileWarning } from '@/core/types/errors';
 import type { Filepath } from '@/core/types/filepath';
@@ -77,21 +77,29 @@ function validateFkSourceToTarget (
 ): CompileWarning[] {
   if (!sourceTable.record || isEmpty(sourceTable.record.values)) return [];
 
+  const sourceColumns = sourceTable.tableSymbol.mergedColumns(compiler);
+  const sourceColumnSymbolMap = keyBy(sourceColumns, (c) => c.name ?? '');
+  const sourceFieldSymbols = compact(sourceEndpoint.fieldNames.map((name) => sourceColumnSymbolMap[name]));
+
+  const targetColumns = targetTable.tableSymbol.mergedColumns(compiler);
+  const targetColumnSymbolMap = keyBy(targetColumns, (c) => c.name ?? '');
+  const targetFieldSymbols = compact(targetEndpoint.fieldNames.map((name) => targetColumnSymbolMap[name]));
+
   const sourceRows = toKeyedRows(sourceTable.record);
   const targetRows = targetTable.record ? toKeyedRows(targetTable.record) : [];
 
   // Build set of valid target values for FK reference check
   const validFkValues = new Set(
-    targetRows.map((row) => extractKeyValueWithDefault(row, targetEndpoint.fieldNames)),
+    targetRows.map((row) => extractKeyValueWithDefault(compiler, row, targetFieldSymbols)),
   );
 
   // Filter rows with NULL values (optional relationships)
   const rowsWithValues = sourceRows
-    .filter((row) => !hasNullWithoutDefaultInKey(row, sourceEndpoint.fieldNames));
+    .filter((row) => !hasNullWithoutDefaultInKey(compiler, row, sourceFieldSymbols));
 
   // Find rows with FK values that don't exist in target
   const invalidRows = rowsWithValues.filter((row) => {
-    const fkValue = extractKeyValueWithDefault(row, sourceEndpoint.fieldNames);
+    const fkValue = extractKeyValueWithDefault(compiler, row, sourceFieldSymbols);
     return !validFkValues.has(fkValue);
   });
 
@@ -110,7 +118,7 @@ function validateFkSourceToTarget (
       targetName.name,
       targetEndpoint.fieldNames,
     );
-    const valueStr = formatValues(row, sourceEndpoint.fieldNames);
+    const valueStr = formatValues(compiler, row, sourceFieldSymbols);
     const message = `FK violation: ${sourceColumnRef} = ${valueStr} does not exist in ${targetColumnRef}`;
 
     return sourceEndpoint.fieldNames.map((col) =>

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
@@ -1,4 +1,6 @@
-import { compact, flatMap, isEmpty, keyBy } from 'lodash-es';
+import {
+  compact, flatMap, isEmpty, keyBy,
+} from 'lodash-es';
 import type Compiler from '@/compiler/index';
 import type { CompileWarning } from '@/core/types/errors';
 import type { Filepath } from '@/core/types/filepath';

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/helper.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/helper.ts
@@ -116,11 +116,16 @@ export function formatFullColumnNames (
 export function formatValues (
   row: Record<string, RecordValue>,
   columnNames: string[],
+  columns?: (ColumnInfo | undefined)[],
 ): string {
   if (columnNames.length === 1) {
-    return JSON.stringify(row[columnNames[0]]?.value);
+    const value = row[columnNames[0]]?.value ?? columns?.[0]?.dbdefault?.value;
+    return JSON.stringify(value);
   }
-  const values = columnNames.map((col) => JSON.stringify(row[col]?.value)).join(', ');
+  const values = columnNames.map((col, idx) => {
+    const value = row[col]?.value ?? columns?.[idx]?.dbdefault?.value;
+    return JSON.stringify(value);
+  }).join(', ');
   return `(${values})`;
 }
 

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/helper.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/helper.ts
@@ -3,33 +3,7 @@ import { DEFAULT_SCHEMA_NAME } from '@/constants';
 import { CompileErrorCode, CompileWarning } from '@/core/types/errors';
 import type { RecordValue } from '@/core/types/schemaJson';
 import type { TableRecord } from '@/core/types/schemaJson';
-import { isSerialType } from '@/core/global_modules/records/utils/data';
 import type { ColumnSymbol } from '@/core/types/symbol';
-
-export interface ColumnInfo {
-  name: string;
-  pk: boolean;
-  unique: boolean;
-  increment: boolean;
-  notNull: boolean;
-  dbdefault?: { value: string | number;
-    type: string; };
-  typeName: string;
-}
-
-export function columnInfoFromSymbol (col: ColumnSymbol, compiler: Compiler): ColumnInfo {
-  const type = col.type(compiler);
-  const def = col.default(compiler);
-  return {
-    name: col.name ?? '',
-    pk: col.pk(compiler),
-    unique: col.unique(compiler),
-    increment: col.increment(compiler),
-    notNull: col.nullable(compiler) === false,
-    dbdefault: def,
-    typeName: type?.name ?? '',
-  };
-}
 
 // Convert positional TableRecord rows to keyed rows (column name -> value)
 export function toKeyedRows (record: TableRecord): Record<string, RecordValue>[] {
@@ -45,17 +19,18 @@ export function makeTableKey (schema: string | null, table: string): string {
 }
 
 export function extractKeyValueWithDefault (
+  compiler: Compiler,
   row: Record<string, RecordValue>,
-  columnNames: string[],
-  columns?: (ColumnInfo | undefined)[],
+  columns: ColumnSymbol[],
 ): string {
-  return columnNames.map((name, idx) => {
+  return columns.map((col) => {
+    const name = col.name ?? '';
     const value = row[name]?.value;
 
-    if ((value === null || value === undefined) && columns && columns[idx]) {
-      const column = columns[idx];
-      if (column?.dbdefault) {
-        return JSON.stringify(column.dbdefault.value);
+    if (value === null || value === undefined) {
+      const dbdefault = col.default(compiler);
+      if (dbdefault) {
+        return JSON.stringify(dbdefault.value);
       }
     }
 
@@ -64,26 +39,23 @@ export function extractKeyValueWithDefault (
 }
 
 export function hasNullWithoutDefaultInKey (
+  compiler: Compiler,
   row: Record<string, RecordValue>,
-  columnNames: string[],
-  columns?: (ColumnInfo | undefined)[],
+  columns: ColumnSymbol[],
 ): boolean {
-  return columnNames.some((name, idx) => {
+  return columns.some((col) => {
+    const name = col.name ?? '';
     const value = row[name]?.value;
 
-    if ((value === null || value === undefined) && columns && columns[idx]) {
-      const column = columns[idx];
-      if (column?.dbdefault) {
+    if (value === null || value === undefined) {
+      const dbdefault = col.default(compiler);
+      if (dbdefault) {
         return false;
       }
     }
 
     return value === null || value === undefined;
   });
-}
-
-export function isAutoIncrementColumn (column: ColumnInfo): boolean {
-  return column.increment || isSerialType(column.typeName);
 }
 
 export function formatFullColumnName (
@@ -113,20 +85,28 @@ export function formatFullColumnNames (
 // e.g. 1 -> '1'
 // e.g. 'a' -> '"a"'
 // e.g. 1, 'a' -> '(1, "a")'
+// Falls back to column default when the column is unspecified in the row.
 export function formatValues (
+  compiler: Compiler,
   row: Record<string, RecordValue>,
-  columnNames: string[],
-  columns?: (ColumnInfo | undefined)[],
+  columns: ColumnSymbol[],
 ): string {
-  if (columnNames.length === 1) {
-    const value = row[columnNames[0]]?.value ?? columns?.[0]?.dbdefault?.value;
-    return JSON.stringify(value);
-  }
-  const values = columnNames.map((col, idx) => {
-    const value = row[col]?.value ?? columns?.[idx]?.dbdefault?.value;
+  const values = columns.map((col) => {
+    const name = col.name ?? '';
+    const value = row[name] !== undefined ? row[name].value : col.default(compiler)?.value;
     return JSON.stringify(value);
   }).join(', ');
-  return `(${values})`;
+  return columns.length === 1 ? values : `(${values})`;
+}
+
+// Get anchor values for a warning from a row.
+// Tries the specified columns first; falls back to all columns in the row.
+export function getDiagnosticAnchorValues (
+  row: Record<string, RecordValue>,
+  columnNames: string[],
+): RecordValue[] {
+  const present = columnNames.filter((col) => row[col]).map((col) => row[col]);
+  return present.length > 0 ? present : Object.values(row).filter(Boolean);
 }
 
 // Create a compile warning anchored to the AST node at a record value's position.

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
@@ -42,6 +42,8 @@ export function validatePrimaryKey (compiler: Compiler, tableSymbol: TableSymbol
   );
 }
 
+// Validate a single PK constraint (single or composite) against all rows.
+// Returns warnings for missing columns, null values, and duplicates.
 function validatePkConstraint (
   compiler: Compiler,
   tableSymbol: TableSymbol,
@@ -59,22 +61,29 @@ function validatePkConstraint (
   if (!isEmpty(missingErrors)) return missingErrors;
 
   const pkColumnFields = compact(pkColumns.map((col) => columnMap[col]));
-  const areAllAutoIncrement = pkColumnFields.every((col) => col && isAutoIncrementColumn(col));
+
+  // Only check null for PK columns that are not auto-increment and have no default
+  const nullCheckColumns = pkColumns.filter((col) => {
+    const field = columnMap[col];
+    return field && !isAutoIncrementColumn(field) && !field.dbdefault;
+  });
+  const nullCheckFields = compact(nullCheckColumns.map((col) => columnMap[col]));
 
   const [
     rowsWithNull,
     rowsWithoutNull,
   ] = partition(
     rows,
-    (row) => hasNullWithoutDefaultInKey(row, pkColumns, pkColumnFields),
+    (row) => hasNullWithoutDefaultInKey(row, nullCheckColumns, nullCheckFields),
   );
 
-  // NULL in PK only errors when not all columns are auto-increment
-  const nullErrors = areAllAutoIncrement
-    ? []
-    : createNullErrors(compiler, rowsWithNull, pkColumns, schemaName, tableName);
+  const nullErrors = createNullErrors(compiler, rowsWithNull, nullCheckColumns, schemaName, tableName);
 
-  const duplicateErrors = findDuplicateErrors(compiler, rowsWithoutNull, pkColumns, pkColumnFields, schemaName, tableName);
+  // If any PK column is auto-increment, the whole key is guaranteed unique
+  const hasAutoIncrement = pkColumnFields.some((col) => isAutoIncrementColumn(col));
+  const duplicateErrors = hasAutoIncrement
+    ? []
+    : findDuplicateErrors(compiler, rowsWithoutNull, pkColumns, pkColumnFields, schemaName, tableName);
 
   return [
     ...nullErrors,
@@ -82,6 +91,8 @@ function validatePkConstraint (
   ];
 }
 
+// Create warnings for rows that have NULL in PK columns.
+// Returns one warning per specified PK column per row.
 function createNullErrors (
   compiler: Compiler,
   rowsWithNull: Record<string, RecordValue>[],
@@ -95,11 +106,18 @@ function createNullErrors (
   const columnRef = formatFullColumnNames(schemaName, tableName, pkColumns);
   const message = `NULL in ${constraintType}: ${columnRef} cannot be NULL`;
 
-  return flatMap(rowsWithNull, (row) =>
-    pkColumns.map((col) => createConstraintWarning(compiler, row[col], message)),
-  );
+  return flatMap(rowsWithNull, (row) => {
+    const presentCols = pkColumns.filter((col) => row[col]);
+    // If PK column is present, anchor warning on it; otherwise span all columns in the row
+    const anchors = presentCols.length > 0
+      ? presentCols.map((col) => row[col])
+      : Object.values(row).filter(Boolean);
+    return anchors.map((v) => createConstraintWarning(compiler, v, message));
+  });
 }
 
+// Find rows with duplicate PK values.
+// Returns warnings for each duplicate row.
 function findDuplicateErrors (
   compiler: Compiler,
   rows: Record<string, RecordValue>[],
@@ -108,9 +126,7 @@ function findDuplicateErrors (
   schemaName: string | null,
   tableName: string,
 ): CompileWarning[] {
-  // Group rows by their PK value
   const rowsByKeyValue = groupBy(rows, (row) => extractKeyValueWithDefault(row, pkColumns, pkColumnFields));
-
   const duplicateGroups = filter(rowsByKeyValue, (group) => group.length > 1);
 
   return flatMap(duplicateGroups, (duplicateRows) => {
@@ -118,13 +134,20 @@ function findDuplicateErrors (
     const columnRef = formatFullColumnNames(schemaName, tableName, pkColumns);
 
     return flatMap(duplicateRows, (row) => {
-      const valueStr = formatValues(row, pkColumns);
+      const valueStr = formatValues(row, pkColumns, pkColumnFields);
       const message = `Duplicate ${constraintType}: ${columnRef} = ${valueStr}`;
-      return pkColumns.map((col) => createConstraintWarning(compiler, row[col], message));
+      const presentCols = pkColumns.filter((col) => row[col]);
+      // If PK column is present, anchor warning on it; otherwise span all columns in the row
+      const anchors = presentCols.length > 0
+        ? presentCols.map((col) => row[col])
+        : Object.values(row).filter(Boolean);
+      return anchors.map((v) => createConstraintWarning(compiler, v, message));
     });
   });
 }
 
+// Check if any PK columns are missing from the record column list.
+// Returns warnings if missing columns have no default or auto-increment.
 function checkMissingPkColumns (
   recordBlock: SyntaxNode,
   pkColumns: string[],
@@ -154,6 +177,8 @@ function checkMissingPkColumns (
   ));
 }
 
+// Collect all PK constraints for a table.
+// Returns an array of column name arrays: single-column PKs and composite PKs from indexes.
 function collectPkConstraints (tableSymbol: TableSymbol, columnInfos: ColumnInfo[], compiler: Compiler): string[][] {
   return [
     ...columnInfos.filter((col) => col.pk).map((col) => [

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
@@ -166,7 +166,9 @@ function collectPkConstraints (tableSymbol: TableSymbol, compiler: Compiler): Co
   const columnSymbolMap = keyBy(columns, (c) => c.name ?? '');
 
   return [
-    ...columns.filter((col) => col.pk(compiler)).map((col) => [col]),
+    ...columns.filter((col) => col.pk(compiler)).map((col) => [
+      col,
+    ]),
     ...tableSymbol.mergedIndexes(compiler).flatMap((index) => {
       const result = compiler.interpretMetadata(index, index.declaration.filepath).getValue();
       if (!Array.isArray(result)) return [];

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
@@ -43,7 +43,6 @@ function validatePkConstraint (
   pkColumnSymbols: ColumnSymbol[],
   record: TableRecord,
 ): CompileWarning[] {
-  const pkColumns = pkColumnSymbols.map((c) => c.name ?? '');
   const rows = toKeyedRows(record);
 
   const missingErrors = checkMissingPkColumns(compiler, tableSymbol, recordBlock, pkColumnSymbols, record);

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/pk.ts
@@ -9,16 +9,14 @@ import type {
   RecordValue,
   TableRecord,
 } from '@/core/types/schemaJson';
-import { TableSymbol } from '@/core/types/symbol';
+import { TableSymbol, type ColumnSymbol } from '@/core/types/symbol';
 import {
-  type ColumnInfo,
-  columnInfoFromSymbol,
   createConstraintWarning,
   extractKeyValueWithDefault,
   formatFullColumnNames,
   formatValues,
+  getDiagnosticAnchorValues,
   hasNullWithoutDefaultInKey,
-  isAutoIncrementColumn,
   toKeyedRows,
 } from './helper';
 
@@ -29,16 +27,10 @@ const getConstraintType = (columnCount: number) =>
 export function validatePrimaryKey (compiler: Compiler, tableSymbol: TableSymbol, recordBlock: SyntaxNode, record: TableRecord): CompileWarning[] {
   if (isEmpty(record.values)) return [];
 
-  const columns = tableSymbol.mergedColumns(compiler);
-  const columnInfos = columns.map((c) => columnInfoFromSymbol(c, compiler));
-  const columnMap = keyBy(columnInfos, 'name');
+  const pkConstraints = collectPkConstraints(tableSymbol, compiler);
 
-  const rows = toKeyedRows(record);
-  const pkConstraints = collectPkConstraints(tableSymbol, columnInfos, compiler);
-  const availableColumns = new Set(record.columns);
-
-  return flatMap(pkConstraints, (pkColumns) =>
-    validatePkConstraint(compiler, tableSymbol, recordBlock, pkColumns, rows, availableColumns, columnMap, record),
+  return flatMap(pkConstraints, (pkColumnSymbols) =>
+    validatePkConstraint(compiler, tableSymbol, recordBlock, pkColumnSymbols, record),
   );
 }
 
@@ -48,42 +40,35 @@ function validatePkConstraint (
   compiler: Compiler,
   tableSymbol: TableSymbol,
   recordBlock: SyntaxNode,
-  pkColumns: string[],
-  rows: Record<string, RecordValue>[],
-  availableColumns: Set<string>,
-  columnMap: Record<string, ColumnInfo>,
+  pkColumnSymbols: ColumnSymbol[],
   record: TableRecord,
 ): CompileWarning[] {
-  const schemaName = tableSymbol.schema(compiler);
-  const tableName = tableSymbol.name ?? '';
+  const pkColumns = pkColumnSymbols.map((c) => c.name ?? '');
+  const rows = toKeyedRows(record);
 
-  const missingErrors = checkMissingPkColumns(recordBlock, pkColumns, availableColumns, columnMap, schemaName, tableName, record);
+  const missingErrors = checkMissingPkColumns(compiler, tableSymbol, recordBlock, pkColumnSymbols, record);
   if (!isEmpty(missingErrors)) return missingErrors;
 
-  const pkColumnFields = compact(pkColumns.map((col) => columnMap[col]));
-
   // Only check null for PK columns that are not auto-increment and have no default
-  const nullCheckColumns = pkColumns.filter((col) => {
-    const field = columnMap[col];
-    return field && !isAutoIncrementColumn(field) && !field.dbdefault;
-  });
-  const nullCheckFields = compact(nullCheckColumns.map((col) => columnMap[col]));
+  const nullCheckSymbols = pkColumnSymbols.filter((col) =>
+    !col.increment(compiler) && !col.default(compiler),
+  );
 
   const [
     rowsWithNull,
     rowsWithoutNull,
   ] = partition(
     rows,
-    (row) => hasNullWithoutDefaultInKey(row, nullCheckColumns, nullCheckFields),
+    (row) => hasNullWithoutDefaultInKey(compiler, row, nullCheckSymbols),
   );
 
-  const nullErrors = createNullErrors(compiler, rowsWithNull, nullCheckColumns, schemaName, tableName);
+  const nullErrors = createNullErrors(compiler, tableSymbol, nullCheckSymbols.map((c) => c.name ?? ''), rowsWithNull);
 
   // If any PK column is auto-increment, the whole key is guaranteed unique
-  const hasAutoIncrement = pkColumnFields.some((col) => isAutoIncrementColumn(col));
+  const hasAutoIncrement = pkColumnSymbols.some((col) => col.increment(compiler));
   const duplicateErrors = hasAutoIncrement
     ? []
-    : findDuplicateErrors(compiler, rowsWithoutNull, pkColumns, pkColumnFields, schemaName, tableName);
+    : findDuplicateErrors(compiler, tableSymbol, pkColumnSymbols, rowsWithoutNull);
 
   return [
     ...nullErrors,
@@ -95,38 +80,36 @@ function validatePkConstraint (
 // Returns one warning per specified PK column per row.
 function createNullErrors (
   compiler: Compiler,
-  rowsWithNull: Record<string, RecordValue>[],
+  tableSymbol: TableSymbol,
   pkColumns: string[],
-  schemaName: string | null,
-  tableName: string,
+  rowsWithNull: Record<string, RecordValue>[],
 ): CompileWarning[] {
   if (isEmpty(rowsWithNull)) return [];
 
+  const schemaName = tableSymbol.schema(compiler);
+  const tableName = tableSymbol.name ?? '';
   const constraintType = getConstraintType(pkColumns.length);
   const columnRef = formatFullColumnNames(schemaName, tableName, pkColumns);
   const message = `NULL in ${constraintType}: ${columnRef} cannot be NULL`;
 
-  return flatMap(rowsWithNull, (row) => {
-    const presentCols = pkColumns.filter((col) => row[col]);
-    // If PK column is present, anchor warning on it; otherwise span all columns in the row
-    const anchors = presentCols.length > 0
-      ? presentCols.map((col) => row[col])
-      : Object.values(row).filter(Boolean);
-    return anchors.map((v) => createConstraintWarning(compiler, v, message));
-  });
+  return flatMap(rowsWithNull, (row) =>
+    getDiagnosticAnchorValues(row, pkColumns).map((v) => createConstraintWarning(compiler, v, message)),
+  );
 }
 
 // Find rows with duplicate PK values.
 // Returns warnings for each duplicate row.
 function findDuplicateErrors (
   compiler: Compiler,
+  tableSymbol: TableSymbol,
+  pkColumnSymbols: ColumnSymbol[],
   rows: Record<string, RecordValue>[],
-  pkColumns: string[],
-  pkColumnFields: ColumnInfo[],
-  schemaName: string | null,
-  tableName: string,
 ): CompileWarning[] {
-  const rowsByKeyValue = groupBy(rows, (row) => extractKeyValueWithDefault(row, pkColumns, pkColumnFields));
+  const pkColumns = pkColumnSymbols.map((c) => c.name ?? '');
+  const schemaName = tableSymbol.schema(compiler);
+  const tableName = tableSymbol.name ?? '';
+
+  const rowsByKeyValue = groupBy(rows, (row) => extractKeyValueWithDefault(compiler, row, pkColumnSymbols));
   const duplicateGroups = filter(rowsByKeyValue, (group) => group.length > 1);
 
   return flatMap(duplicateGroups, (duplicateRows) => {
@@ -134,14 +117,9 @@ function findDuplicateErrors (
     const columnRef = formatFullColumnNames(schemaName, tableName, pkColumns);
 
     return flatMap(duplicateRows, (row) => {
-      const valueStr = formatValues(row, pkColumns, pkColumnFields);
+      const valueStr = formatValues(compiler, row, pkColumnSymbols);
       const message = `Duplicate ${constraintType}: ${columnRef} = ${valueStr}`;
-      const presentCols = pkColumns.filter((col) => row[col]);
-      // If PK column is present, anchor warning on it; otherwise span all columns in the row
-      const anchors = presentCols.length > 0
-        ? presentCols.map((col) => row[col])
-        : Object.values(row).filter(Boolean);
-      return anchors.map((v) => createConstraintWarning(compiler, v, message));
+      return getDiagnosticAnchorValues(row, pkColumns).map((v) => createConstraintWarning(compiler, v, message));
     });
   });
 }
@@ -149,21 +127,25 @@ function findDuplicateErrors (
 // Check if any PK columns are missing from the record column list.
 // Returns warnings if missing columns have no default or auto-increment.
 function checkMissingPkColumns (
+  compiler: Compiler,
+  tableSymbol: TableSymbol,
   recordBlock: SyntaxNode,
-  pkColumns: string[],
-  availableColumns: Set<string>,
-  columnMap: Record<string, ColumnInfo>,
-  schemaName: string | null,
-  tableName: string,
+  pkColumnSymbols: ColumnSymbol[],
   record: TableRecord,
 ): CompileWarning[] {
+  const pkColumns = pkColumnSymbols.map((c) => c.name ?? '');
+  const availableColumns = new Set(record.columns);
+  const schemaName = tableSymbol.schema(compiler);
+  const tableName = tableSymbol.name ?? '';
+
   const missingColumns = difference(pkColumns, Array.from(availableColumns));
   if (isEmpty(missingColumns)) return [];
 
-  const missingWithoutDefaults = missingColumns.filter((colName) => {
-    const col = columnMap[colName];
-    return !!(col && !isAutoIncrementColumn(col) && !col.dbdefault);
-  });
+  const missingSet = new Set(missingColumns);
+  const missingSymbols = pkColumnSymbols.filter((c) => missingSet.has(c.name ?? ''));
+  const missingWithoutDefaults = missingSymbols
+    .filter((col) => !col.increment(compiler) && !col.default(compiler))
+    .map((c) => c.name ?? '');
   if (isEmpty(missingWithoutDefaults)) return [];
 
   const constraintType = getConstraintType(missingWithoutDefaults.length);
@@ -178,16 +160,17 @@ function checkMissingPkColumns (
 }
 
 // Collect all PK constraints for a table.
-// Returns an array of column name arrays: single-column PKs and composite PKs from indexes.
-function collectPkConstraints (tableSymbol: TableSymbol, columnInfos: ColumnInfo[], compiler: Compiler): string[][] {
+// Returns an array of ColumnSymbol arrays: single-column PKs and composite PKs from indexes.
+function collectPkConstraints (tableSymbol: TableSymbol, compiler: Compiler): ColumnSymbol[][] {
+  const columns = tableSymbol.mergedColumns(compiler);
+  const columnSymbolMap = keyBy(columns, (c) => c.name ?? '');
+
   return [
-    ...columnInfos.filter((col) => col.pk).map((col) => [
-      col.name,
-    ]),
+    ...columns.filter((col) => col.pk(compiler)).map((col) => [col]),
     ...tableSymbol.mergedIndexes(compiler).flatMap((index) => {
       const result = compiler.interpretMetadata(index, index.declaration.filepath).getValue();
       if (!Array.isArray(result)) return [];
-      return (result as Index[]).filter((e) => e.pk).map((e) => e.columns.map((c) => c.value));
+      return (result as Index[]).filter((e) => e.pk).map((e) => compact(e.columns.map((c) => columnSymbolMap[c.value])));
     }),
   ];
 }

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
@@ -8,10 +8,8 @@ import type {
   RecordValue,
   TableRecord,
 } from '@/core/types/schemaJson';
-import { TableSymbol } from '@/core/types/symbol';
+import { TableSymbol, type ColumnSymbol } from '@/core/types/symbol';
 import {
-  type ColumnInfo,
-  columnInfoFromSymbol,
   createConstraintWarning,
   extractKeyValueWithDefault,
   formatFullColumnNames,
@@ -27,50 +25,48 @@ const getConstraintType = (columnCount: number) =>
 export function validateUnique (compiler: Compiler, tableSymbol: TableSymbol, record: TableRecord): CompileWarning[] {
   if (isEmpty(record.values)) return [];
 
-  const columns = tableSymbol.mergedColumns(compiler);
-  const columnInfos = columns.map((c) => columnInfoFromSymbol(c, compiler));
-  const columnMap = keyBy(columnInfos, 'name');
-
   const rows = toKeyedRows(record);
-  const schemaName = tableSymbol.schema(compiler);
-  const tableName = tableSymbol.name ?? '';
-  const uniqueConstraints = collectUniqueConstraints(tableSymbol, columnInfos, compiler);
+  const uniqueConstraints = collectUniqueConstraints(tableSymbol, compiler);
 
-  return flatMap(uniqueConstraints, (uniqueColumns) => {
-    const uniqueColumnFields = compact(uniqueColumns.map((col) => columnMap[col]));
-    return checkUniqueDuplicates(compiler, rows, uniqueColumns, uniqueColumnFields, schemaName, tableName);
-  });
+  return flatMap(uniqueConstraints, (uniqueColumnSymbols) =>
+    checkUniqueDuplicates(compiler, tableSymbol, uniqueColumnSymbols, rows),
+  );
 }
 
-function collectUniqueConstraints (tableSymbol: TableSymbol, columnInfos: ColumnInfo[], compiler: Compiler): string[][] {
+function collectUniqueConstraints (tableSymbol: TableSymbol, compiler: Compiler): ColumnSymbol[][] {
+  const columns = tableSymbol.mergedColumns(compiler);
+  const columnSymbolMap = keyBy(columns, (c) => c.name ?? '');
+
   return [
-    ...columnInfos.filter((col) => col.unique).map((col) => [
-      col.name,
+    ...columns.filter((col) => col.unique(compiler)).map((col) => [
+      col,
     ]),
     ...tableSymbol.mergedIndexes(compiler).flatMap((index) => {
       const result = compiler.interpretMetadata(index, index.declaration.filepath).getValue();
       if (!Array.isArray(result)) return [];
-      return (result as Index[]).filter((e) => e.unique).map((e) => e.columns.map((c) => c.value));
+      return (result as Index[]).filter((e) => e.unique).map((e) => compact(e.columns.map((c) => columnSymbolMap[c.value])));
     }),
   ];
 }
 
 function checkUniqueDuplicates (
   compiler: Compiler,
+  tableSymbol: TableSymbol,
+  uniqueColumnSymbols: ColumnSymbol[],
   rows: Record<string, RecordValue>[],
-  uniqueColumns: string[],
-  uniqueColumnFields: (ColumnInfo | undefined)[],
-  schemaName: string | null,
-  tableName: string,
 ): CompileWarning[] {
+  const uniqueColumns = uniqueColumnSymbols.map((c) => c.name ?? '');
+  const schemaName = tableSymbol.schema(compiler);
+  const tableName = tableSymbol.name ?? '';
+
   // Filter out rows with NULL values (SQL standard: NULLs don't conflict in UNIQUE constraints)
   const rowsWithoutNull = rows.filter((row) =>
-    !hasNullWithoutDefaultInKey(row, uniqueColumns, uniqueColumnFields),
+    !hasNullWithoutDefaultInKey(compiler, row, uniqueColumnSymbols),
   );
 
   // Group rows by their unique key value
   const rowsByKeyValue = groupBy(rowsWithoutNull, (row) =>
-    extractKeyValueWithDefault(row, uniqueColumns, uniqueColumnFields),
+    extractKeyValueWithDefault(compiler, row, uniqueColumnSymbols),
   );
 
   // Find groups with more than 1 row (duplicates)
@@ -82,7 +78,7 @@ function checkUniqueDuplicates (
     const columnRef = formatFullColumnNames(schemaName, tableName, uniqueColumns);
 
     return flatMap(duplicateRows, (row) => {
-      const valueStr = formatValues(row, uniqueColumns);
+      const valueStr = formatValues(compiler, row, uniqueColumnSymbols);
       const message = `Duplicate ${constraintType}: ${columnRef} = ${valueStr}`;
       return uniqueColumns.map((col) => createConstraintWarning(compiler, row[col], message));
     });

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
@@ -14,12 +14,10 @@ import {
   extractKeyValueWithDefault,
   formatFullColumnNames,
   formatValues,
+  getDiagnosticAnchorValues,
   hasNullWithoutDefaultInKey,
   toKeyedRows,
 } from './helper';
-
-const getConstraintType = (columnCount: number) =>
-  columnCount > 1 ? 'Composite UNIQUE' : 'UNIQUE';
 
 // Validate unique constraints for a table's records.
 export function validateUnique (compiler: Compiler, tableSymbol: TableSymbol, record: TableRecord): CompileWarning[] {
@@ -33,31 +31,43 @@ export function validateUnique (compiler: Compiler, tableSymbol: TableSymbol, re
   );
 }
 
+// Find all unique constraints in a table symbol:
+// - Inline unique
+// - Composite unique via indexes
 function collectUniqueConstraints (compiler: Compiler, tableSymbol: TableSymbol): ColumnSymbol[][] {
   const columns = tableSymbol.mergedColumns(compiler);
   const columnSymbolMap = keyBy(columns, (c) => c.name ?? '');
 
   return [
-    ...columns.filter((col) => col.unique(compiler)).map((col) => [
-      col,
-    ]),
+    ...columns
+      .filter((col) => col.unique(compiler))
+      .map((col) => [
+        col,
+      ]),
     ...tableSymbol.mergedIndexes(compiler).flatMap((index) => {
       const result = compiler.interpretMetadata(index, index.declaration.filepath).getValue();
+
       if (!Array.isArray(result)) return [];
-      return (result as Index[]).filter((e) => e.unique).map((e) => compact(e.columns.map((c) => columnSymbolMap[c.value])));
+      return (result as Index[])
+        .filter((e) => e.unique)
+        .map((e) => compact(
+          e.columns.map(
+            (c) => columnSymbolMap[c.value],
+          ),
+        ));
     }),
   ];
 }
 
+// Check if 1 unique constraint is violated.
+// A unique constraint is represented as a list of column symbols
 function checkUniqueDuplicates (
   compiler: Compiler,
   tableSymbol: TableSymbol,
   uniqueColumnSymbols: ColumnSymbol[],
   rows: Record<string, RecordValue>[],
 ): CompileWarning[] {
-  const uniqueColumns = uniqueColumnSymbols.map((c) => c.name ?? '');
-  const schemaName = tableSymbol.schema(compiler);
-  const tableName = tableSymbol.name ?? '';
+  const uniqueColumnNames = uniqueColumnSymbols.map((c) => c.name ?? '');
 
   // Filter out rows with NULL values (SQL standard: NULLs don't conflict in UNIQUE constraints)
   const rowsWithoutNull = rows.filter((row) =>
@@ -74,13 +84,21 @@ function checkUniqueDuplicates (
 
   // Transform duplicate groups to warnings
   return flatMap(duplicateGroups, (duplicateRows) => {
-    const constraintType = getConstraintType(uniqueColumns.length);
-    const columnRef = formatFullColumnNames(schemaName, tableName, uniqueColumns);
+    const constraintType = uniqueColumnSymbols.length > 1 ? 'Composite UNIQUE' : 'UNIQUE';
+
+    const columnRef = formatFullColumnNames(
+      tableSymbol.schema(compiler),
+      tableSymbol.name ?? '',
+      uniqueColumnNames,
+    );
 
     return flatMap(duplicateRows, (row) => {
       const valueStr = formatValues(compiler, row, uniqueColumnSymbols);
       const message = `Duplicate ${constraintType}: ${columnRef} = ${valueStr}`;
-      return uniqueColumns.map((col) => createConstraintWarning(compiler, row[col], message));
+
+      // Generate diagnostics for every anchor nodes
+      return getDiagnosticAnchorValues(row, uniqueColumnNames)
+        .map((v) => createConstraintWarning(compiler, v, message));
     });
   });
 }

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/unique.ts
@@ -26,14 +26,14 @@ export function validateUnique (compiler: Compiler, tableSymbol: TableSymbol, re
   if (isEmpty(record.values)) return [];
 
   const rows = toKeyedRows(record);
-  const uniqueConstraints = collectUniqueConstraints(tableSymbol, compiler);
+  const uniqueConstraints = collectUniqueConstraints(compiler, tableSymbol);
 
   return flatMap(uniqueConstraints, (uniqueColumnSymbols) =>
     checkUniqueDuplicates(compiler, tableSymbol, uniqueColumnSymbols, rows),
   );
 }
 
-function collectUniqueConstraints (tableSymbol: TableSymbol, compiler: Compiler): ColumnSymbol[][] {
+function collectUniqueConstraints (compiler: Compiler, tableSymbol: TableSymbol): ColumnSymbol[][] {
   const columns = tableSymbol.mergedColumns(compiler);
   const columnSymbolMap = keyBy(columns, (c) => c.name ?? '');
 

--- a/packages/dbml-parse/src/core/global_modules/table/interpret.ts
+++ b/packages/dbml-parse/src/core/global_modules/table/interpret.ts
@@ -271,7 +271,7 @@ export class TableInterpreter {
 
     column.pk = columnSymbol?.pk(this.compiler) || false;
     column.unique = columnSymbol?.unique(this.compiler) || false;
-    column.increment = columnSymbol?.increment(this.compiler) || undefined;
+    column.increment = columnSymbol?.isIncrementSet(this.compiler) || undefined;
     const nullable = columnSymbol?.nullable(this.compiler);
     column.not_null = nullable === undefined ? undefined : !nullable;
     column.dbdefault = columnSymbol?.default(this.compiler);

--- a/packages/dbml-parse/src/core/global_modules/tablePartial/interpret.ts
+++ b/packages/dbml-parse/src/core/global_modules/tablePartial/interpret.ts
@@ -184,7 +184,7 @@ export class TablePartialInterpreter {
 
     column.pk = columnSymbol?.pk(this.compiler) || undefined;
     column.unique = columnSymbol?.unique(this.compiler) || undefined;
-    column.increment = columnSymbol?.increment(this.compiler) || undefined;
+    column.increment = columnSymbol?.isIncrementSet(this.compiler) || undefined;
     const nullable = columnSymbol?.nullable(this.compiler);
     column.not_null = nullable === undefined ? undefined : !nullable;
     column.dbdefault = columnSymbol?.default(this.compiler);

--- a/packages/dbml-parse/src/core/global_modules/tablePartial/interpret.ts
+++ b/packages/dbml-parse/src/core/global_modules/tablePartial/interpret.ts
@@ -1,4 +1,4 @@
-import { head, last, partition } from 'lodash-es';
+import { head, partition } from 'lodash-es';
 import Compiler from '@/compiler/index';
 import { CompileError } from '@/core/types/errors';
 import { ElementKind, SettingName } from '@/core/types/keywords';

--- a/packages/dbml-parse/src/core/types/symbol/symbols.ts
+++ b/packages/dbml-parse/src/core/types/symbol/symbols.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SCHEMA_NAME } from '@/constants';
+import { isSerialType } from '@/core/global_modules/records/utils/data';
 import type { Filepath } from '@/core/types/filepath';
 import type { Internable } from '@/core/types/internable';
 import { UNHANDLED } from '@/core/types/module';
@@ -514,11 +515,15 @@ export class ColumnSymbol extends NodeSymbol {
     return undefined;
   }
 
-  increment (compiler: Compiler): boolean {
+  isIncrementSet (compiler: Compiler): boolean {
     if (!this.declaration) return false;
     const s = compiler.nodeSettings(this.declaration).getFiltered(UNHANDLED);
 
     return !!s?.[SettingName.Increment]?.length;
+  }
+
+  increment (compiler: Compiler): boolean {
+    return this.isIncrementSet(compiler) || isSerialType(this.type(compiler)?.name ?? '');
   }
 
   default (compiler: Compiler): {


### PR DESCRIPTION
## Summary
* Problem: When a **composite PK column**:
  - Has increment or default constraint (so technically, `null` is fine).
  - Is omitted from records (no entry in records -> assume the default/unique values if increment)
  -> This causes `createNullErrors`/`findDuplicateErrors` to crash on undefined row values for the omitted PK columns (because the records do not have nodes for these entries)
* Fix some bugs:
  1. If PK columns are missing, fallback to report errors on the entire row, instead of crash.
  2. A PK's uniqueness check should be skipped if it has an auto-increment field.
* Refactor:
  1. Simplify signature of the records validator function which use the legacy pre-query-based compiler API.
  
Previously this would cause silent error:

```
Table T {
  id int [pk, increment]
  name string
  records (name) {
    '12' // id pk is missing, but it is increment, so the missing pk field check passes
         // however, when check if `id` is not null, we reject increment (bug) -> report not null, but there's no column `id` -> silent error
  }
}
```

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Lint Checks Passed
- [ ] Unit Tests Passed
- [ ] Coverage Tests Passed
- [ ] Integration Tests Passed
- [ ] Code Review
