### PR TITLE
Correct semantics for enums and nulls

### DIFF
--- a/packages/dbml-cli/__tests__/dbml2sql/filename --oracle --out-file/expect-out-files/schema.sql
+++ b/packages/dbml-cli/__tests__/dbml2sql/filename --oracle --out-file/expect-out-files/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "orders" (
   "id" int GENERATED AS IDENTITY PRIMARY KEY,
   "user_id" int UNIQUE NOT NULL,
-  "status" nvarchar2(255) NOT NULL CHECK ("status" IN ('created', 'running', 'done', 'failure'))
+  "status" nvarchar2(255) CHECK ("status" IN ('created', 'running', 'done', 'failure'))
 );
 
 CREATE TABLE "order_items" (
@@ -15,7 +15,7 @@ CREATE TABLE "products" (
   "name" nvarchar2(255),
   "merchant_id" int NOT NULL,
   "price" int,
-  "status" nvarchar2(255) NOT NULL CHECK ("status" IN ('Out of Stock', 'In Stock')),
+  "status" nvarchar2(255) CHECK ("status" IN ('Out of Stock', 'In Stock')),
   "created_at" timestamp DEFAULT current_timestamp
 );
 

--- a/packages/dbml-cli/__tests__/dbml2sql/filename --oracle stdout/stdout.txt
+++ b/packages/dbml-cli/__tests__/dbml2sql/filename --oracle stdout/stdout.txt
@@ -1,7 +1,7 @@
 CREATE TABLE "orders" (
   "id" int GENERATED AS IDENTITY PRIMARY KEY,
   "user_id" int UNIQUE NOT NULL,
-  "status" nvarchar2(255) NOT NULL CHECK ("status" IN ('created', 'running', 'done', 'failure'))
+  "status" nvarchar2(255) CHECK ("status" IN ('created', 'running', 'done', 'failure'))
 );
 
 CREATE TABLE "order_items" (
@@ -15,7 +15,7 @@ CREATE TABLE "products" (
   "name" nvarchar2(255),
   "merchant_id" int NOT NULL,
   "price" int,
-  "status" nvarchar2(255) NOT NULL CHECK ("status" IN ('Out of Stock', 'In Stock')),
+  "status" nvarchar2(255) CHECK ("status" IN ('Out of Stock', 'In Stock')),
   "created_at" timestamp DEFAULT current_timestamp
 );
 

--- a/packages/dbml-cli/__tests__/dbml2sql/multiple_schema_mssql/expect-out-files/multiple_schema.out.sql
+++ b/packages/dbml-cli/__tests__/dbml2sql/multiple_schema_mssql/expect-out-files/multiple_schema.out.sql
@@ -10,10 +10,10 @@ GO
 CREATE TABLE [users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [pjs] nvarchar(255) NOT NULL CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pjs2] nvarchar(255) NOT NULL CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pg] nvarchar(255) NOT NULL CHECK ([pg] IN ('male', 'female')),
-  [pg2] nvarchar(255) NOT NULL CHECK ([pg2] IN ('male2', 'female2'))
+  [pjs] nvarchar(255) CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pjs2] nvarchar(255) CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pg] nvarchar(255) CHECK ([pg] IN ('male', 'female')),
+  [pg2] nvarchar(255) CHECK ([pg2] IN ('male2', 'female2'))
 )
 GO
 
@@ -26,10 +26,10 @@ GO
 CREATE TABLE [ecommerce].[users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [ejs] nvarchar(255) NOT NULL CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [ejs2] nvarchar(255) NOT NULL CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [eg] nvarchar(255) NOT NULL CHECK ([eg] IN ('male', 'female')),
-  [eg2] nvarchar(255) NOT NULL CHECK ([eg2] IN ('male2', 'female2'))
+  [ejs] nvarchar(255) CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [ejs2] nvarchar(255) CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [eg] nvarchar(255) CHECK ([eg] IN ('male', 'female')),
+  [eg2] nvarchar(255) CHECK ([eg2] IN ('male2', 'female2'))
 )
 GO
 

