### PR TITLE
Fix schema-qualified TableGroup export names

### DIFF
--- a/packages/dbml-core/__tests__/examples/model_exporter/model_exporter.spec.ts
+++ b/packages/dbml-core/__tests__/examples/model_exporter/model_exporter.spec.ts
@@ -169,6 +169,41 @@ describe('@dbml/core - DbmlExporter flags', () => {
   });
 });
 
+describe('@dbml/core - ModelExporter table groups', () => {
+  test('does not schema-qualify TableGroup names', () => {
+    const database = (new Parser()).parse(
+      'create schema "s"; create table "s"."t" ("id" int not null, primary key ("id"));',
+      'postgres',
+    );
+    const model = database.normalize();
+    const schema = Object.values(model.schemas).find((item) => item.name === 's');
+
+    if (!schema) {
+      throw new Error('Expected schema "s" to exist');
+    }
+
+    const groupId = Math.max(0, ...Object.keys(model.tableGroups).map(Number)) + 1;
+    model.tableGroups[groupId] = {
+      id: groupId,
+      name: 'g',
+      schemaId: schema.id,
+      tableIds: [...schema.tableIds],
+      note: null,
+      color: '#cccccc',
+    };
+    schema.tableGroupIds.push(groupId);
+    schema.tableIds.forEach((tableId) => {
+      model.tables[tableId].groupId = groupId;
+    });
+
+    const res = ModelExporter.export(model, 'dbml', { isNormalized: true, includeRecords: false });
+
+    expect(res).toContain('TableGroup "g" [color: #cccccc] {');
+    expect(res).not.toContain('TableGroup "s"."g"');
+    expect(() => (new Parser()).parse(res, 'dbmlv2')).not.toThrow();
+  });
+});
+
 describe('@dbml/core - ModelExporter backwards compatibility', () => {
   test('accepts boolean true as isNormalized (old signature)', () => {
     const database = (new Parser()).parse(DBML_WITH_RECORDS, 'dbmlv2');

--- a/packages/dbml-core/src/export/DbmlExporter.ts
+++ b/packages/dbml-core/src/export/DbmlExporter.ts
@@ -342,12 +342,10 @@ class DbmlExporter {
   static exportTableGroups (tableGroupIds: number[], model: NormalizedModel): string {
     const tableGroupStrs = tableGroupIds.map((groupId) => {
       const group = model.tableGroups[groupId];
-      const groupSchema = model.schemas[group.schemaId];
       const groupSettingStr = DbmlExporter.getTableGroupSettings(group);
 
       const groupNote = group.note ? `  Note: ${DbmlExporter.escapeNote(group.note)}\n` : '';
-      const groupSchemaName = shouldPrintSchema(groupSchema, model) ? `"${groupSchema.name}".` : '';
-      const groupName = `${groupSchemaName}"${group.name}"`;
+      const groupName = `"${group.name}"`;
 
       const tableNames = group.tableIds
         .reduce((result, tableId) => {


### PR DESCRIPTION
## Summary
* Stop DBML export from schema-qualifying `TableGroup` names so exported DBML remains parseable.
* Add a regression test covering a non-default-schema table group round trip through `ModelExporter`.

## Issue
Fixes #927

## Lasting Changes (Technical)
* `DbmlExporter.exportTableGroups` now emits `TableGroup "name"` while still schema-qualifying member table references when needed.

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [x] Lint Checks Passed
- [x] Unit Tests Passed
- [ ] Coverage Tests Passed
- [ ] Integration Tests Passed
- [ ] Code Review