### PR TITLE
Config lerna to always use tag alpha for *.*.*-*.* and tag latest for *.*.*

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,11 @@
 {
   "version": "10.1.1",
   "npmClient": "yarn",
-  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "command": {
+    "publish": {
+      "distTag": "latest",
+      "preDistTag": "alpha"
+    }
+  }
 }

--- a/packages/dbml-parse/src/index.ts
+++ b/packages/dbml-parse/src/index.ts
@@ -118,9 +118,7 @@ export type {
 export { findDiagramViewBlocks } from '@/compiler/queries/transform';
 
 // Dep transform types
-export type {
-  DepSyncOperation, DepSyncEdge, DepEndpointRef,
-} from '@/compiler/queries/transform';
+export type { DepSyncOperation, DepSyncEdge, DepEndpointRef } from '@/compiler/queries/transform';
 
 // Element identifier types
 export type {


### PR DESCRIPTION
## Summary

Tested on local verdaccio:
- Bump to 10.2.0 -> run `yarn lerna publish from-package --registry localhost:4873` -> 10.2.0 tagged with `latest`
- Bump to 10.2.1-alpha.0 -> run `yarn lerna publish from-package --registry localhost:4873` -> `10.2.1-alpha.0` tagged with `alpha`

<img width="1768" height="828" alt="image" src="https://github.com/user-attachments/assets/14b33cf2-76d9-49b9-84b6-981d30fea23b" />

#973 

Doc:
- https://github.com/lerna/lerna/tree/main/libs/commands/publish#--dist-tag-tag
- https://github.com/lerna/lerna/tree/main/libs/commands/publish#--pre-dist-tag-tag

## Issue
(issue link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Checklist

Please check directly on the box once each of these are done

- [ ] Documentation (if necessary)
- [ ] Updated `dbml-homepage/static/llms.txt` (if docs/features changed)
- [ ] Lint Checks Passed
- [ ] Unit Tests Passed
- [ ] Coverage Tests Passed
- [ ] Integration Tests Passed
- [ ] Code Review