--- a/packages/dbml-cli/__tests__/sql2dbml/multiple_schema_mssql/expect-out-files/multiple_schema.out.dbml
+++ b/packages/dbml-cli/__tests__/sql2dbml/multiple_schema_mssql/expect-out-files/multiple_schema.out.dbml
@@ -1,10 +1,10 @@
 Table "users" {
   "id" int [pk]
   "name" nvarchar(255)
-  "pjs" nvarchar(255) [not null, check: `[pjs] IN ('created2', 'running2', 'done2', 'failure2')`]
-  "pjs2" nvarchar(255) [not null, check: `[pjs2] IN ('created2', 'running2', 'done2', 'failure2')`]
-  "pg" nvarchar(255) [not null, check: `[pg] IN ('male', 'female')`]
-  "pg2" nvarchar(255) [not null, check: `[pg2] IN ('male2', 'female2')`]
+  "pjs" nvarchar(255) [check: `[pjs] IN ('created2', 'running2', 'done2', 'failure2')`]
+  "pjs2" nvarchar(255) [check: `[pjs2] IN ('created2', 'running2', 'done2', 'failure2')`]
+  "pg" nvarchar(255) [check: `[pg] IN ('male', 'female')`]
+  "pg2" nvarchar(255) [check: `[pg2] IN ('male2', 'female2')`]
 }
 
 Table "products" {
@@ -27,10 +27,10 @@ Ref:"users"."id" < "schemaA"."locations"."name"
 Table "ecommerce"."users" {
   "id" int [pk]
   "name" nvarchar(255)
-  "ejs" nvarchar(255) [not null, check: `[ejs] IN ('created2', 'running2', 'done2', 'failure2')`]
-  "ejs2" nvarchar(255) [not null, check: `[ejs2] IN ('created2', 'running2', 'done2', 'failure2')`]
-  "eg" nvarchar(255) [not null, check: `[eg] IN ('male', 'female')`]
-  "eg2" nvarchar(255) [not null, check: `[eg2] IN ('male2', 'female2')`]
+  "ejs" nvarchar(255) [check: `[ejs] IN ('created2', 'running2', 'done2', 'failure2')`]
+  "ejs2" nvarchar(255) [check: `[ejs2] IN ('created2', 'running2', 'done2', 'failure2')`]
+  "eg" nvarchar(255) [check: `[eg] IN ('male', 'female')`]
+  "eg2" nvarchar(255) [check: `[eg2] IN ('male2', 'female2')`]
 
   Indexes {
     (name, ejs) [name: "idx_1"]

--- a/packages/dbml-cli/__tests__/sql2dbml/multiple_schema_mssql/in-files/multiple_schema.in.sql
+++ b/packages/dbml-cli/__tests__/sql2dbml/multiple_schema_mssql/in-files/multiple_schema.in.sql
@@ -10,10 +10,10 @@ GO
 CREATE TABLE [users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [pjs] nvarchar(255) NOT NULL CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pjs2] nvarchar(255) NOT NULL CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pg] nvarchar(255) NOT NULL CHECK ([pg] IN ('male', 'female')),
-  [pg2] nvarchar(255) NOT NULL CHECK ([pg2] IN ('male2', 'female2'))
+  [pjs] nvarchar(255) CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pjs2] nvarchar(255) CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pg] nvarchar(255) CHECK ([pg] IN ('male', 'female')),
+  [pg2] nvarchar(255) CHECK ([pg2] IN ('male2', 'female2'))
 )
 GO
 
@@ -26,10 +26,10 @@ GO
 CREATE TABLE [ecommerce].[users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [ejs] nvarchar(255) NOT NULL CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [ejs2] nvarchar(255) NOT NULL CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [eg] nvarchar(255) NOT NULL CHECK ([eg] IN ('male', 'female')),
-  [eg2] nvarchar(255) NOT NULL CHECK ([eg2] IN ('male2', 'female2'))
+  [ejs] nvarchar(255) CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [ejs2] nvarchar(255) CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [eg] nvarchar(255) CHECK ([eg] IN ('male', 'female')),
+  [eg2] nvarchar(255) CHECK ([eg2] IN ('male2', 'female2'))
 )
 GO
 

