### PR TITLE
Fix many-to-many FK validation in records constraints

### DIFF
--- a/packages/dbml-parse/__tests__/examples/interpreter/record/fk.test.ts
+++ b/packages/dbml-parse/__tests__/examples/interpreter/record/fk.test.ts
@@ -173,7 +173,7 @@ describe('[example - record] composite foreign key constraints', () => {
     }); // status
   });
 
-  test('should validate many-to-many composite FK both directions', () => {
+  test('should validate FK for <> composite refs (both min=1)', () => {
     const source = `
       Table products {
         id int
@@ -205,11 +205,8 @@ describe('[example - record] composite foreign key constraints', () => {
     const result = interpret(source);
     const warnings = result.getWarnings();
 
-    expect(warnings.length).toBe(4);
-    expect(warnings[0].diagnostic).toBe('FK violation: (products.id, products.region) = (2, "US") does not exist in (categories.id, categories.region)');
-    expect(warnings[1].diagnostic).toBe('FK violation: (products.id, products.region) = (2, "US") does not exist in (categories.id, categories.region)');
-    expect(warnings[2].diagnostic).toBe('FK violation: (categories.id, categories.region) = (3, "EU") does not exist in (products.id, products.region)');
-    expect(warnings[3].diagnostic).toBe('FK violation: (categories.id, categories.region) = (3, "EU") does not exist in (products.id, products.region)');
+    // <> has min=1 on both sides, so existence is validated both ways
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist'))).toBe(true);
   });
 
   test('should validate composite FK with schema-qualified tables', () => {
@@ -978,5 +975,137 @@ describe('[example - record] FK skip validation for one side', () => {
     // products.region is injected from partial but is in a PK index on products
     // null in products.id should trigger FK violation
     expect(warnings.some((w) => w.diagnostic.includes('must not be null'))).toBe(true);
+  });
+});
+
+describe('[example - record] many-to-many FK constraints', () => {
+  test('<> should validate FK existence in both directions', () => {
+    const source = `
+      Table students {
+        id int [pk]
+      }
+      Table courses {
+        id int [pk]
+      }
+      Ref: students.id <> courses.id
+
+      records students(id) {
+        1
+        2
+        3
+      }
+      records courses(id) {
+        10
+        20
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+    // students 1,2,3 don't exist in courses; courses 10,20 don't exist in students
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist in courses.id'))).toBe(true);
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist in students.id'))).toBe(true);
+  });
+
+  test('?<> should skip existence on left side (0..*) but validate on right side (1..*)', () => {
+    const source = `
+      Table tags {
+        id int [pk]
+      }
+      Table posts {
+        id int [pk]
+      }
+      Ref: tags.id ?<> posts.id
+
+      records tags(id) {
+        1
+      }
+      records posts(id) {
+        10
+        20
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+    // left is 0..*, right max = * -> skip existence for left (tags.id=1 not in posts is OK)
+    expect(warnings.filter((w) => w.diagnostic.includes('does not exist in posts.id')).length).toBe(0);
+    // right is 1..*, validates existence -> posts 10,20 must exist in tags
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist in tags.id'))).toBe(true);
+  });
+
+  test('<>? should skip existence on right side (0..*) but validate on left side (1..*)', () => {
+    const source = `
+      Table tags {
+        id int [pk]
+      }
+      Table posts {
+        id int [pk]
+      }
+      Ref: tags.id <>? posts.id
+
+      records tags(id) {
+        1
+        2
+      }
+      records posts(id) {
+        10
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+    // right is 0..*, left max = * -> skip existence for right (posts.id=10 not in tags is OK)
+    expect(warnings.filter((w) => w.diagnostic.includes('does not exist in tags.id')).length).toBe(0);
+    // left is 1..*, validates existence -> tags 1,2 must exist in posts
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist in posts.id'))).toBe(true);
+  });
+
+  test('?<>? should not validate FK existence, and should allow NULL on both sides', () => {
+    const source = `
+      Table tags {
+        id int [pk]
+      }
+      Table posts {
+        id int [pk]
+      }
+      Ref: tags.id ?<>? posts.id
+
+      records tags(id) {
+        null
+        1
+      }
+      records posts(id) {
+        null
+        10
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+    const fkWarnings = warnings.filter((w) => w.diagnostic.includes('FK violation'));
+    expect(fkWarnings.length).toBe(0);
+  });
+
+  test('<> should reject both NULL and non-existent values', () => {
+    const source = `
+      Table tags {
+        id int [pk]
+      }
+      Table posts {
+        id int [pk]
+      }
+      Ref: tags.id <> posts.id
+
+      records tags(id) {
+        null
+        1
+      }
+      records posts(id) {
+        10
+      }
+    `;
+    const result = interpret(source);
+    const warnings = result.getWarnings();
+    // <> has min=1 on both sides, so null should be rejected
+    expect(warnings.some((w) => w.diagnostic.includes('must not be null'))).toBe(true);
+    // non-existent values should also be rejected
+    expect(warnings.some((w) => w.diagnostic.includes('does not exist'))).toBe(true);
   });
 });

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
@@ -122,7 +122,7 @@ function validateEndpoint (
   rightTable: TableInfo,
   rightEndpoint: ColumnSymbol[],
   leftCard: RelationCardinality,
-  rightCard: RelationCardinality,
+  rightCard: RelationCardinality, // This will constrains the left table's records
   filepath: Filepath,
 ): CompileWarning[] {
   if (!leftTable.record || isEmpty(leftTable.record.values)) return [];

--- a/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
+++ b/packages/dbml-parse/src/core/global_modules/records/utils/constraints/fk.ts
@@ -103,9 +103,9 @@ function validateForeignKey (
 
   return [
     // card2 constrains table1's rows
-    ...(skipTable1 ? [] : validateEndpoint(compiler, table1, endpoint1, table2, endpoint2, rawEndpoint2.relation, filepath)),
+    ...(skipTable1 ? [] : validateEndpoint(compiler, table1, endpoint1, table2, endpoint2, rawEndpoint1.relation, rawEndpoint2.relation, filepath)),
     // card1 constrains table2's rows
-    ...(skipTable2 ? [] : validateEndpoint(compiler, table2, endpoint2, table1, endpoint1, rawEndpoint1.relation, filepath)),
+    ...(skipTable2 ? [] : validateEndpoint(compiler, table2, endpoint2, table1, endpoint1, rawEndpoint2.relation, rawEndpoint1.relation, filepath)),
   ];
 }
 
@@ -113,19 +113,22 @@ function validateForeignKey (
 //   - right min = 0  -> left allows NULL
 //   - right min >= 1 -> left must not be NULL
 //   - right max = 1  -> left must map to exactly 1 right row (FK existence)
-//   - right max = *  -> no FK constraint
+//   - right max = * and left min >= 1 -> left must exist in right
+//   - right max = * and left min = 0 and left max = * -> no FK existence constraint
 function validateEndpoint (
   compiler: Compiler,
   leftTable: TableInfo,
   leftEndpoint: ColumnSymbol[],
   rightTable: TableInfo,
   rightEndpoint: ColumnSymbol[],
-  rightCard: RelationCardinality, // This will constrains the left table's records
+  leftCard: RelationCardinality,
+  rightCard: RelationCardinality,
   filepath: Filepath,
 ): CompileWarning[] {
   if (!leftTable.record || isEmpty(leftTable.record.values)) return [];
 
-  const { min: rightMin } = parseCardinality(rightCard);
+  const { min: leftMin, max: leftMax } = parseCardinality(leftCard);
+  const { min: rightMin, max: rightMax } = parseCardinality(rightCard);
 
   const leftColumnNames = compact(leftEndpoint.map((c) => c.name));
   const rightColumnNames = compact(rightEndpoint.map((c) => c.name));
@@ -158,8 +161,10 @@ function validateEndpoint (
     }
 
     // right max = 1 -> non-null left value must map to exactly 1 right row
-    // right max = * -> non-null left value must exist in right
-    // Both cases: left value must exist in right values
+    // right max = * and left min = 0 and left max = * -> no FK existence constraint
+    // right max = * and not above -> non-null left value must exist in right
+    if (rightMax === '*' && leftMin === 0 && leftMax === '*') return [];
+
     const fkValue = extractKeyValueWithDefault(compiler, row, leftEndpoint);
     if (validFkValues.has(fkValue)) return [];
 


### PR DESCRIPTION
### Problem

Many-to-many FK validation in records are wrong

```dbml
Table students { id int [pk] }
Table courses { id int [pk] }
Ref: students.id ?<>? courses.id

records students(id) {
  1
  2
  3
}

records courses(id) {
  10
  20
}
```

**Before**: False FK violations - `students.id = 1 does not exist in courses.id` (many to many should not require the non-null many side to exist on the other side)

**After**: No FK violations - `?<>?` means neither side constrains the other

### Rules

| Operator | Left | Right | Left existence | Right existence |
|----------|------|-------|----------------|-----------------|
| `<>` | `1..*` | `1..*` | checked | checked |
| `?<>` | `0..*` | `1..*` | skipped | checked |
| `<>?` | `1..*` | `0..*` | checked | skipped |
| `?<>?` | `0..*` | `0..*` | skipped | skipped |

The guard: skip FK existence check when `rightMax = * && leftMin = 0 && leftMax = *`.