### PR TITLE
docs(readme): add dbmlgraph to Community Contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Example of a database definition of a simple blogging site:
 * [C# parser for Dbml by Niels Bosma](https://github.com/Ivy-Interactive/Ivy.Dbml.Parser)
 * [Scafoldr: DBML-Powered Code Scaffolding Tool](https://scafoldr.com/code-generator)
 * [Jetbrains IDEs (Intellij/PyCharm/Datagrip etc.) Plugin for DBML by LiamClarkeNZ](https://plugins.jetbrains.com/plugin/30905-dbml)
+* [dbmlgraph: Generate LLM-ready markdown docs and search a DBML schema from the CLI by Verry Anto Paulus](https://github.com/verryp/dbmlgraph)

--- a/dbml-homepage/docs/home.md
+++ b/dbml-homepage/docs/home.md
@@ -167,3 +167,4 @@ DBML is created and maintained by [Holistics](https://holistics.io?utm_source=db
 * [C# parser for Dbml by Niels Bosma](https://github.com/Ivy-Interactive/Ivy.Dbml.Parser)
 * [Scafoldr: DBML-Powered Code Scaffolding Tool](https://scafoldr.com/code-generator)
 * [Jetbrains IDEs (Intellij/PyCharm/Datagrip etc.) Plugin for DBML by LiamClarkeNZ](https://plugins.jetbrains.com/plugin/30905-dbml)
+* [dbmlgraph: Generate LLM-ready markdown docs and search a DBML schema from the CLI by Verry Anto Paulus](https://github.com/verryp/dbmlgraph)


### PR DESCRIPTION
Adds [dbmlgraph](https://github.com/verryp/dbmlgraph) to the Community Contributions list.

It is an MIT-licensed npm CLI that consumes a `.dbml` file and generates browsable markdown documentation from it (an index plus per-table and per-domain pages), and can search the schema by identifier — `dbmlgraph find cycle_id` returns every table and column that matches, along with the enum values and references attached to them.

The generated output is plain markdown, so it works as human-readable schema docs in a repo and as a retrieval source for coding assistants. Built on `@dbml/core` for parsing.

- npm: https://www.npmjs.com/package/dbmlgraph
- Repo: https://github.com/verryp/dbmlgraph