--- a/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/general_schema.out.sql
+++ b/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/general_schema.out.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [orders] (
   [id] int PRIMARY KEY IDENTITY(1, 1),
   [user_id] int UNIQUE NOT NULL,
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('created', 'running', 'done', 'failure')),
+  [status] nvarchar(255) CHECK ([status] IN ('created', 'running', 'done', 'failure')),
   [created_at] varchar(255)
 )
 GO
@@ -18,7 +18,7 @@ CREATE TABLE [products] (
   [name] varchar(255),
   [merchant_id] int NOT NULL,
   [price] int,
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('Out of Stock', 'In Stock')),
+  [status] nvarchar(255) CHECK ([status] IN ('Out of Stock', 'In Stock')),
   [created_at] datetime DEFAULT (now()),
   PRIMARY KEY ([id], [name])
 )

--- a/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/multiple_schema.out.sql
+++ b/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/multiple_schema.out.sql
@@ -10,10 +10,10 @@ GO
 CREATE TABLE [users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [pjs] nvarchar(255) NOT NULL CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pjs2] nvarchar(255) NOT NULL CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [pg] nvarchar(255) NOT NULL CHECK ([pg] IN ('male', 'female')),
-  [pg2] nvarchar(255) NOT NULL CHECK ([pg2] IN ('male2', 'female2'))
+  [pjs] nvarchar(255) CHECK ([pjs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pjs2] nvarchar(255) CHECK ([pjs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [pg] nvarchar(255) CHECK ([pg] IN ('male', 'female')),
+  [pg2] nvarchar(255) CHECK ([pg2] IN ('male2', 'female2'))
 )
 GO
 
@@ -26,10 +26,10 @@ GO
 CREATE TABLE [ecommerce].[users] (
   [id] int PRIMARY KEY,
   [name] nvarchar(255),
-  [ejs] nvarchar(255) NOT NULL CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
-  [ejs2] nvarchar(255) NOT NULL CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
-  [eg] nvarchar(255) NOT NULL CHECK ([eg] IN ('male', 'female')),
-  [eg2] nvarchar(255) NOT NULL CHECK ([eg2] IN ('male2', 'female2'))
+  [ejs] nvarchar(255) CHECK ([ejs] IN ('created2', 'running2', 'done2', 'failure2')),
+  [ejs2] nvarchar(255) CHECK ([ejs2] IN ('created2', 'running2', 'done2', 'failure2')),
+  [eg] nvarchar(255) CHECK ([eg] IN ('male', 'female')),
+  [eg2] nvarchar(255) CHECK ([eg2] IN ('male2', 'female2'))
 )
 GO
 

--- a/packages/dbml-core/__tests__/examples/exporter/oracle_exporter/output/special_schema.out.sql
+++ b/packages/dbml-core/__tests__/examples/exporter/oracle_exporter/output/special_schema.out.sql
@@ -6,7 +6,7 @@ CREATE TABLE "users" (
 
 CREATE TABLE "orders" (
   "id" integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-  "status" nvarchar2(255) NOT NULL CHECK ("status" IN ('created', 'pending', 'processing', 'waiting_for_payment', 'success', 'cancel')),
+  "status" nvarchar2(255) CHECK ("status" IN ('created', 'pending', 'processing', 'waiting_for_payment', 'success', 'cancel')),
   "note" nclob DEFAULT '',
   "user_id" integer NOT NULL,
   "created_at" timestamp DEFAULT current_timestamp,

--- a/packages/dbml-core/__tests__/examples/model_exporter/mssql_exporter/output/enum_tables.out.sql
+++ b/packages/dbml-core/__tests__/examples/model_exporter/mssql_exporter/output/enum_tables.out.sql
@@ -1,13 +1,13 @@
 CREATE TABLE [jobs] (
   [id] integer PRIMARY KEY,
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('created', 'running', 'done', 'failed', 'wait for validation'))
+  [status] nvarchar(255) CHECK ([status] IN ('created', 'running', 'done', 'failed', 'wait for validation'))
 )
 GO
 
 CREATE TABLE [orders] (
   [id] int PRIMARY KEY,
   [created_at] varchar(255),
-  [priority] nvarchar(255) NOT NULL CHECK ([priority] IN ('low', 'medium', 'high')),
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('pending', 'processing', 'done'))
+  [priority] nvarchar(255) CHECK ([priority] IN ('low', 'medium', 'high')),
+  [status] nvarchar(255) CHECK ([status] IN ('pending', 'processing', 'done'))
 )
 GO

--- a/packages/dbml-core/__tests__/examples/model_exporter/mssql_exporter/output/general_schema.out.sql
+++ b/packages/dbml-core/__tests__/examples/model_exporter/mssql_exporter/output/general_schema.out.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [orders] (
   [id] int PRIMARY KEY IDENTITY(1, 1),
   [user_id] int UNIQUE NOT NULL,
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('created', 'running', 'done', 'failure')),
+  [status] nvarchar(255) CHECK ([status] IN ('created', 'running', 'done', 'failure')),
   [created_at] varchar(255)
 )
 GO
@@ -18,7 +18,7 @@ CREATE TABLE [products] (
   [name] varchar(255),
   [merchant_id] int NOT NULL,
   [price] int,
-  [status] nvarchar(255) NOT NULL CHECK ([status] IN ('Out of Stock', 'In Stock')),
+  [status] nvarchar(255) CHECK ([status] IN ('Out of Stock', 'In Stock')),
   [created_at] datetime DEFAULT (now())
 )
 GO

--- a/packages/dbml-core/src/export/OracleExporter.js
+++ b/packages/dbml-core/src/export/OracleExporter.js
@@ -137,7 +137,7 @@ class OracleExporter {
         });
 
         const enumString = enumValues.join(', ');
