### PR TITLE
bug(mssql): indexes in MSSQL can't contain schema name

### DIFF
--- a/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/input/schema_indexes.in.dbml
+++ b/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/input/schema_indexes.in.dbml
@@ -1,0 +1,10 @@
+Table "schemaA"."products" {
+  "id" int [pk]
+  "name" varchar(255)
+  "merchant_id" int
+
+  Indexes {
+    (merchant_id) [name: "product_merchant_index"]
+    (name) [unique]
+  }
+}

--- a/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/schema_indexes.out.sql
+++ b/packages/dbml-core/__tests__/examples/exporter/mssql_exporter/output/schema_indexes.out.sql
@@ -1,0 +1,15 @@
+CREATE SCHEMA [schemaA]
+GO
+
+CREATE TABLE [schemaA].[products] (
+  [id] int PRIMARY KEY,
+  [name] varchar(255),
+  [merchant_id] int
+)
+GO
+
+CREATE INDEX [product_merchant_index] ON [schemaA].[products] ("merchant_id")
+GO
+
+CREATE UNIQUE INDEX [products_index_1] ON [schemaA].[products] ("name")
+GO

--- a/packages/dbml-core/src/export/SqlServerExporter.js
+++ b/packages/dbml-core/src/export/SqlServerExporter.js
@@ -314,9 +314,7 @@ class SqlServerExporter {
       }
       const indexName = index.name
         ? `[${index.name}]`
-        : `${shouldPrintSchema(schema, model)
-          ? `[${schema.name}].`
-          : ''}[${table.name}_index_${i}]`;
+        : `[${table.name}_index_${i}]`;
       line += ` INDEX ${indexName} ON ${shouldPrintSchema(schema, model)
         ? `[${schema.name}].`
         : ''}[${table.name}]`;


### PR DESCRIPTION
## Summary
Unlike in Oracle and PostgreSQL, the CREATE INDEX command cannot specify which schema the index should belong to; it is unconditionally set to the schema of the columns being indexed. Trying to put the schema name in the CREATE INDEX command causes a syntax error.

## Checklist

Please check directly on the box once each of these are done

- [X] Documentation (if necessary)
- [X] Updated `dbml-homepage/static/llms.txt` (if docs/features changed)
- [can't run] Lint Checks Passed
- [X] Unit Tests Passed
- [X] Coverage Tests Passed
- [X] Integration Tests Passed
- [ ] Code Review