-        line += ` nvarchar2(255) NOT NULL CHECK (${fieldName} IN (${enumString}))`;
+        line += ` nvarchar2(255) CHECK (${fieldName} IN (${enumString}))`;
       } else {
         line += ` ${field.type.type_name}`;
       }

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -68,7 +68,7 @@ class SqlServerExporter {
 
       if (field.enumId) {
         const _enum = model.enums[field.enumId];
-        line = `[${field.name}] nvarchar(255) NOT NULL CHECK ([${field.name}] IN (`;
+        line = `[${field.name}] nvarchar(255) CHECK ([${field.name}] IN (`;
         const enumValues = _enum.valueIds.map((valueId) => {
           const value = model.enumValues[valueId];
           return `'${value.name}'`;


### PR DESCRIPTION
## Summary

Currently, DBML has an incorrect semantic behavior when specifying exporting an enum in MSSQL and Oracle. For both of these database formats, the exporter unconditionally sets the column to be NOT NULL. At first, this seems to intrinsically make sense --- an enum is a closed set of specified values, so what would NULL even mean.

While this is logical, it is not the way NULL is implemented in any of the major databases. Both PostgreSQL and MySQL implement enums directly, and MySQL is explicit about the fact that NULL is a supported value (https://dev.mysql.com/doc/refman/8.4/en/enum.html#enum-nulls).  PostgreSQL's docs don't contain a similar assertion, but it also supports NULL in columns with enums.

## Lasting Changes (Technical)

This change does cause the exporter to potentially emit different SQL than it would have previously, but it ensures that all the databases behave the same based on the same input.  It also fixes a bug that occurs when you specify a column to be both an enum and NOT NULL in the MSSQL/Oracle exporter.

## Checklist

Please check directly on the box once each of these are done

- [X] Documentation (if necessary)
- [X] Updated `dbml-homepage/static/llms.txt` (if docs/features changed)
- [X] Lint Checks Passed
- [X] Unit Tests Passed
- [X] Coverage Tests Passed
- [X] Integration Tests Passed
- [ ] Code Review
